### PR TITLE
fix(master): allow creating a setting after deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.55-beta.0](https://github.com/mbc-net/mbc-cqrs-serverless/compare/v0.1.54-beta.0...v0.1.55-beta.0) (2025-02-14)
+
+### Features
+
+- update template to use node 20 runtime ([edeaf00](https://github.com/mbc-net/mbc-cqrs-serverless/commit/edeaf00459db3a9e41b57cae8f8a0cda00540c80))
+
 ## [0.1.54-beta.0](https://github.com/mbc-net/mbc-cqrs-serverless/compare/v0.1.53-beta.0...v0.1.54-beta.0) (2025-02-13)
 
 **Note:** Version bump only for package mbc-cqrs-serverless

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.1.54-beta.0",
+  "version": "0.1.55-beta.0",
   "packages": ["packages/*"],
   "command": {
     "version": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24132,7 +24132,7 @@
     },
     "packages/cli": {
       "name": "@mbc-cqrs-serverless/cli",
-      "version": "0.1.54-beta.0",
+      "version": "0.1.55-beta.0",
       "license": "MIT",
       "dependencies": {
         "@angular-devkit/core": "^17.3.11",
@@ -24162,7 +24162,7 @@
     },
     "packages/core": {
       "name": "@mbc-cqrs-serverless/core",
-      "version": "0.1.54-beta.0",
+      "version": "0.1.55-beta.0",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",
@@ -24337,7 +24337,7 @@
     },
     "packages/master": {
       "name": "@mbc-cqrs-serverless/master",
-      "version": "0.1.54-beta.0",
+      "version": "0.1.55-beta.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -24374,23 +24374,23 @@
     },
     "packages/sequence": {
       "name": "@mbc-cqrs-serverless/sequence",
-      "version": "0.1.54-beta.0",
+      "version": "0.1.55-beta.0",
       "license": "MIT",
       "dependencies": {
-        "@mbc-cqrs-serverless/core": "^0.1.54-beta.0"
+        "@mbc-cqrs-serverless/core": "^0.1.55-beta.0"
       }
     },
     "packages/task": {
       "name": "@mbc-cqrs-serverless/task",
-      "version": "0.1.54-beta.0",
+      "version": "0.1.55-beta.0",
       "license": "MIT",
       "dependencies": {
-        "@mbc-cqrs-serverless/core": "^0.1.54-beta.0"
+        "@mbc-cqrs-serverless/core": "^0.1.55-beta.0"
       }
     },
     "packages/tenant": {
       "name": "@mbc-cqrs-serverless/tenant",
-      "version": "0.1.54-beta.0",
+      "version": "0.1.55-beta.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -24427,10 +24427,10 @@
     },
     "packages/ui-setting": {
       "name": "@mbc-cqrs-serverless/ui-setting",
-      "version": "0.1.54-beta.0",
+      "version": "0.1.55-beta.0",
       "license": "MIT",
       "dependencies": {
-        "@mbc-cqrs-serverless/core": "^0.1.54-beta.0"
+        "@mbc-cqrs-serverless/core": "^0.1.55-beta.0"
       }
     }
   }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.55-beta.0](https://github.com/mbc-net/mbc-cqrs-serverless/compare/v0.1.54-beta.0...v0.1.55-beta.0) (2025-02-14)
+
+### Features
+
+- update template to use node 20 runtime ([edeaf00](https://github.com/mbc-net/mbc-cqrs-serverless/commit/edeaf00459db3a9e41b57cae8f8a0cda00540c80))
+
 ## [0.1.54-beta.0](https://github.com/mbc-net/mbc-cqrs-serverless/compare/v0.1.53-beta.0...v0.1.54-beta.0) (2025-02-13)
 
 **Note:** Version bump only for package @mbc-cqrs-serverless/cli

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mbc-cqrs-serverless/cli",
-  "version": "0.1.54-beta.0",
+  "version": "0.1.55-beta.0",
   "description": "a CLI to get started with MBC CQRS serverless framework",
   "keywords": [
     "mbc",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.55-beta.0](https://github.com/mbc-net/mbc-cqrs-serverless/compare/v0.1.54-beta.0...v0.1.55-beta.0) (2025-02-14)
+
+**Note:** Version bump only for package @mbc-cqrs-serverless/core
+
 ## [0.1.54-beta.0](https://github.com/mbc-net/mbc-cqrs-serverless/compare/v0.1.53-beta.0...v0.1.54-beta.0) (2025-02-13)
 
 **Note:** Version bump only for package @mbc-cqrs-serverless/core

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mbc-cqrs-serverless/core",
-  "version": "0.1.54-beta.0",
+  "version": "0.1.55-beta.0",
   "description": "CQRS and event base core",
   "keywords": [
     "mbc",

--- a/packages/master/CHANGELOG.md
+++ b/packages/master/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.55-beta.0](https://github.com/mbc-net/mbc-cqrs-serverless/compare/v0.1.54-beta.0...v0.1.55-beta.0) (2025-02-14)
+
+**Note:** Version bump only for package @mbc-cqrs-serverless/master
+
 ## [0.1.54-beta.0](https://github.com/mbc-net/mbc-cqrs-serverless/compare/v0.1.53-beta.0...v0.1.54-beta.0) (2025-02-13)
 
 **Note:** Version bump only for package @mbc-cqrs-serverless/master

--- a/packages/master/package.json
+++ b/packages/master/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mbc-cqrs-serverless/master",
-  "version": "0.1.54-beta.0",
+  "version": "0.1.55-beta.0",
   "description": " Master data management such as setting, sequence, etc.",
   "keywords": [
     "mbc",

--- a/packages/master/src/services/master-setting.service.ts
+++ b/packages/master/src/services/master-setting.service.ts
@@ -165,7 +165,7 @@ export class MasterSettingService implements IMasterSettingService {
     const pk = generateMasterPk(SettingTypeEnum.TENANT_COMMON)
     const sk = generateMasterSettingSk(code)
     const setting = await this.dataService.getItem({ pk, sk })
-    if (setting) {
+    if (setting && setting.isDeleted === false) {
       throw new BadRequestException(`Setting already exists: ${code}`)
     }
     const command: CommandDto = {
@@ -176,7 +176,7 @@ export class MasterSettingService implements IMasterSettingService {
       id: generateId(pk, sk),
       tenantCode: SettingTypeEnum.TENANT_COMMON,
       type: SettingTypeEnum.TENANT_COMMON,
-      version: VERSION_FIRST,
+      version: setting.version ?? VERSION_FIRST,
       isDeleted: false,
       attributes: settingValue,
     }
@@ -192,7 +192,7 @@ export class MasterSettingService implements IMasterSettingService {
     const sk = generateMasterSettingSk(code)
 
     const setting = await this.dataService.getItem({ pk, sk })
-    if (setting) {
+    if (setting && setting.isDeleted === false) {
       throw new BadRequestException(`Setting already exists: ${code}`)
     }
 
@@ -204,7 +204,7 @@ export class MasterSettingService implements IMasterSettingService {
       id: generateId(pk, sk),
       tenantCode: tenantCode,
       type: SettingTypeEnum.TENANT,
-      version: VERSION_FIRST,
+      version: setting.version ?? VERSION_FIRST,
       isDeleted: false,
       attributes: settingValue,
     }
@@ -222,7 +222,7 @@ export class MasterSettingService implements IMasterSettingService {
     const sk = `${SETTING_SK_PREFIX}${KEY_SEPARATOR}${SettingTypeEnum.TENANT_GROUP}${KEY_SEPARATOR}${groupId}${KEY_SEPARATOR}${code}`
 
     const setting = await this.dataService.getItem({ pk, sk })
-    if (setting) {
+    if (setting && setting.isDeleted === false) {
       throw new BadRequestException(`Setting already exists: ${code}`)
     }
 
@@ -234,7 +234,7 @@ export class MasterSettingService implements IMasterSettingService {
       id: generateId(pk, sk),
       tenantCode: tenantCode,
       type: SettingTypeEnum.TENANT_GROUP,
-      version: VERSION_FIRST,
+      version: setting.version ?? VERSION_FIRST,
       isDeleted: false,
       attributes: settingValue,
     }
@@ -251,7 +251,7 @@ export class MasterSettingService implements IMasterSettingService {
     const sk = `${SETTING_SK_PREFIX}${KEY_SEPARATOR}${SettingTypeEnum.TENANT_USER}${KEY_SEPARATOR}${userId}${KEY_SEPARATOR}${code}`
 
     const setting = await this.dataService.getItem({ pk, sk })
-    if (setting) {
+    if (setting && setting.isDeleted === false) {
       throw new BadRequestException(`Setting already exists: ${code}`)
     }
 
@@ -263,7 +263,7 @@ export class MasterSettingService implements IMasterSettingService {
       id: generateId(pk, sk),
       tenantCode: tenantCode,
       type: SettingTypeEnum.TENANT_USER,
-      version: VERSION_FIRST,
+      version: setting.version ?? VERSION_FIRST,
       isDeleted: false,
       attributes: settingValue,
     }

--- a/packages/sequence/CHANGELOG.md
+++ b/packages/sequence/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.55-beta.0](https://github.com/mbc-net/mbc-cqrs-serverless/compare/v0.1.54-beta.0...v0.1.55-beta.0) (2025-02-14)
+
+**Note:** Version bump only for package @mbc-cqrs-serverless/sequence
+
 ## [0.1.54-beta.0](https://github.com/mbc-net/mbc-cqrs-serverless/compare/v0.1.53-beta.0...v0.1.54-beta.0) (2025-02-13)
 
 **Note:** Version bump only for package @mbc-cqrs-serverless/sequence

--- a/packages/sequence/package.json
+++ b/packages/sequence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mbc-cqrs-serverless/sequence",
-  "version": "0.1.54-beta.0",
+  "version": "0.1.55-beta.0",
   "description": "Generate increment sequence with time-rotation",
   "keywords": [
     "mbc",
@@ -41,6 +41,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@mbc-cqrs-serverless/core": "^0.1.54-beta.0"
+    "@mbc-cqrs-serverless/core": "^0.1.55-beta.0"
   }
 }

--- a/packages/task/CHANGELOG.md
+++ b/packages/task/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.55-beta.0](https://github.com/mbc-net/mbc-cqrs-serverless/compare/v0.1.54-beta.0...v0.1.55-beta.0) (2025-02-14)
+
+**Note:** Version bump only for package @mbc-cqrs-serverless/task
+
 ## [0.1.54-beta.0](https://github.com/mbc-net/mbc-cqrs-serverless/compare/v0.1.53-beta.0...v0.1.54-beta.0) (2025-02-13)
 
 **Note:** Version bump only for package @mbc-cqrs-serverless/task

--- a/packages/task/package.json
+++ b/packages/task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mbc-cqrs-serverless/task",
-  "version": "0.1.54-beta.0",
+  "version": "0.1.55-beta.0",
   "description": "long-running task",
   "keywords": [
     "mbc",
@@ -41,6 +41,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@mbc-cqrs-serverless/core": "^0.1.54-beta.0"
+    "@mbc-cqrs-serverless/core": "^0.1.55-beta.0"
   }
 }

--- a/packages/tenant/CHANGELOG.md
+++ b/packages/tenant/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.55-beta.0](https://github.com/mbc-net/mbc-cqrs-serverless/compare/v0.1.54-beta.0...v0.1.55-beta.0) (2025-02-14)
+
+**Note:** Version bump only for package @mbc-cqrs-serverless/tenant
+
 ## [0.1.54-beta.0](https://github.com/mbc-net/mbc-cqrs-serverless/compare/v0.1.53-beta.0...v0.1.54-beta.0) (2025-02-13)
 
 **Note:** Version bump only for package @mbc-cqrs-serverless/tenant

--- a/packages/tenant/package.json
+++ b/packages/tenant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mbc-cqrs-serverless/tenant",
-  "version": "0.1.54-beta.0",
+  "version": "0.1.55-beta.0",
   "description": "Multiple tenant management",
   "keywords": [
     "mbc",

--- a/packages/ui-setting/CHANGELOG.md
+++ b/packages/ui-setting/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.55-beta.0](https://github.com/mbc-net/mbc-cqrs-serverless/compare/v0.1.54-beta.0...v0.1.55-beta.0) (2025-02-14)
+
+**Note:** Version bump only for package @mbc-cqrs-serverless/ui-setting
+
 ## [0.1.54-beta.0](https://github.com/mbc-net/mbc-cqrs-serverless/compare/v0.1.53-beta.0...v0.1.54-beta.0) (2025-02-13)
 
 **Note:** Version bump only for package @mbc-cqrs-serverless/ui-setting

--- a/packages/ui-setting/package.json
+++ b/packages/ui-setting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mbc-cqrs-serverless/ui-setting",
-  "version": "0.1.54-beta.0",
+  "version": "0.1.55-beta.0",
   "description": "Setting master data",
   "keywords": [
     "mbc",
@@ -41,6 +41,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@mbc-cqrs-serverless/core": "^0.1.54-beta.0"
+    "@mbc-cqrs-serverless/core": "^0.1.55-beta.0"
   }
 }


### PR DESCRIPTION
## Description:
This PR fixes an issue where deleted settings could not be recreated. Now, users can create a new setting even if a previous one with the same identifier was deleted.