### PR TITLE
ci: run test on multiple version of node 

### DIFF
--- a/.github/workflows/run-test-and-publish-main.yaml
+++ b/.github/workflows/run-test-and-publish-main.yaml
@@ -14,13 +14,16 @@ jobs:
   unit_tests:
     name: Unit Test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 22.x]
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: ${{ matrix.node-version }}
           cache: npm
 
       - name: Install dependencies
@@ -36,7 +39,7 @@ jobs:
         uses: dorny/test-reporter@v1
         if: success() || failure()
         with:
-          name: Unit Tests Reporter
+          name: Unit Tests Reporter-${{ matrix.node-version }}
           path: report/unit.xml
           reporter: jest-junit
           fail-on-error: 'true'
@@ -45,13 +48,16 @@ jobs:
     name: E2e Test For Core package
     needs: unit_tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 22.x]
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: ${{ matrix.node-version }}
           cache: npm
 
       - name: Install dependencies
@@ -67,14 +73,14 @@ jobs:
         name: 'upload artifact'
         if: success() || failure()
         with:
-          name: my-artifacts
+          name: core-report-artifact-${{ matrix.node-version }}
           path: ./packages/core/test/scripts/*.out.txt
 
       - name: E2E Test Report
         uses: dorny/test-reporter@v1
         if: success() || failure()
         with:
-          name: E2E Core Tests Reporter
+          name: E2E Core Tests Reporter-${{ matrix.node-version }}
           path: report/e2e-core.xml
           reporter: jest-junit
           fail-on-error: 'true'

--- a/.github/workflows/run-test-develop.yaml
+++ b/.github/workflows/run-test-develop.yaml
@@ -14,13 +14,16 @@ jobs:
   unit_tests:
     name: Unit Test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 22.x]
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: ${{ matrix.node-version }}
           cache: npm
 
       - name: Install dependencies
@@ -36,7 +39,7 @@ jobs:
         uses: dorny/test-reporter@v1
         if: success() || failure()
         with:
-          name: Unit Tests Reporter
+          name: Unit Tests Reporter-${{ matrix.node-version }}
           path: report/unit.xml
           reporter: jest-junit
           fail-on-error: 'true'
@@ -45,13 +48,16 @@ jobs:
     name: E2e Test For Core package
     needs: unit_tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 22.x]
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: ${{ matrix.node-version }}
           cache: npm
 
       - name: Install dependencies
@@ -67,14 +73,14 @@ jobs:
         name: 'upload artifact'
         if: success() || failure()
         with:
-          name: my-artifacts
+          name: core-report-artifact-${{ matrix.node-version }}
           path: ./packages/core/test/scripts/*.out.txt
 
       - name: E2E Test Report
         uses: dorny/test-reporter@v1
         if: success() || failure()
         with:
-          name: E2E Core Tests Reporter
+          name: E2E Core Tests Reporter-${{ matrix.node-version }}
           path: report/e2e-core.xml
           reporter: jest-junit
           fail-on-error: 'true'

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.1.45-beta.0",
+  "version": "0.1.46-beta.0",
   "packages": ["packages/*"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28266,7 +28266,7 @@
     },
     "packages/cli": {
       "name": "@mbc-cqrs-serverless/cli",
-      "version": "0.1.45-beta.0",
+      "version": "0.1.46-beta.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",
@@ -28290,7 +28290,7 @@
     },
     "packages/core": {
       "name": "@mbc-cqrs-serverless/core",
-      "version": "0.1.45-beta.0",
+      "version": "0.1.46-beta.0",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",
@@ -28338,26 +28338,26 @@
     },
     "packages/sequence": {
       "name": "@mbc-cqrs-serverless/sequence",
-      "version": "0.1.45-beta.0",
+      "version": "0.1.46-beta.0",
       "license": "MIT",
       "dependencies": {
-        "@mbc-cqrs-serverless/core": "^0.1.45-beta.0"
+        "@mbc-cqrs-serverless/core": "^0.1.46-beta.0"
       }
     },
     "packages/task": {
       "name": "@mbc-cqrs-serverless/task",
-      "version": "0.1.45-beta.0",
+      "version": "0.1.46-beta.0",
       "license": "MIT",
       "dependencies": {
-        "@mbc-cqrs-serverless/core": "^0.1.45-beta.0"
+        "@mbc-cqrs-serverless/core": "^0.1.46-beta.0"
       }
     },
     "packages/ui-setting": {
       "name": "@mbc-cqrs-serverless/ui-setting",
-      "version": "0.1.45-beta.0",
+      "version": "0.1.46-beta.0",
       "license": "MIT",
       "dependencies": {
-        "@mbc-cqrs-serverless/core": "^0.1.45-beta.0"
+        "@mbc-cqrs-serverless/core": "^0.1.46-beta.0"
       }
     }
   }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mbc-cqrs-serverless/cli",
-  "version": "0.1.45-beta.0",
+  "version": "0.1.46-beta.0",
   "description": "a CLI to get started with MBC CQRS serverless framework",
   "keywords": [
     "mbc",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mbc-cqrs-serverless/core",
-  "version": "0.1.45-beta.0",
+  "version": "0.1.46-beta.0",
   "description": "CQRS and event base core",
   "keywords": [
     "mbc",

--- a/packages/sequence/package.json
+++ b/packages/sequence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mbc-cqrs-serverless/sequence",
-  "version": "0.1.45-beta.0",
+  "version": "0.1.46-beta.0",
   "description": "Generate increment sequence with time-rotation",
   "keywords": [
     "mbc",
@@ -41,6 +41,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@mbc-cqrs-serverless/core": "^0.1.45-beta.0"
+    "@mbc-cqrs-serverless/core": "^0.1.46-beta.0"
   }
 }

--- a/packages/sequence/src/sequence-master-factory.ts
+++ b/packages/sequence/src/sequence-master-factory.ts
@@ -25,7 +25,7 @@ export class SequenceMasterDataProvider implements IMasterDataProvider {
       if (!item) {
         return this.defaultValue
       }
-      return item
+      return item.attributes
     } catch (error) {
       return this.defaultValue
     }

--- a/packages/task/package.json
+++ b/packages/task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mbc-cqrs-serverless/task",
-  "version": "0.1.45-beta.0",
+  "version": "0.1.46-beta.0",
   "description": "long-running task",
   "keywords": [
     "mbc",
@@ -41,6 +41,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@mbc-cqrs-serverless/core": "^0.1.45-beta.0"
+    "@mbc-cqrs-serverless/core": "^0.1.46-beta.0"
   }
 }

--- a/packages/ui-setting/package.json
+++ b/packages/ui-setting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mbc-cqrs-serverless/ui-setting",
-  "version": "0.1.45-beta.0",
+  "version": "0.1.46-beta.0",
   "description": "Setting master data",
   "keywords": [
     "mbc",
@@ -41,6 +41,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@mbc-cqrs-serverless/core": "^0.1.45-beta.0"
+    "@mbc-cqrs-serverless/core": "^0.1.46-beta.0"
   }
 }


### PR DESCRIPTION
## Summary

This PR adds support for running tests across multiple Node.js versions (18, 20, 22). This ensures compatibility and stability across different environments by validating the application behavior on various LTS and current Node.js releases.

## Related

- https://github.com/mbc-net/mbc-cqrs-serverless/discussions/60