### PR TITLE
fix: improve CI/CD tag comparison logic for proper version detection

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -98,7 +98,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: develop # Checkout develop branch instead of tag
+          # Remove ref to checkout the tag itself, not develop branch
       - uses: actions/setup-node@v4
         with:
           node-version: 18
@@ -153,22 +153,41 @@ jobs:
         if: steps.release-type.outputs.prerelease == 'true'
         id: beta-diff-base
         run: |
-          # For beta: compare against last beta/alpha tag OR develop branch
-          LAST_BETA=$(git tag -l "v*-beta*" "v*-alpha*" | sort -V | tail -1)
-          if [ -z "$LAST_BETA" ]; then
-            echo "diff_base=develop" >> $GITHUB_OUTPUT
-            echo "No previous beta/alpha tag found, using develop branch"
+          CURRENT_TAG=${{ github.ref_name }}
+          RELEASE_TYPE=${{ steps.release-type.outputs.tag }}
+
+          # Determine which tags to search based on release type
+          if [ "$RELEASE_TYPE" = "beta" ]; then
+            # For beta: compare with previous beta tag only
+            PREVIOUS_TAG=$(git tag -l "v*-beta*" | grep -v "^${CURRENT_TAG}$" | sort -V | tail -1)
+            TAG_TYPE="beta"
+          elif [ "$RELEASE_TYPE" = "alpha" ]; then
+            # For alpha: compare with previous alpha tag only
+            PREVIOUS_TAG=$(git tag -l "v*-alpha*" | grep -v "^${CURRENT_TAG}$" | sort -V | tail -1)
+            TAG_TYPE="alpha"
+          fi
+
+          if [ -z "$PREVIOUS_TAG" ]; then
+            # No previous tag of same type found, use appropriate base branch
+            if [ "$RELEASE_TYPE" = "beta" ]; then
+              echo "diff_base=develop" >> $GITHUB_OUTPUT
+              echo "No previous beta tag found, using develop branch"
+            elif [ "$RELEASE_TYPE" = "alpha" ]; then
+              echo "diff_base=develop" >> $GITHUB_OUTPUT
+              echo "No previous alpha tag found, using develop branch"
+            fi
           else
-            echo "diff_base=$LAST_BETA" >> $GITHUB_OUTPUT
-            echo "Using last beta/alpha tag: $LAST_BETA"
+            echo "diff_base=$PREVIOUS_TAG" >> $GITHUB_OUTPUT
+            echo "Using previous $TAG_TYPE tag: $PREVIOUS_TAG"
           fi
 
       - name: Determine diff base for production
         if: steps.release-type.outputs.prerelease == 'false'
         id: prod-diff-base
         run: |
-          # For production: compare against last production tag OR main branch
-          LAST_PROD=$(git tag -l "v*.*.*" | grep -v -E "(alpha|beta|rc)" | sort -V | tail -1)
+          CURRENT_TAG=${{ github.ref_name }}
+          # For production: compare against last production tag (excluding pre-releases and current tag)
+          LAST_PROD=$(git tag -l "v*.*.*" | grep -v -E "(alpha|beta|rc)" | grep -v "^${CURRENT_TAG}$" | sort -V | tail -1)
           if [ -z "$LAST_PROD" ]; then
             echo "diff_base=main" >> $GITHUB_OUTPUT
             echo "No previous production tag found, using main branch"


### PR DESCRIPTION
- Remove 'ref: develop' to checkout the actual tag instead of develop branch
- Separate comparison logic for alpha, beta, and production releases
- Beta versions now compare only with previous beta tags
- Alpha versions now compare only with previous alpha tags
- Exclude current tag from comparison to avoid self-comparison
- Fix the issue where 8 packages were incorrectly detected as changed

This ensures that only actually modified packages are published to npm when creating release tags.

🤖 Generated with [Claude Code](https://claude.ai/code)