### PR TITLE
ci: upgrade serverless to support mutil node version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28309,7 +28309,7 @@
         "ulid": "^2.3.0"
       },
       "devDependencies": {
-        "serverless": "^3.38.0",
+        "serverless": "^3.40.0",
         "serverless-dynamodb": "^0.2.47",
         "serverless-localstack": "^1.1.2",
         "serverless-offline": "^13.3.2",
@@ -28330,11 +28330,140 @@
         "supertest": "^7.0.0"
       }
     },
+    "packages/core/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "packages/core/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "packages/core/node_modules/reflect-metadata": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
       "license": "Apache-2.0"
+    },
+    "packages/core/node_modules/serverless": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/serverless/-/serverless-3.40.0.tgz",
+      "integrity": "sha512-6vUSIUqBkhZeIpFz0howqKlT1BNjYxOrucvvSICKCEsxVS9MbTJokGkykDrpr/k4Io3WI8tcvrf25+U5Ynf3lw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@aws-sdk/client-api-gateway": "^3.588.0",
+        "@aws-sdk/client-cognito-identity-provider": "^3.588.0",
+        "@aws-sdk/client-eventbridge": "^3.588.0",
+        "@aws-sdk/client-iam": "^3.588.0",
+        "@aws-sdk/client-lambda": "^3.588.0",
+        "@aws-sdk/client-s3": "^3.588.0",
+        "@serverless/dashboard-plugin": "^7.2.0",
+        "@serverless/platform-client": "^4.5.1",
+        "@serverless/utils": "^6.13.1",
+        "abort-controller": "^3.0.0",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^2.1.1",
+        "archiver": "^5.3.1",
+        "aws-sdk": "^2.1404.0",
+        "bluebird": "^3.7.2",
+        "cachedir": "^2.3.0",
+        "chalk": "^4.1.2",
+        "child-process-ext": "^2.1.1",
+        "ci-info": "^3.8.0",
+        "cli-progress-footer": "^2.3.2",
+        "d": "^1.0.1",
+        "dayjs": "^1.11.8",
+        "decompress": "^4.2.1",
+        "dotenv": "^16.3.1",
+        "dotenv-expand": "^10.0.0",
+        "essentials": "^1.2.0",
+        "ext": "^1.7.0",
+        "fastest-levenshtein": "^1.0.16",
+        "filesize": "^10.0.7",
+        "fs-extra": "^10.1.0",
+        "get-stdin": "^8.0.0",
+        "globby": "^11.1.0",
+        "graceful-fs": "^4.2.11",
+        "https-proxy-agent": "^5.0.1",
+        "is-docker": "^2.2.1",
+        "js-yaml": "^4.1.0",
+        "json-colorizer": "^2.2.2",
+        "json-cycle": "^1.5.0",
+        "json-refs": "^3.0.15",
+        "lodash": "^4.17.21",
+        "memoizee": "^0.4.15",
+        "micromatch": "^4.0.5",
+        "node-fetch": "^2.6.11",
+        "npm-registry-utilities": "^1.0.0",
+        "object-hash": "^3.0.0",
+        "open": "^8.4.2",
+        "path2": "^0.1.0",
+        "process-utils": "^4.0.0",
+        "promise-queue": "^2.2.5",
+        "require-from-string": "^2.0.2",
+        "semver": "^7.5.3",
+        "signal-exit": "^3.0.7",
+        "stream-buffers": "^3.0.2",
+        "strip-ansi": "^6.0.1",
+        "supports-color": "^8.1.1",
+        "tar": "^6.1.15",
+        "timers-ext": "^0.1.7",
+        "type": "^2.7.2",
+        "untildify": "^4.0.0",
+        "uuid": "^9.0.0",
+        "ws": "^7.5.9",
+        "yaml-ast-parser": "0.0.43"
+      },
+      "bin": {
+        "serverless": "bin/serverless.js",
+        "sls": "bin/serverless.js"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "packages/core/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "packages/core/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
     },
     "packages/sequence": {
       "name": "@mbc-cqrs-serverless/sequence",

--- a/packages/cli/templates/package.json
+++ b/packages/cli/templates/package.json
@@ -73,7 +73,7 @@
     "nestjs-spelunker": "^1.3.0",
     "prettier": "^3.1.1",
     "run-script-os": "^1.1.6",
-    "serverless": "^3.38.0",
+    "serverless": "^3.40.0",
     "serverless-dynamodb": "^0.2.47",
     "serverless-localstack": "^1.1.2",
     "serverless-offline": "^13.3.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -66,7 +66,7 @@
     "ulid": "^2.3.0"
   },
   "devDependencies": {
-    "serverless": "^3.38.0",
+    "serverless": "^3.40.0",
     "serverless-dynamodb": "^0.2.47",
     "serverless-localstack": "^1.1.2",
     "serverless-offline": "^13.3.2",


### PR DESCRIPTION
## Summary

This PR increase serverless package vesion to 3.40.0, which resolves the Node v22 incompatibility

## Related 

- https://github.com/mbc-net/mbc-cqrs-serverless/discussions/60
