### PR TITLE
[Sequence] Configuration Changes

### DIFF
--- a/packages/sequence/src/constants/sequence.constant.ts
+++ b/packages/sequence/src/constants/sequence.constant.ts
@@ -1,5 +1,4 @@
 type MasterDataType = {
-  typeCode: string
   format: string
   startMonth?: number
   registerDate?: Date
@@ -8,6 +7,5 @@ type MasterDataType = {
 export const DEFAULT_MASTER_DATA = Symbol('DEFAULT_MASTER_DATA')
 
 export const DEFAULT_VALUE_MASTER_DATA: MasterDataType = {
-  typeCode: 'sequence',
   format: '%%no%%',
 }

--- a/packages/sequence/src/dto/gen-sequence.dto.ts
+++ b/packages/sequence/src/dto/gen-sequence.dto.ts
@@ -97,6 +97,9 @@ export class GenerateFormattedSequenceDto {
   @IsString()
   tenantCode: string
 
+  @IsString()
+  typeCode: string
+
   /**
    * Type code for specific sequence classification.
    */

--- a/packages/sequence/src/sequences.service.spec.ts
+++ b/packages/sequence/src/sequences.service.spec.ts
@@ -6,6 +6,7 @@ import { RotateByEnum } from './enums/rotate-by.enum';
 import { FiscalYearOptions } from './interfaces/fiscal-year.interface';
 import { SequenceMasterDataProvider } from './sequence-master-factory';
 import { SequenceEntity } from './entities/sequence.entity';
+import { register } from 'module';
 
 
 const optionsMock = {
@@ -1067,6 +1068,49 @@ describe('SequencesService', () => {
           },
           date: new Date("2024-11-15T13:44:16+07:00"),
           rotateBy: RotateByEnum.YEARLY,
+        },
+        optionsMock
+      );
+      expect(result).toEqual(mockSequenceResponse);
+    })
+    it('should call generateSequenceItem with register date,  format is %%code1%%-%%fiscal_year%%-%%no%%', async () => {
+      const mockMasterData = {
+        typeCode: 'sequence',
+        format: '%%code1%%-%%fiscal_year%%-%%no%%',
+        registerDate: new Date("2020-01-01"),
+      }
+      const mockUpdate ={
+       "code": "sequence#PI#2024",
+        "updatedBy": "92ca4f68-9ac6-4080-9ae2-2f02a86206a4",
+        "createdIp": "127.0.0.1",
+        "tenantCode": "MBC",
+        "type": "sequence",
+        "createdAt": "2024-11-27T17:45:45+07:00",
+        "updatedIp": "127.0.0.1",
+        "createdBy": "92ca4f68-9ac6-4080-9ae2-2f02a86206a4",
+        "requestId": "9fc8d555-f200-4f5d-b3e0-07d2fa9dcd16",
+        "name": "fiscal_yearly",
+        "sk": "sequence#PI#2024",
+        "pk": "SEQ#MBC",
+        "seq": 2,
+        "updatedAt": "2024-11-27T17:46:36+07:00"
+      }
+      jest.spyOn(masterService, 'getData').mockResolvedValue(mockMasterData);
+      jest.spyOn(dynamoDbService, 'updateItem').mockResolvedValue(mockUpdate);
+      const mockSequenceResponse = new SequenceEntity({
+        id: "SEQ#MBC#sequence#PI#2024",
+        no: 2,
+        formattedNo:"PI-5-2",
+        issuedAt: new Date("2024-11-27T17:46:36+07:00"),
+      })
+      const result = await service.generateSequenceItem(
+        {
+          tenantCode: tenantCode,
+          params: {
+            code1: 'PI',
+          },
+          date: new Date("2024-11-27T17:46:36+07:00"),
+          rotateBy: RotateByEnum.FISCAL_YEARLY,
         },
         optionsMock
       );

--- a/packages/sequence/src/sequences.service.spec.ts
+++ b/packages/sequence/src/sequences.service.spec.ts
@@ -6,7 +6,6 @@ import { RotateByEnum } from './enums/rotate-by.enum';
 import { FiscalYearOptions } from './interfaces/fiscal-year.interface';
 import { SequenceMasterDataProvider } from './sequence-master-factory';
 import { SequenceEntity } from './entities/sequence.entity';
-import { register } from 'module';
 
 
 const optionsMock = {

--- a/packages/sequence/src/sequences.service.spec.ts
+++ b/packages/sequence/src/sequences.service.spec.ts
@@ -330,6 +330,7 @@ describe('SequencesService', () => {
       const result = await service.generateSequenceItem(
         {
           tenantCode: tenantCode,
+          typeCode: 'sequence',
           params: {
             code1: 'TODO',
           },
@@ -372,6 +373,7 @@ describe('SequencesService', () => {
       const result = await service.generateSequenceItem(
         {
           tenantCode: tenantCode,
+          typeCode: 'sequence',
           date: new Date("2024-11-27T13:44:16+07:00"),  
           params: {
             code1: 'TODO',
@@ -414,6 +416,7 @@ describe('SequencesService', () => {
       const result = await service.generateSequenceItem(
         {
           tenantCode: tenantCode,
+          typeCode:  'sequence',
           params: {
             code1: 'TODO',
           },
@@ -457,6 +460,7 @@ describe('SequencesService', () => {
       const result = await service.generateSequenceItem(
         {
           tenantCode: tenantCode,
+          typeCode  : 'sequence',
           params: {
             code1: 'TODO',
           },
@@ -500,6 +504,7 @@ describe('SequencesService', () => {
       const result = await service.generateSequenceItem(
         {
           tenantCode: tenantCode,
+          typeCode  : 'sequence',
           params: {
             code1: 'TODO',
           },
@@ -543,6 +548,7 @@ describe('SequencesService', () => {
       const result = await service.generateSequenceItem(
         {
           tenantCode: tenantCode,
+          typeCode: 'sequence',
           params: {
             code1: 'TODO',
           },
@@ -586,6 +592,7 @@ describe('SequencesService', () => {
       const result = await service.generateSequenceItem(
         {
           tenantCode: tenantCode,
+          typeCode: 'sequence',
           date : new Date("2024-11-27T13:54:04+07:00"),
           params: {
             code1: 'TODO',
@@ -629,6 +636,7 @@ describe('SequencesService', () => {
       const result = await service.generateSequenceItem(
         {
           tenantCode: tenantCode,
+          typeCode: 'sequence',
           params: {
             code1: 'TODO',
           },
@@ -672,6 +680,7 @@ describe('SequencesService', () => {
       const result = await service.generateSequenceItem(
         {
           tenantCode: tenantCode,
+          typeCode: 'sequence',
           date : new Date("2024-11-27T13:56:39+07:00"),
           params: {
             code1: 'TODO',
@@ -715,6 +724,7 @@ describe('SequencesService', () => {
       const result = await service.generateSequenceItem(
         {
           tenantCode: tenantCode,
+          typeCode: 'sequence',
           params: {
             code1: 'TODO',
           },
@@ -758,6 +768,7 @@ describe('SequencesService', () => {
       const result = await service.generateSequenceItem(
         {
           tenantCode: tenantCode,
+          typeCode: 'sequence',
           params: {
             code1: 'TODO',
           },
@@ -801,6 +812,7 @@ describe('SequencesService', () => {
       const result = await service.generateSequenceItem(
         {
           tenantCode: tenantCode,
+          typeCode: 'sequence',
           params: {
             code1: 'TODO',
           },
@@ -844,6 +856,7 @@ describe('SequencesService', () => {
         {
           tenantCode: tenantCode,
           date : new Date("2024-11-27T13:56:39+07:00"),
+          typeCode: 'sequence',
           params: {
             code1: 'TODO',
           },
@@ -885,6 +898,7 @@ describe('SequencesService', () => {
       const result = await service.generateSequenceItem(
         {
           tenantCode: tenantCode,
+          typeCode: 'sequence',
           params: {
             code1: 'TODO',
           },
@@ -928,6 +942,7 @@ describe('SequencesService', () => {
       const result = await service.generateSequenceItem(
         {
           tenantCode: tenantCode,
+          typeCode: 'sequence',
           rotateBy: RotateByEnum.NONE,
           date: new Date("2024-11-27T13:44:16+07:00"),
           params: {
@@ -974,6 +989,7 @@ describe('SequencesService', () => {
       const result = await service.generateSequenceItem(
         {
           tenantCode: tenantCode,
+          typeCode: 'sequence',
           date: new Date("2024-11-27T13:44:16+07:00"),
           rotateBy: RotateByEnum.NONE,
           params: {
@@ -1021,6 +1037,7 @@ describe('SequencesService', () => {
       const result = await service.generateSequenceItem(
         {
           tenantCode: tenantCode,
+          typeCode: 'sequence',
           params: {
             code1: 'TODO',
           },
@@ -1063,6 +1080,7 @@ describe('SequencesService', () => {
       const result = await service.generateSequenceItem(
         {
           tenantCode: tenantCode,
+          typeCode: 'sequence',
           params: {
             code1: 'TODO',
           },
@@ -1106,6 +1124,7 @@ describe('SequencesService', () => {
       const result = await service.generateSequenceItem(
         {
           tenantCode: tenantCode,
+          typeCode: 'sequence',
           params: {
             code1: 'PI',
           },

--- a/packages/sequence/src/sequences.service.ts
+++ b/packages/sequence/src/sequences.service.ts
@@ -120,7 +120,7 @@ export class SequencesService implements ISequenceService {
     const { date, rotateBy, tenantCode, params, typeCode } = dto
 
     const generalMasterPk = masterPk(tenantCode)
-    const generalMasterSk = `SEQ${KEY_SEPARATOR}${params?.code1}`
+    const generalMasterSk = `SEQ${KEY_SEPARATOR}${typeCode}`
     this.logger.log('general master pk: ', generalMasterPk)
     this.logger.log('general master sk: ', generalMasterSk)
     const masterData = await this.masterDataProvider.getData({

--- a/packages/sequence/src/sequences.service.ts
+++ b/packages/sequence/src/sequences.service.ts
@@ -117,7 +117,7 @@ export class SequencesService implements ISequenceService {
     dto: GenerateFormattedSequenceDto,
     options: { invokeContext: IInvoke },
   ): Promise<SequenceEntity> {
-    const { date, rotateBy, tenantCode, params } = dto
+    const { date, rotateBy, tenantCode, params, typeCode } = dto
 
     const generalMasterPk = masterPk(tenantCode)
     const generalMasterSk = `SEQ${KEY_SEPARATOR}${params?.code1}`
@@ -128,7 +128,7 @@ export class SequencesService implements ISequenceService {
       sk: generalMasterSk,
     })
     // Get master data for the tenant
-    const { format, typeCode, registerDate, startMonth } = masterData
+    const { format, registerDate, startMonth } = masterData
     const pk = seqPk(tenantCode)
     // Construct the sort key for the sequence
     let sk = [


### PR DESCRIPTION
### 1. Configuration Changes
1.1 Providing typeCode via DTO
The **typeCode** is now passed as a parameter through the **DTO** when calling the sequence feature.
```
{
  "tenantCode": "exampleTenant",
  "typeCode": "sequence",
  "rotateBy": "fiscal_yearly",
  "params": {
     "code1": "exampleCode1",
     "code2":"exampleCode2",
     "code3":"exampleCode3",
     "code4":"exampleCode4",
     "code5":"exampleCode5"
  }
}
```