### PR TITLE
[CLI]: create project with the latest template

### DIFF
--- a/packages/cli/src/actions/new.action.is-latest-version.spec.ts
+++ b/packages/cli/src/actions/new.action.is-latest-version.spec.ts
@@ -1,0 +1,46 @@
+import { execSync } from 'child_process'
+
+import { exportsForTesting } from './new.action'
+
+const { isLatestCli } = exportsForTesting
+
+jest.mock('child_process', () => ({
+  execSync: jest.fn(),
+}))
+
+jest.mock('fs', () => ({
+  readFileSync: jest.fn(() => JSON.stringify({ version: '1.0.0' })),
+}))
+jest.mock('path', () => ({
+  join: jest.fn(() => '/mocked/path/to/package.json'),
+}))
+
+describe('isLatestCli', () => {
+  const mockExecSync = execSync as jest.MockedFunction<typeof execSync>
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should return true if the current version matches the latest version', () => {
+    const mockLatestVersion = ['1.0.0']
+    mockExecSync.mockReturnValue(Buffer.from(`${mockLatestVersion}\n`))
+
+    // Run the function
+    const result = isLatestCli()
+
+    // Assert that the result is true
+    expect(result).toBe(true)
+  })
+
+  it('should return false if the current version does not match the latest version', () => {
+    const mockLatestVersion = ['1.2.3']
+    mockExecSync.mockReturnValue(Buffer.from(`${mockLatestVersion}\n`))
+
+    // Run the function
+    const result = isLatestCli()
+
+    // Assert that the result is true
+    expect(result).toBe(false)
+  })
+})

--- a/packages/cli/src/actions/new.action.spec.ts
+++ b/packages/cli/src/actions/new.action.spec.ts
@@ -16,7 +16,7 @@ jest.mock('fs', () => ({
   unlinkSync: jest.fn(),
   writeFileSync: jest.fn(),
   readFileSync: jest.fn(() =>
-    JSON.stringify({ dependencies: {}, devDependencies: {} }),
+    JSON.stringify({ version: '1.2.3', dependencies: {}, devDependencies: {} }),
   ),
 }))
 
@@ -32,7 +32,8 @@ describe('newAction', () => {
     const projectName = 'test-project'
     const latestVersion = '1.2.3'
     mockExecSync
-      .mockReturnValueOnce(Buffer.from(latestVersion))
+      .mockReturnValueOnce(Buffer.from(latestVersion)) // latest core
+      .mockReturnValueOnce(Buffer.from(latestVersion)) // latest cli
       .mockReturnValue(Buffer.from(''))
 
     await newAction(`${projectName}`, {}, mockCommand)
@@ -63,7 +64,8 @@ describe('newAction', () => {
     const version = '1.0.0'
     const mockVersions = ['1.0.0', '1.1.0', '1.2.0']
     mockExecSync
-      .mockReturnValueOnce(Buffer.from(JSON.stringify(mockVersions)))
+      .mockReturnValueOnce(Buffer.from(JSON.stringify(mockVersions))) // list version core
+      .mockReturnValueOnce(Buffer.from('1.2.3')) // latest cli
       .mockReturnValue(Buffer.from(''))
 
     await newAction(`${projectName}@${version}`, {}, mockCommand)


### PR DESCRIPTION
## Description

When use `mbc new` command, the new project scaffolded will alway use the latest version of the template.

## Related Issues

- https://github.com/mbc-net/mbc-cqrs-serverless/issues/41