### PR TITLE
[CLI]: specify framework version for project creation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36045,8 +36045,7 @@
         "mbc": "dist/index.js"
       },
       "devDependencies": {
-        "@faker-js/faker": "^8.3.1",
-        "@mbc-cqrs-serverless/core": "^0.1.21-beta.0"
+        "@faker-js/faker": "^8.3.1"
       }
     },
     "packages/cli/node_modules/commander": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,7 +47,6 @@
     "rimraf": "^5.0.5"
   },
   "devDependencies": {
-    "@faker-js/faker": "^8.3.1",
-    "@mbc-cqrs-serverless/core": "^0.1.21-beta.0"
+    "@faker-js/faker": "^8.3.1"
   }
 }

--- a/packages/cli/src/actions/new.action.spec.ts
+++ b/packages/cli/src/actions/new.action.spec.ts
@@ -4,11 +4,12 @@ import path from 'path'
 
 import { exportsForTesting } from './new.action'
 
-const { useLatestPackageVersion } = exportsForTesting
+const { usePackageVersion } = exportsForTesting
 
-// create testcase for useLatestPackageVersion function in new.action.ts file
-describe('useLatestPackageVersion', () => {
+// create testcase for usePackageVersion function in new.action.ts file
+describe('usePackageVersion', () => {
   const fname = path.join(__dirname, 'package.json')
+  const packageVersion = '1.0.0'
   const packageJson = JSON.parse(
     readFileSync(path.join(__dirname, '../../package.json')).toString(),
   )
@@ -22,11 +23,11 @@ describe('useLatestPackageVersion', () => {
   })
 
   it('it should update deps', () => {
-    useLatestPackageVersion(__dirname)
+    usePackageVersion(__dirname, packageVersion)
     const tplPackageJson = JSON.parse(readFileSync(fname).toString())
 
-    expect(packageJson.devDependencies['@mbc-cqrs-serverless/core']).toBe(
-      tplPackageJson.dependencies['@mbc-cqrs-serverless/core'],
+    expect(tplPackageJson.dependencies['@mbc-cqrs-serverless/core']).toBe(
+      packageVersion,
     )
     expect(packageJson.version).toBe(
       tplPackageJson.devDependencies['@mbc-cqrs-serverless/cli'],
@@ -36,7 +37,7 @@ describe('useLatestPackageVersion', () => {
   it('it should not update name', () => {
     const { name } = JSON.parse(readFileSync(fname).toString())
 
-    useLatestPackageVersion(__dirname)
+    usePackageVersion(__dirname, packageVersion)
     const tplPackageJson = JSON.parse(readFileSync(fname).toString())
 
     expect(name).toBe(tplPackageJson.name)
@@ -45,7 +46,7 @@ describe('useLatestPackageVersion', () => {
   it('it should not update name with empty name', () => {
     const { name } = JSON.parse(readFileSync(fname).toString())
 
-    useLatestPackageVersion(__dirname, '')
+    usePackageVersion(__dirname, packageVersion, '')
     const tplPackageJson = JSON.parse(readFileSync(fname).toString())
 
     expect(name).toBe(tplPackageJson.name)
@@ -53,7 +54,7 @@ describe('useLatestPackageVersion', () => {
 
   it('it should update name', () => {
     const name = faker.word.sample()
-    useLatestPackageVersion(__dirname, name)
+    usePackageVersion(__dirname, packageVersion, name)
     const tplPackageJson = JSON.parse(readFileSync(fname).toString())
 
     expect(name).toBe(tplPackageJson.name)

--- a/packages/cli/src/actions/new.action.ts
+++ b/packages/cli/src/actions/new.action.ts
@@ -16,19 +16,43 @@ export default async function newAction(
   options: object,
   command: Command,
 ) {
+  const [projectName, version = 'latest'] = name.split('@')
+
   console.log(
-    `Executing command '${command.name()}' for application '${name}' with options '${JSON.stringify(
+    `Executing command '${command.name()}' for application '${projectName}' with options '${JSON.stringify(
       options,
     )}'`,
   )
 
-  const destDir = path.join(process.cwd(), name)
+  let packageVersion
+
+  if (version === 'latest') {
+    packageVersion = `^${
+      getPackageVersion('@mbc-cqrs-serverless/core', true)[0]
+    }` //  use the latest patch and minor versions
+  } else {
+    const versions = getPackageVersion('@mbc-cqrs-serverless/core')
+    const regex = new RegExp(`^${version}(?![0-9]).*$`) // start with version and not directly follow by a digit
+    const matchVersions = versions.filter((v) => regex.test(v))
+    if (versions.includes(version)) {
+      packageVersion = version // specific version
+    } else if (matchVersions.length !== 0) {
+      packageVersion = `^${matchVersions.at(-1)}` // use the patch and minor versions
+    } else {
+      console.log(
+        'The specified package version does not exist. Please chose a valid version!\n',
+        versions,
+      )
+      return
+    }
+  }
+
+  const destDir = path.join(process.cwd(), projectName)
   console.log('Generating MBC cqrs serverless application in', destDir)
   mkdirSync(destDir, { recursive: true })
   cpSync(path.join(__dirname, '../../templates'), destDir, { recursive: true })
 
-  // upgrade package
-  useLatestPackageVersion(destDir, name)
+  usePackageVersion(destDir, packageVersion, projectName)
 
   // mv gitignore .gitignore
   const gitignore = path.join(destDir, 'gitignore')
@@ -47,27 +71,44 @@ export default async function newAction(
   console.log(logs.toString())
 }
 
-function useLatestPackageVersion(destDir: string, name?: string) {
+function usePackageVersion(
+  destDir: string,
+  packageVersion: string,
+  projectName?: string,
+) {
   const packageJson = JSON.parse(
     readFileSync(path.join(__dirname, '../../package.json')).toString(),
   )
   const fname = path.join(destDir, 'package.json')
   const tplPackageJson = JSON.parse(readFileSync(fname).toString())
 
-  if (name) {
-    tplPackageJson.name = name
+  if (projectName) {
+    tplPackageJson.name = projectName
   }
 
-  tplPackageJson.dependencies['@mbc-cqrs-serverless/core'] =
-    packageJson.devDependencies['@mbc-cqrs-serverless/core']
+  tplPackageJson.dependencies['@mbc-cqrs-serverless/core'] = packageVersion
   tplPackageJson.devDependencies['@mbc-cqrs-serverless/cli'] =
     packageJson.version
 
   writeFileSync(fname, JSON.stringify(tplPackageJson, null, 2))
 }
 
+function getPackageVersion(packageName: string, isLatest = false): string[] {
+  if (isLatest) {
+    const latestVersion = execSync(`npm view ${packageName} dist-tags.latest`)
+      .toString()
+      .trim()
+    return [latestVersion]
+  }
+
+  const versions = JSON.parse(
+    execSync(`npm view ${packageName} versions --json`).toString(),
+  ) as string[]
+  return versions
+}
+
 export let exportsForTesting = {
-  useLatestPackageVersion,
+  usePackageVersion,
 }
 if (process.env.NODE_ENV !== 'test') {
   exportsForTesting = undefined


### PR DESCRIPTION
## Summary
This pull request enhances the CLI tool mbc by adding the capability to specify the framework version for project creation. The update provides flexibility for users to choose between using the latest framework version, specifying a version, or matching a version prefix.

## Changed
Users can now create projects with the following commands:
- `mbc new`
  - Creates a new project using a default name with the latest framework version.
- `mbc new projectName`
  - Creates a new project with the specified projectName using the latest framework version.
- `mbc new projectName@version`
  - If the specified version exists, the CLI uses that exact version.
  - If the provided version is a prefix, the CLI uses the latest version matching that prefix.
  - If no matching version is found, the CLI logs an error and provides a list of available versions for the user.