### PR TITLE
fix: commit version changes before lerna publish to avoid uncommitted…

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -236,6 +236,10 @@ jobs:
           DIFF_BASE="${{ steps.beta-diff-base.outputs.diff_base }}"
           npx lerna version ${{ steps.version.outputs.version }} --yes --no-git-tag-version --no-push --exact --force-publish --amend
 
+          # Commit the version changes to avoid uncommitted changes error
+          git add -A
+          git commit -m "chore: version packages for release" || echo "No changes to commit"
+
           # Then publish the versioned packages
           npx lerna publish from-package --yes --dist-tag ${{ steps.release-type.outputs.tag }} --no-git-tag-version --no-push
         env:
@@ -250,6 +254,10 @@ jobs:
           # First update versions in changed packages
           DIFF_BASE="${{ steps.prod-diff-base.outputs.diff_base }}"
           npx lerna version ${{ steps.version.outputs.version }} --yes --no-git-tag-version --no-push --exact --force-publish --amend
+
+          # Commit the version changes to avoid uncommitted changes error
+          git add -A
+          git commit -m "chore: version packages for release" || echo "No changes to commit"
 
           # Then publish the versioned packages
           npx lerna publish from-package --yes --no-git-tag-version --no-push


### PR DESCRIPTION
… changes error

- Add git commit step after lerna version and before lerna publish
- lerna publish from-package requires clean working tree
- Temporary commit on CI branch doesn't affect remote repository

This fixes "EUNCOMMIT Working tree has uncommitted changes" error when running lerna publish from-package after version update.

🤖 Generated with [Claude Code](https://claude.ai/code)