### PR TITLE
feat: add dataSync support to MasterModule and TenantModule

### DIFF
--- a/packages/master/src/master.module-definition.ts
+++ b/packages/master/src/master.module-definition.ts
@@ -1,7 +1,10 @@
+import { IDataSyncHandler } from '@mbc-cqrs-serverless/core'
 import { ConfigurableModuleBuilder } from '@nestjs/common'
+import { Type } from '@nestjs/common'
 
 export interface MasterModuleOptions {
   enableController?: boolean
+  dataSyncHandlers?: Type<IDataSyncHandler>[]
 }
 
 export const { ConfigurableModuleClass, MODULE_OPTIONS_TOKEN, OPTIONS_TYPE } =

--- a/packages/master/src/master.module.ts
+++ b/packages/master/src/master.module.ts
@@ -14,13 +14,7 @@ import {
 import { MasterDataService, MasterSettingService } from './services'
 
 @Module({
-  imports: [
-    CommandModule.register({
-      tableName: TABLE_NAME,
-    }),
-    DataStoreModule,
-    QueueModule,
-  ],
+  imports: [DataStoreModule, QueueModule],
   providers: [MasterDataService, MasterSettingService],
   exports: [MasterDataService, MasterSettingService],
 })
@@ -35,9 +29,18 @@ export class MasterModule extends ConfigurableModuleClass {
       module.controllers.push(MasterDataController)
       module.controllers.push(MasterSettingController)
     }
+    const imports = [...(module.imports ?? [])]
+
+    imports.push(
+      CommandModule.register({
+        tableName: TABLE_NAME,
+        dataSyncHandlers: options?.dataSyncHandlers,
+      }),
+    )
 
     return {
       ...module,
+      imports,
     }
   }
 }

--- a/packages/tenant/src/tenant.module-definition.ts
+++ b/packages/tenant/src/tenant.module-definition.ts
@@ -1,7 +1,9 @@
-import { ConfigurableModuleBuilder } from '@nestjs/common'
+import { IDataSyncHandler } from '@mbc-cqrs-serverless/core'
+import { ConfigurableModuleBuilder, Type } from '@nestjs/common'
 
 export interface TenantModuleOptions {
   enableController?: boolean
+  dataSyncHandlers?: Type<IDataSyncHandler>[]
 }
 
 export const { ConfigurableModuleClass, MODULE_OPTIONS_TOKEN, OPTIONS_TYPE } =

--- a/packages/tenant/src/tenant.module.ts
+++ b/packages/tenant/src/tenant.module.ts
@@ -14,13 +14,7 @@ import {
 } from './tenant.module-definition'
 
 @Module({
-  imports: [
-    CommandModule.register({
-      tableName: TABLE_NAME,
-    }),
-    DataStoreModule,
-    QueueModule,
-  ],
+  imports: [DataStoreModule, QueueModule],
   providers: [TenantService],
   exports: [TenantService],
 })
@@ -34,8 +28,18 @@ export class TenantModule extends ConfigurableModuleClass {
       }
       module.controllers.push(TenantController)
     }
+    const imports = [...(module.imports ?? [])]
+
+    imports.push(
+      CommandModule.register({
+        tableName: TABLE_NAME,
+        dataSyncHandlers: options?.dataSyncHandlers,
+      }),
+    )
+
     return {
       ...module,
+      imports,
     }
   }
 }


### PR DESCRIPTION
### 概要 (Summary)

- MasterModule とTenantModule に dataSyncHandlers のサポートを追加
- enableController が有効な場合に CommandModule を統合
- MasterDataController と MasterSettingController を登録

### 変更点 (Changes)

- register メソッドを更新し、dataSyncHandlers を含む CommandModule を追加
- モジュールに controller を追加するための条件をチェック
### テスト方法 (How to Test)

- MasterModule.register({ enableController: true, dataSyncHandlers: [...] }) を実行して確認
- Controllers および CommandModule を使用したデータ同期が正しく動作することを確認