### PR TITLE
Add detailed instructions and single quotes in tests

### DIFF
--- a/packages/cli/templates/prisma/schema.prisma
+++ b/packages/cli/templates/prisma/schema.prisma
@@ -17,7 +17,7 @@ model Master {
   id             String   @id
   cpk            String // コマンド用PK
   csk            String // コマンド用SK
-  pk             String // データ用PK, MASTER#unigrab (テナントコード)
+  pk             String // データ用PK, MASTER#tenantCode (テナントコード)
   sk             String // データ用SK, マスタ種別コード#マスタコード
   masterTypeCode String   @map("master_type_code") // マスタ種別コード, 【共通マスタ】 or 【テナント固有マスタ】
   masterCode     String   @map("master_code") // マスタコード

--- a/packages/cli/templates/src/master/master.controller.ts
+++ b/packages/cli/templates/src/master/master.controller.ts
@@ -42,7 +42,9 @@ export class MasterController {
   ): Promise<MasterDataEntity> {
     this.logger.debug('cmd:', masterDto)
     this.logger.debug('commandService:' + this.commandService.tableName)
-    const item = await this.commandService.publish(masterDto, { invokeContext })
+    const item = await this.commandService.publishAsync(masterDto, {
+      invokeContext,
+    })
     return new MasterDataEntity(item as MasterDataEntity)
   }
 

--- a/packages/cli/templates/src/repl.ts
+++ b/packages/cli/templates/src/repl.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
-import { repl } from '@nestjs/core'
 import { AppModule } from '@mbc-cqrs-serverless/core'
+import { repl } from '@nestjs/core'
 
 import { MainModule } from './main.module'
 


### PR DESCRIPTION
Expanded the README.md for the sequence package with detailed installation and setup instructions. Enhanced code readability in the sequence service test file by replacing double quotes with single quotes, which is the project's preferred style. Alongside this, the installation command description was standardized across various README.md files.