### PR TITLE
feat(master): Add Bulk Creation Endpoints for Master Data and Settings

### DIFF
--- a/packages/master/src/controllers/master-data.controller.ts
+++ b/packages/master/src/controllers/master-data.controller.ts
@@ -25,6 +25,7 @@ import {
   MasterDataCreateDto,
   MasterDataUpdateDto,
 } from '../dto'
+import { MasterDataCreateBulkDto } from '../dto/master-copy/master-data-create-bulk.dto'
 import { CreateMasterDataDto } from '../dto/master-data/data-create.dto'
 import { MasterDataSearchDto } from '../dto/master-data/data-search.dto'
 import { UpdateDataSettingDto } from '../dto/master-data/data-update.dto'
@@ -111,6 +112,14 @@ export class MasterDataController {
     @INVOKE_CONTEXT() invokeContext: IInvoke,
   ) {
     return this.masterDataService.createSetting(createDto, invokeContext)
+  }
+
+  @Post('/bulk')
+  async createBulk(
+    @Body() createDto: MasterDataCreateBulkDto,
+    @INVOKE_CONTEXT() invokeContext: IInvoke,
+  ) {
+    return this.masterDataService.createBulk(createDto, invokeContext)
   }
 
   @Put('/:id')

--- a/packages/master/src/controllers/master-setting.controller.ts
+++ b/packages/master/src/controllers/master-setting.controller.ts
@@ -32,6 +32,7 @@ import { UpdateSettingDto } from '../dto/master-setting/update.setting.dto'
 import { UserSettingDto } from '../dto/master-setting/user-setting-create.dto'
 import { parsePk } from '../helpers'
 import { MasterSettingService } from '../services/master-setting.service'
+import { CommonSettingBulkDto } from '../dto/master-setting/common-setting-create-bulk.dto'
 
 @Controller('api/master-setting')
 @ApiTags('master-settings')
@@ -122,6 +123,14 @@ export class MasterSettingController {
     @INVOKE_CONTEXT() invokeContext: IInvoke,
   ) {
     return this.masterSettingService.create(createDto, invokeContext)
+  }
+
+  @Post('/bulk')
+  async createBulk(
+    @Body() createDto: CommonSettingBulkDto,
+    @INVOKE_CONTEXT() invokeContext: IInvoke,
+  ) {
+    return this.masterSettingService.createBulk(createDto, invokeContext)
   }
 
   @Put('/:id')

--- a/packages/master/src/dto/master-copy/master-data-create-bulk.dto.ts
+++ b/packages/master/src/dto/master-copy/master-data-create-bulk.dto.ts
@@ -1,0 +1,12 @@
+import { Type } from 'class-transformer'
+import { ArrayNotEmpty, IsArray, ValidateNested } from 'class-validator'
+
+import { MasterDataCreateDto } from './master-data-create.dto'
+
+export class MasterDataCreateBulkDto {
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => MasterDataCreateDto)
+  @ArrayNotEmpty()
+  items: MasterDataCreateDto[]
+}

--- a/packages/master/src/dto/master-setting/common-setting-create-bulk.dto.ts
+++ b/packages/master/src/dto/master-setting/common-setting-create-bulk.dto.ts
@@ -1,0 +1,12 @@
+import { Type } from 'class-transformer'
+import { ArrayNotEmpty, IsArray, ValidateNested } from 'class-validator'
+
+import { CommonSettingDto } from './common-setting-create.dto'
+
+export class CommonSettingBulkDto {
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CommonSettingDto)
+  @ArrayNotEmpty()
+  items: CommonSettingDto[]
+}

--- a/packages/master/src/services/master-data.service.ts
+++ b/packages/master/src/services/master-data.service.ts
@@ -33,6 +33,7 @@ import {
   MasterRdsListEntity,
   UpdateDataSettingDto,
 } from '../dto'
+import { MasterDataCreateBulkDto } from '../dto/master-copy/master-data-create-bulk.dto'
 import { MasterDataEntity, MasterDataListEntity } from '../entities'
 import { generateMasterDataSk, generateMasterPk } from '../helpers'
 import { getOrderBys } from '../helpers/rds'
@@ -311,6 +312,12 @@ export class MasterDataService implements IMasterDataService {
         seq,
       },
       { invokeContext },
+    )
+  }
+
+  async createBulk(createDto: MasterDataCreateBulkDto, invokeContext: IInvoke) {
+    return Promise.all(
+      createDto.items.map((item) => this.createSetting(item, invokeContext)),
     )
   }
 

--- a/packages/master/src/services/master-setting.service.ts
+++ b/packages/master/src/services/master-setting.service.ts
@@ -45,6 +45,7 @@ import {
   UpdateSettingDto,
   UserSettingDto,
 } from '../dto'
+import { CommonSettingBulkDto } from '../dto/master-setting/common-setting-create-bulk.dto'
 import { MasterSettingEntity } from '../entities'
 import { SettingTypeEnum } from '../enums'
 import { generateMasterPk, generateMasterSettingSk, parseId } from '../helpers'
@@ -370,6 +371,12 @@ export class MasterSettingService implements IMasterSettingService {
     )
   }
 
+  async createBulk(createDto: CommonSettingBulkDto, invokeContext: IInvoke) {
+    return Promise.all(
+      createDto.items.map((item) => this.create(item, invokeContext)),
+    )
+  }
+
   async update(
     key: DetailDto,
     updateDto: MasterSettingUpdateDto,
@@ -426,7 +433,7 @@ export class MasterSettingService implements IMasterSettingService {
 
     if (searchDto.name?.trim()) {
       andConditions.push({
-        name: { contains: searchDto.name.trim(), mode: 'insensitive' }
+        name: { contains: searchDto.name.trim(), mode: 'insensitive' },
       })
     }
 

--- a/packages/survey-template/src/survey-template.module.ts
+++ b/packages/survey-template/src/survey-template.module.ts
@@ -61,7 +61,6 @@ export class SurveyTemplateModule extends ConfigurableModuleClass {
         provide: PRISMA_SERVICE,
         useExisting: options.prismaService,
       })
-      module.providers.push(SurveyTemplateDataSyncRdsHandler)
       if (!module.imports) {
         module.imports = []
       }
@@ -70,7 +69,9 @@ export class SurveyTemplateModule extends ConfigurableModuleClass {
       imports.push(
         CommandModule.register({
           tableName: 'survey',
-          dataSyncHandlers: options?.dataSyncHandlers,
+          dataSyncHandlers: options?.dataSyncHandlers ?? [
+            SurveyTemplateDataSyncRdsHandler,
+          ],
         }),
       )
       return {


### PR DESCRIPTION
## Summary

This MR introduces bulk creation functionality for master data and settings, allowing users to create multiple records in a single API call. This improves performance and user experience when dealing with large datasets.

## Bulk Creation Endpoints

- **Master Data Controller**: Added `POST /api/master-data/bulk` endpoint
- **Master Setting Controller**: Added `POST /api/master-setting/bulk` endpoint