### PR TITLE
Feature: Custom Fiscal Year Start Calculation

### DIFF
--- a/packages/sequence/src/dto/gen-sequence.dto.ts
+++ b/packages/sequence/src/dto/gen-sequence.dto.ts
@@ -1,5 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger'
-import { IsEnum, IsObject, IsOptional, IsString } from 'class-validator'
+import {
+  IsEnum,
+  IsNumber,
+  IsObject,
+  IsOptional,
+  IsString,
+} from 'class-validator'
 
 import { RotateByEnum } from '../enums/rotate-by.enum'
 
@@ -45,9 +51,25 @@ export class GenSequenceDto {
   @IsObject()
   params: SequenceParamsDto
 
+  /**
+   * Format of no
+   */
+
   @IsString()
   @IsOptional()
   format?: string
+
+  /**
+   * Start month of fiscal year (default: 4)
+   */
+
+  @IsNumber()
+  @IsOptional()
+  startMonth?: number
+
+  /**
+   * Company registration date
+   */
 
   @IsString()
   @IsOptional()

--- a/packages/sequence/src/dto/gen-sequence.dto.ts
+++ b/packages/sequence/src/dto/gen-sequence.dto.ts
@@ -48,4 +48,8 @@ export class GenSequenceDto {
   @IsString()
   @IsOptional()
   format?: string
+
+  @IsString()
+  @IsOptional()
+  registerDate?: Date
 }

--- a/packages/sequence/src/dto/gen-sequence.dto.ts
+++ b/packages/sequence/src/dto/gen-sequence.dto.ts
@@ -1,7 +1,33 @@
 import { ApiProperty } from '@nestjs/swagger'
-import { IsEnum, IsOptional, IsString } from 'class-validator'
+import { IsEnum, IsObject, IsOptional, IsString } from 'class-validator'
 
 import { RotateByEnum } from '../enums/rotate-by.enum'
+
+export class SequenceParamsDto {
+  //code1#code2#code3#code4#code5
+
+  @IsString()
+  code1: string
+
+  @IsString()
+  code2: string
+
+  @IsOptional()
+  @IsString()
+  code3?: string
+
+  @IsOptional()
+  @IsString()
+  code4?: string
+
+  @IsOptional()
+  @IsString()
+  code5?: string
+
+  constructor(partial: Partial<SequenceParamsDto>) {
+    Object.assign(this, partial)
+  }
+}
 
 export class GenSequenceDto {
   @IsString()
@@ -16,6 +42,10 @@ export class GenSequenceDto {
   @IsString()
   tenantCode: string
 
+  @IsObject()
+  params: SequenceParamsDto
+
   @IsString()
-  typeCode: string
+  @IsOptional()
+  format?: string
 }

--- a/packages/sequence/src/interfaces/fiscal-year.interface.ts
+++ b/packages/sequence/src/interfaces/fiscal-year.interface.ts
@@ -1,0 +1,5 @@
+export interface FiscalYearOptions {
+  now: Date // Current date
+  startMonth?: number // Optional, defaults to 4
+  registerTime?: Date // Optional registration date
+}

--- a/packages/sequence/src/interfaces/sequence-service.interface.ts
+++ b/packages/sequence/src/interfaces/sequence-service.interface.ts
@@ -1,0 +1,14 @@
+import { DataEntity, DetailKey, IInvoke } from '@mbc-cqrs-serverless/core'
+
+import { GenSequenceDto } from '../dto/gen-sequence.dto'
+
+export interface ISequenceService {
+  getCurrentSequence(key: DetailKey): Promise<DataEntity>
+
+  genNewSequence(
+    dto: GenSequenceDto,
+    opts: {
+      invokeContext: IInvoke
+    },
+  ): Promise<DataEntity>
+}

--- a/packages/sequence/src/sequences.service.spec.ts
+++ b/packages/sequence/src/sequences.service.spec.ts
@@ -1,0 +1,186 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SequencesService } from './sequences.service';
+import { DynamoDbService } from '@mbc-cqrs-serverless/core';
+import { Logger } from '@nestjs/common';
+import { RotateByEnum } from './enums/rotate-by.enum';
+
+describe('SequencesService', () => {
+  let service: SequencesService;
+  let dynamoDbService: DynamoDbService;
+  const mockTableName = 'mockTableName';
+  const tenantCode = 'MBC';
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SequencesService,
+        {
+          provide: DynamoDbService,
+          useValue: {
+            getItem: jest.fn(),
+            updateItem: jest.fn(),
+            getTableName: jest.fn().mockReturnValue(mockTableName),
+          },
+        },
+        Logger,
+      ],
+    }).compile();
+
+    service = module.get<SequencesService>(SequencesService);
+    dynamoDbService = module.get<DynamoDbService>(DynamoDbService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should get table name on initialization', () => {
+    expect(dynamoDbService.getTableName).toHaveBeenCalledWith('sequences');
+    expect(service['tableName']).toBe(mockTableName);
+  });
+
+
+
+  describe('getCurrentSequence', () => {
+    it('should call getItem with correct parameters and return the result', async () => {
+      const mockKey = { pk: "SEQ#MBC", sk: "TODO#TASK1#2024" };
+      const mockResponse = {
+        code: "TODO#TASK1#2024",
+        updatedBy: "92ca4f68-9ac6-4080-9ae2-2f02a86206a4",
+        createdIp: "127.0.0.1",
+        tenantCode: tenantCode,
+        type: "TODO",
+        createdAt: "2024-11-08T13:50:26+07:00",
+        updatedIp: "127.0.0.1",
+        createdBy: "92ca4f68-9ac6-4080-9ae2-2f02a86206a4",
+        requestId: "81bf1821-34b0-4dc5-a2ce-685d37d22f8c",
+        name: "fiscal_yearly",
+        sk: "TODO#TASK1#2024",
+        attributes: {
+          fiscal_year: 71,
+          issued_at: "2024-11-08T13:50:26+07:00",
+          formatted_no: "00TASK1-71-code3001"
+        },
+        pk: "SEQ#MBC",
+        seq: 1,
+        updatedAt: "2024-11-08T13:50:26+07:00"
+      };
+      jest.spyOn(dynamoDbService, 'getItem').mockResolvedValue(mockResponse);
+
+      const result = await service.getCurrentSequence(mockKey);
+      expect(dynamoDbService.getItem).toHaveBeenCalledWith(mockTableName, mockKey);
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  it('should return 68 for a date in November 2021', () => {
+    const testDate = new Date('2021-11-15'); // November 2021
+    expect(service.getFiscalYear(testDate)).toBe(68);
+  });
+
+  it('should return 68 for a date in March 2022 (end of fiscal year 68)', () => {
+    const testDate = new Date('2022-03-31'); // March 2022
+    expect(service.getFiscalYear(testDate)).toBe(68);
+  });
+
+  it('should return 69 for a date in April 2022 (start of fiscal year 69)', () => {
+    const testDate = new Date('2022-04-01'); // April 2022
+    expect(service.getFiscalYear(testDate)).toBe(69);
+  });
+
+  it('should return 69 for a date in December 2022', () => {
+    const testDate = new Date('2022-12-01'); // December 2022
+    expect(service.getFiscalYear(testDate)).toBe(69);
+  });
+
+  it('should return 69 for a date in February 2023 (within fiscal year 69)', () => {
+    const testDate = new Date('2023-02-15'); // February 2023
+    expect(service.getFiscalYear(testDate)).toBe(69);
+  });
+
+  it('should return 70 for a date in April 2023 (start of fiscal year 70)', () => {
+    const testDate = new Date('2023-04-01'); // April 2023
+    expect(service.getFiscalYear(testDate)).toBe(70);
+  });
+
+  it('should return fiscal year when rotateBy is FISCAL_YEARLY', () => {
+    const testDate = new Date('2024-02-15'); // February (before April)
+    expect(service.getRotateValue(RotateByEnum.FISCAL_YEARLY, testDate)).toBe('2023');
+
+    const testDate2 = new Date('2024-04-15'); // April (new fiscal year)
+    expect(service.getRotateValue(RotateByEnum.FISCAL_YEARLY, testDate2)).toBe('2024');
+  });
+
+  it('should return year when rotateBy is YEARLY', () => {
+    const testDate = new Date('2024-06-15');
+    expect(service.getRotateValue(RotateByEnum.YEARLY, testDate)).toBe('2024');
+  });
+
+  it('should return year and month when rotateBy is MONTHLY', () => {
+    const testDate = new Date('2024-06-15');
+    expect(service.getRotateValue(RotateByEnum.MONTHLY, testDate)).toBe('202406');
+
+    const testDate2 = new Date('2024-01-15');
+    expect(service.getRotateValue(RotateByEnum.MONTHLY, testDate2)).toBe('202401');
+  });
+
+  it('should return year, month, and day when rotateBy is DAILY', () => {
+    const testDate = new Date('2024-06-15');
+    expect(service.getRotateValue(RotateByEnum.DAILY, testDate)).toBe('20240615');
+
+    const testDate2 = new Date('2024-01-05');
+    expect(service.getRotateValue(RotateByEnum.DAILY, testDate2)).toBe('20240105');
+  });
+
+  it('should return RotateByEnum.NONE for undefined or unhandled rotateBy', () => {
+    expect(service.getRotateValue()).toBe(RotateByEnum.NONE);
+    expect(service.getRotateValue(undefined, new Date('2024-06-15'))).toBe(RotateByEnum.NONE);
+  });
+
+  it('should return true if rotateBy is not provided', () => {
+    const result = service.isIncrementNo(undefined, 2024, 2024, new Date());
+    expect(result).toBe(true);
+  });
+
+  it('should return true if rotateBy is FISCAL_YEARLY and fiscal year matches', () => {
+    const result = service.isIncrementNo(RotateByEnum.FISCAL_YEARLY, 2024, 2024, new Date());
+    expect(result).toBe(true);
+  });
+
+  it('should return false if rotateBy is FISCAL_YEARLY and fiscal year does not match', () => {
+    const result = service.isIncrementNo(RotateByEnum.FISCAL_YEARLY, 2024, 2023, new Date());
+    expect(result).toBe(false);
+  });
+  it('should return false if rotateBy is MONTHLY and issued year does not match current year', () => {
+    const issuedAt = new Date('2023-06-15');
+    // jest.spyOn(global, 'Date').mockImplementation(() => currentDate);
+
+    const result = service.isIncrementNo(RotateByEnum.MONTHLY, 2024, 2024, issuedAt);
+    expect(result).toBe(false);
+  });
+
+  it('should return false if rotateBy is MONTHLY and issued month does not match current month but matches year', () => {
+    const issuedAt = new Date('2024-05-01');
+    const result = service.isIncrementNo(RotateByEnum.MONTHLY, 2024, 2024, issuedAt);
+    expect(result).toBe(false);
+  });
+  it('should return false if rotateBy is YEARLY and issued year does not match current year', () => {
+    const issuedAt = new Date('2023-01-15');
+    const result = service.isIncrementNo(RotateByEnum.YEARLY, 2024, 2024, issuedAt);
+    expect(result).toBe(false);
+  });
+  it('should return true if rotateBy is YEARLY and issued year matches current year', () => {
+    const issuedAt = new Date('2024-01-15');
+    const currentDate = new Date('2024-06-15');
+    jest.spyOn(global, 'Date').mockImplementation(() => currentDate); // Mock current date
+
+    const result = service.isIncrementNo(RotateByEnum.YEARLY, 2024, 2024, issuedAt);
+    expect(result).toBe(true);
+  });
+  it('should return true if rotateBy is MONTHLY and issued month matches current month and year', () => {
+    const issuedAt = new Date();
+    const result = service.isIncrementNo(RotateByEnum.MONTHLY, 2024, 2024, issuedAt);
+    expect(result).toBe(true);
+  });
+
+});

--- a/packages/sequence/src/sequences.service.ts
+++ b/packages/sequence/src/sequences.service.ts
@@ -59,6 +59,7 @@ export class SequencesService implements ISequenceService {
       tenantCode,
       params,
       registerDate,
+      startMonth,
     } = dto
     const pk = `SEQ${KEY_SEPARATOR}${tenantCode}`
     let sk = [
@@ -76,6 +77,7 @@ export class SequencesService implements ISequenceService {
     const nowFiscalYear = this.getFiscalYear({
       now: date || now,
       registerTime: registerDate,
+      startMonth,
     })
     const sourceIp = opts.invokeContext?.event?.requestContext?.http?.sourceIp
     const userContext = getUserContext(opts.invokeContext)

--- a/packages/sequence/src/sequences.service.ts
+++ b/packages/sequence/src/sequences.service.ts
@@ -305,7 +305,7 @@ export class SequencesService implements ISequenceService {
     return false
   }
 
-  getFiscalYear(now: Date) {
+  getFiscalYear(now: Date, registerDate?: Date) {
     /**
      * This function calculates the fiscal year for MELTEC.
      * Fiscal year is from April to March.
@@ -316,6 +316,9 @@ export class SequencesService implements ISequenceService {
     // If the month is January, February, or March, subtract 1 from the year
     if (now.getMonth() + 1 <= 3) {
       year -= 1
+    }
+    if (registerDate) {
+      return year - registerDate.getFullYear()
     }
 
     // Subtract 1953 because 2021 corresponds to the 68th fiscal year

--- a/packages/sequence/src/sequences.service.ts
+++ b/packages/sequence/src/sequences.service.ts
@@ -142,7 +142,7 @@ export class SequencesService implements ISequenceService {
             { pk: rotateSequenceData.pk, sk: rotateSequenceData.sk },
             {
               set: {
-                code: params.code2,
+                code: sk,
                 name: rotateBy || 'none',
                 tenantCode: dto.tenantCode,
                 type: params.code1,
@@ -229,7 +229,7 @@ export class SequencesService implements ISequenceService {
     })
   }
 
-  private getRotateValue(rotateBy?: RotateByEnum, forDate?: Date) {
+  getRotateValue(rotateBy?: RotateByEnum, forDate?: Date) {
     const date = forDate || new Date()
 
     switch (rotateBy) {
@@ -259,8 +259,8 @@ export class SequencesService implements ISequenceService {
     }
   }
 
-  private isIncrementNo(
-    rotateBy: RotateByEnum,
+  isIncrementNo(
+    rotateBy: RotateByEnum | undefined,
     nowFiscalYear: number,
     fiscalYear: number,
     issuedAt: Date,
@@ -305,7 +305,7 @@ export class SequencesService implements ISequenceService {
     return false
   }
 
-  private getFiscalYear(now: Date) {
+  getFiscalYear(now: Date) {
     /**
      * This function calculates the fiscal year for MELTEC.
      * Fiscal year is from April to March.
@@ -322,7 +322,7 @@ export class SequencesService implements ISequenceService {
     return year - 1953
   }
 
-  private createFormatDict(
+  createFormatDict(
     sequenceParams: SequenceParamsDto,
     fiscalYear: number,
     fixNo: number,

--- a/packages/sequence/src/sequences.service.ts
+++ b/packages/sequence/src/sequences.service.ts
@@ -119,15 +119,19 @@ export class SequencesService implements ISequenceService {
         sk: `${sk}${KEY_SEPARATOR}${rotateSortKeyVal}`,
       })
       fixNo = rotateSequenceData ? rotateSequenceData.seq + 1 : 1
-    } else if (!date && sequenceData) {
-      fixNo = this.isIncrementNo(
-        rotateBy,
-        nowFiscalYear,
-        sequenceData.attributes.fiscal_year,
-        new Date(sequenceData.issuedAt),
-      )
-        ? sequenceData.seq + 1
-        : 1
+    } else if (!date) {
+      if (sequenceData) {
+        fixNo = this.isIncrementNo(
+          rotateBy,
+          nowFiscalYear,
+          sequenceData.attributes.fiscal_year,
+          new Date(sequenceData.issuedAt),
+        )
+          ? sequenceData.seq + 1
+          : 1
+      } else {
+        fixNo = 1
+      }
     }
 
     const formatDict = this.createFormatDict(

--- a/packages/sequence/src/sequences.service.ts
+++ b/packages/sequence/src/sequences.service.ts
@@ -5,14 +5,16 @@ import {
   getUserContext,
   IInvoke,
   KEY_SEPARATOR,
+  toISOStringWithTimezone,
 } from '@mbc-cqrs-serverless/core'
 import { Injectable, Logger } from '@nestjs/common'
 
-import { GenSequenceDto } from './dto/gen-sequence.dto'
+import { GenSequenceDto, SequenceParamsDto } from './dto/gen-sequence.dto'
 import { RotateByEnum } from './enums/rotate-by.enum'
+import { ISequenceService } from './interfaces/sequence-service.interface'
 
 @Injectable()
-export class SequencesService {
+export class SequencesService implements ISequenceService {
   private readonly logger = new Logger(SequencesService.name)
   private readonly tableName: string
 
@@ -35,42 +37,196 @@ export class SequencesService {
    * - type: typeCode
    * - seq: sequence value ( atomic counter )
    */
+
   async genNewSequence(
     dto: GenSequenceDto,
     opts: {
       invokeContext: IInvoke
     },
   ): Promise<DataEntity> {
-    const rotateVal = this.getRotateValue(dto.rotateBy, dto.date)
-    const pk = `SEQ${KEY_SEPARATOR}${dto.tenantCode}`
-    const sk = `${dto.typeCode}${KEY_SEPARATOR}${rotateVal}`
+    const { date, rotateBy, format = '%%no%%', tenantCode, params } = dto
+    const pk = `SEQ${KEY_SEPARATOR}${tenantCode}`
+    let sk = [
+      params.code1,
+      params.code2,
+      params.code3,
+      params.code4,
+      params.code5,
+    ]
+      .filter(Boolean)
+      .join(KEY_SEPARATOR)
+
+    const now = new Date()
+    let rotateSequenceData = null
+    const issuedAt = toISOStringWithTimezone(date || now)
+    const nowFiscalYear = this.getFiscalYear(date || now)
+    let failCount = 0
+    let fixNo = 0
+    let formattedNo = ''
 
     const sourceIp = opts.invokeContext?.event?.requestContext?.http?.sourceIp
     const userContext = getUserContext(opts.invokeContext)
     const userId = userContext.userId || 'system'
-    const now = new Date()
-    const item = await this.dynamoDbService.updateItem(
-      this.tableName,
-      { pk, sk },
-      {
-        set: {
-          code: sk,
-          name: dto.rotateBy || 'none',
-          tenantCode: dto.tenantCode,
-          type: dto.typeCode,
-          seq: { ifNotExists: 0, incrementBy: 1 },
-          requestId: opts.invokeContext?.context?.awsRequestId,
-          createdAt: { ifNotExists: now },
-          createdBy: { ifNotExists: userId },
-          createdIp: { ifNotExists: sourceIp },
-          updatedAt: now,
-          updatedBy: userId,
-          updatedIp: sourceIp,
-        },
-      },
-    )
+    for (let i = 0; i < 5; i++) {
+      try {
+        const sequenceData = await this.dynamoDbService.getItem(
+          this.tableName,
+          { pk, sk },
+        )
+        if (date && failCount === 0) {
+          // Handle rotating sequence data if date is provided
+          const rotateSortKeyVal = this.getRotateValue(rotateBy, date)
+          rotateSequenceData = await this.dynamoDbService.getItem(
+            this.tableName,
+            {
+              pk,
+              sk: `${sk}${KEY_SEPARATOR}${rotateSortKeyVal}`,
+            },
+          )
 
-    return item
+          fixNo = rotateSequenceData ? rotateSequenceData.seq + 1 : 1
+        } else if (!date && sequenceData) {
+          // Handle non-date logic for sequence increment
+          fixNo = this.isIncrementNo(
+            rotateBy,
+            nowFiscalYear,
+            sequenceData.attributes.fiscal_year,
+            new Date(sequenceData.issuedAt),
+          )
+            ? sequenceData.seq + 1
+            : 1
+        }
+
+        const formatDate = date || now
+
+        const formatDict = this.createFormatDict(
+          params,
+          nowFiscalYear,
+          fixNo,
+          formatDate,
+        )
+
+        formattedNo = this.createFormattedNo(format, formatDict)
+
+        const updateData = {
+          set: {
+            code: sk,
+            name: rotateBy || 'none',
+            tenantCode,
+            type: params.code1,
+            seq: fixNo,
+            requestId: opts.invokeContext?.context?.awsRequestId,
+            createdAt: { ifNotExists: now },
+            createdBy: { ifNotExists: userId },
+            createdIp: { ifNotExists: sourceIp },
+            attributes: {
+              formatted_no: formattedNo,
+              fiscal_year: nowFiscalYear,
+              issued_at: issuedAt,
+            },
+            updatedAt: now,
+            updatedBy: userId,
+            updatedIp: sourceIp,
+          },
+        }
+        if (!date) {
+          await this.dynamoDbService.updateItem(
+            this.tableName,
+            { pk, sk },
+            updateData,
+          )
+        }
+        if (rotateSequenceData) {
+          return await this.dynamoDbService.updateItem(
+            this.tableName,
+            { pk: rotateSequenceData.pk, sk: rotateSequenceData.sk },
+            {
+              set: {
+                code: params.code2,
+                name: rotateBy || 'none',
+                tenantCode: dto.tenantCode,
+                type: params.code1,
+                seq: fixNo,
+                requestId: opts.invokeContext?.context?.awsRequestId,
+                createdAt: { ifNotExists: now },
+                createdBy: { ifNotExists: userId },
+                createdIp: { ifNotExists: sourceIp },
+                attributes: {
+                  formatted_no: formattedNo,
+                  fiscal_year: nowFiscalYear,
+                  issued_at: issuedAt,
+                },
+                updatedAt: now,
+                updatedBy: userId,
+                updatedIp: sourceIp,
+              },
+            },
+          )
+        } else if (date) {
+          const rotateSortKeyVal = this.getRotateValue(rotateBy, date)
+          sk = `${sk}${KEY_SEPARATOR}${rotateSortKeyVal}`
+          await this.dynamoDbService.updateItem(
+            this.tableName,
+            { pk, sk },
+            {
+              set: {
+                code: sk,
+                name: rotateBy || 'none',
+                tenantCode: dto.tenantCode,
+                type: params.code1,
+                seq: fixNo,
+                requestId: opts.invokeContext?.context?.awsRequestId,
+                createdAt: { ifNotExists: now },
+                createdBy: { ifNotExists: userId },
+                createdIp: { ifNotExists: sourceIp },
+                attributes: {
+                  formatted_no: formattedNo,
+                  fiscal_year: nowFiscalYear,
+                  issued_at: issuedAt,
+                },
+                updatedAt: now,
+                updatedBy: userId,
+                updatedIp: sourceIp,
+              },
+            },
+          )
+          break
+        } else {
+          await this.dynamoDbService.updateItem(
+            this.tableName,
+            { pk, sk },
+            {
+              set: {
+                code: sk,
+                name: rotateBy || 'none',
+                tenantCode: dto.tenantCode,
+                type: params.code1,
+                seq: fixNo,
+                requestId: opts.invokeContext?.context?.awsRequestId,
+                createdAt: { ifNotExists: now },
+                createdBy: { ifNotExists: userId },
+                createdIp: { ifNotExists: sourceIp },
+                attributes: {
+                  formatted_no: formattedNo,
+                  fiscal_year: nowFiscalYear,
+                  issued_at: issuedAt,
+                },
+                updatedAt: now,
+                updatedBy: userId,
+                updatedIp: sourceIp,
+              },
+            },
+          )
+          break
+        }
+      } catch (error) {
+        failCount++
+      }
+    }
+    return await this.dynamoDbService.getItem(this.tableName, {
+      pk,
+      sk,
+    })
   }
 
   private getRotateValue(rotateBy?: RotateByEnum, forDate?: Date) {
@@ -80,7 +236,7 @@ export class SequencesService {
       case RotateByEnum.FISCAL_YEARLY:
         const year = date.getFullYear()
         // new fiscal year from April
-        return date.getMonth() < 3 ? year - 1 : year
+        return date.getMonth() < 3 ? (year - 1).toString() : year.toString()
 
       case RotateByEnum.YEARLY:
         return date.getFullYear().toString()
@@ -100,6 +256,129 @@ export class SequencesService {
 
       default:
         return RotateByEnum.NONE
+    }
+  }
+
+  private isIncrementNo(
+    rotateBy: RotateByEnum,
+    nowFiscalYear: number,
+    fiscalYear: number,
+    issuedAt: Date,
+  ) {
+    /**
+     * Determine whether to increment the number (no)
+     * based on rotateBy. If rotateBy matches the fiscal year, year, or month,
+     * depending on the value, it will return true for incrementing.
+     */
+
+    // If rotateBy is not provided, increment
+    if (!rotateBy) {
+      return true
+    }
+
+    // Reset the number if fiscal year changes
+    if (rotateBy === RotateByEnum.FISCAL_YEARLY) {
+      if (nowFiscalYear === fiscalYear) {
+        return true
+      }
+    }
+
+    // Use the current date in Japan time (JST)
+    const nowDate = new Date() // Assuming the server time is in JST
+
+    // Reset the number if year changes
+    if (rotateBy === RotateByEnum.YEARLY) {
+      if (nowDate.getFullYear() === issuedAt.getFullYear()) {
+        return true
+      }
+    }
+
+    // Reset the number if month changes
+    if (rotateBy === RotateByEnum.MONTHLY) {
+      if (nowDate.getFullYear() === issuedAt.getFullYear()) {
+        if (nowDate.getMonth() === issuedAt.getMonth()) {
+          return true
+        }
+      }
+    }
+
+    return false
+  }
+
+  private getFiscalYear(now: Date) {
+    /**
+     * This function calculates the fiscal year for MELTEC.
+     * Fiscal year is from April to March.
+     * Example: November 2021 → 68th fiscal year.
+     */
+    let year = now.getFullYear()
+
+    // If the month is January, February, or March, subtract 1 from the year
+    if (now.getMonth() + 1 <= 3) {
+      year -= 1
+    }
+
+    // Subtract 1953 because 2021 corresponds to the 68th fiscal year
+    return year - 1953
+  }
+
+  private createFormatDict(
+    sequenceParams: SequenceParamsDto,
+    fiscalYear: number,
+    fixNo: number,
+    now: Date,
+  ) {
+    return {
+      ...sequenceParams,
+      fiscal_year: fiscalYear,
+      no: fixNo,
+      month: now.getMonth() + 1,
+      day: now.getDate(),
+      date: now,
+    }
+  }
+
+  createFormattedNo(format: string, formatDict: SequenceParamsDto) {
+    let result = ''
+
+    const words = format.split('%%')
+    for (const word of words) {
+      if (word.includes('#')) {
+        const wordList = word.split('#')
+        if (formatDict[wordList[0]]) {
+          const key = wordList[0]
+          const value: string = formatDict[key].toString()
+
+          const paddingInfo = this.extractPaddingInfo(wordList[1])
+
+          const paddingValue = value.padStart(
+            paddingInfo.paddingNumber,
+            paddingInfo.paddingValue,
+          )
+
+          result += paddingValue
+        } else {
+          result += word
+        }
+      } else {
+        if (formatDict[word]) {
+          result += formatDict[word].toString()
+        } else {
+          result += word
+        }
+      }
+    }
+
+    return result
+  }
+
+  extractPaddingInfo(str: string) {
+    const regex = /:(\d)>(\d)/
+    const match = str.match(regex)
+
+    return {
+      paddingValue: match[1],
+      paddingNumber: parseInt(match[2], 10),
     }
   }
 }

--- a/packages/sequence/src/sequences.service.ts
+++ b/packages/sequence/src/sequences.service.ts
@@ -311,16 +311,36 @@ export class SequencesService implements ISequenceService {
      * Fiscal year is from April to March.
      * Example: November 2021 → 68th fiscal year.
      */
+
+    // If registerDate is provided, calculate the fiscal year period (期)
+    if (registerDate) {
+      const registerYear = registerDate.getFullYear() // Registration year
+      const registerMonth = registerDate.getMonth() + 1 // Registration month (1 - 12)
+
+      let year = now.getFullYear() // Current year
+      let fiscalYearPeriod
+
+      // If the current month is January, February, or March, the fiscal year belongs to the previous year
+      if (now.getMonth() + 1 <= 3) {
+        year -= 1
+      }
+
+      // Calculate the fiscal year period (期) from the company's registration date
+      fiscalYearPeriod = year - registerYear + 1
+
+      // If the registration month is after March, the fiscal year starts from the following year
+      if (registerMonth > 3) {
+        fiscalYearPeriod++
+      }
+
+      return fiscalYearPeriod
+    }
     let year = now.getFullYear()
 
     // If the month is January, February, or March, subtract 1 from the year
     if (now.getMonth() + 1 <= 3) {
       year -= 1
     }
-    if (registerDate) {
-      return year - registerDate.getFullYear()
-    }
-
     // Subtract 1953 because 2021 corresponds to the 68th fiscal year
     return year - 1953
   }

--- a/packages/sequence/src/sequences.service.ts
+++ b/packages/sequence/src/sequences.service.ts
@@ -44,7 +44,14 @@ export class SequencesService implements ISequenceService {
       invokeContext: IInvoke
     },
   ): Promise<DataEntity> {
-    const { date, rotateBy, format = '%%no%%', tenantCode, params } = dto
+    const {
+      date,
+      rotateBy,
+      format = '%%no%%',
+      tenantCode,
+      params,
+      registerDate,
+    } = dto
     const pk = `SEQ${KEY_SEPARATOR}${tenantCode}`
     let sk = [
       params.code1,


### PR DESCRIPTION
## Descriptions
- Custom Start Month: Allow users to specify any month as the start of the fiscal year, instead of being fixed to April.
- Fiscal Year Based on Establishment Date: Calculate the fiscal year starting from the company’s establishment date.
- Configurable Function: Provide a function to calculate the fiscal year based on a custom start date and return the fiscal year in the desired format.
- Flexible Numbering: Automatically adjust the fiscal year period number according to the chosen start date, enabling companies to have custom fiscal year cycles and period numbering.

## Related 
- https://github.com/mbc-net/mbc-cqrs-serverless/discussions/37