### PR TITLE
feat(mcp-server): update for v1.1.x, refactor shared utilities, and fix JSON safety

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -33,8 +33,30 @@ Generate code and analyze projects:
 | `mbc_generate_entity` | Generate an entity |
 | `mbc_generate_dto` | Generate a DTO |
 | `mbc_validate_cqrs` | Validate CQRS pattern implementation |
-| `mbc_analyze_project` | Analyze project structure |
-| `mbc_lookup_error` | Look up error solutions |
+| `mbc_analyze_project` | Analyze project structure and detect framework usage |
+| `mbc_lookup_error` | Look up error solutions from the error catalog |
+| `mbc_check_anti_patterns` | Detect anti-patterns (AP001–AP012) in project source files |
+| `mbc_health_check` | Health check for dependencies, structure, and configuration |
+| `mbc_explain_code` | Explain a file or code section in the MBC CQRS context |
+
+#### Anti-Pattern Detection (`mbc_check_anti_patterns`)
+
+Detects 12 anti-patterns including v1.1.x breaking changes:
+
+| Code | Name | Severity |
+|------|------|----------|
+| AP001 | Direct DynamoDB Write | Critical |
+| AP002 | Ignored Version Mismatch | High |
+| AP003 | N+1 Query Pattern | High |
+| AP004 | Full Table Scan | High |
+| AP005 | Hardcoded Tenant | Critical |
+| AP006 | Missing Tenant Validation | Critical |
+| AP007 | Throwing in Sync Handler | High |
+| AP008 | Hardcoded Secret | Critical |
+| AP009 | Manual JWT Parsing | Critical |
+| AP010 | Heavy Module Import | Medium |
+| AP011 | Deprecated Method Usage (`publish`, `publishPartialUpdate` removed in v1.1.0) | High |
+| AP012 | Uppercase COMMON Tenant Key (`#COMMON` → `#common` in v1.1.0) | Critical |
 
 ### Prompts
 
@@ -42,9 +64,17 @@ Get guided assistance:
 
 | Prompt | Description |
 |--------|-------------|
-| `cqrs_implementation_guide` | Step-by-step CQRS implementation |
+| `cqrs_implementation_guide` | Step-by-step CQRS implementation (module, entity, command, query, event) |
 | `debug_command_error` | Debug command-related errors |
-| `migration_guide` | Version migration guidance |
+| `migration_guide` | Version migration guidance including v1.1.x breaking changes |
+
+#### `migration_guide` coverage
+
+| Version | Changes |
+|---------|---------|
+| v1.1.0 | `TENANT_COMMON` renamed to lowercase `'common'`; `publish()` / `publishPartialUpdate()` removed |
+| v1.1.4 | `publishSync` now writes full audit trail to Command + History tables |
+| v1.1.5 | CSV import batch architecture — `finalize_parent_job` state required in Step Functions |
 
 ## Installation
 
@@ -98,7 +128,8 @@ Add to Cursor's MCP settings:
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `MBC_PROJECT_PATH` | Path to the project directory | Current working directory |
+| `MBC_PROJECT_PATH` | Path to the user's project directory | Current working directory |
+| `MBC_FRAMEWORK_ROOT` | Path to the framework root (for installed packages). Set automatically by the CLI; override only if the default monorepo layout does not apply. | Auto-resolved from package location |
 
 ## Usage Examples
 
@@ -123,6 +154,12 @@ Claude Code will use the `mbc_analyze_project` tool to provide insights.
 ```
 
 Claude Code will use the `debug_command_error` prompt and `mbc_lookup_error` tool.
+
+```
+"Check my project for anti-patterns"
+```
+
+Claude Code will use the `mbc_check_anti_patterns` tool to report issues.
 
 ### Resource Access
 
@@ -185,7 +222,7 @@ Review the code in src/order/order.service.ts
 
 ```
 /mbc-migrate
-I need to upgrade from v1.0.20 to v1.0.23
+I need to upgrade from v1.0.x to v1.1.x
 ```
 
 ```

--- a/packages/mcp-server/src/prompts/cqrs-guide.ts
+++ b/packages/mcp-server/src/prompts/cqrs-guide.ts
@@ -194,16 +194,18 @@ export class ${featureName}Service {
 
   // Create (Async - returns immediately, processes in background)
   async createAsync(dto: Create${featureName}Dto, options: IInvoke) {
+    const { tenantCode } = getUserContext(options)
     const entity = new ${featureName}CommandEntity()
-    entity.pk = \`${featureName.toUpperCase()}#\${options.tenantCode}\`
+    entity.pk = \`${featureName.toUpperCase()}#\${tenantCode}\`
     entity.sk = \`${featureName.toUpperCase()}#\${ulid()}\`
     // ... set other fields
 
     return this.commandService.publishAsync(entity, options)
   }
 
-  // Create (Sync - waits for completion)
+  // Create (Sync - waits for completion, writes full audit trail since v1.1.4)
   async createSync(dto: Create${featureName}Dto, options: IInvoke) {
+    const { tenantCode } = getUserContext(options)
     const entity = new ${featureName}CommandEntity()
     // ... same setup
 
@@ -415,9 +417,9 @@ await commandService.publishPartialUpdateAsync({
   name: 'Updated',
 }, options)
 
-// Or fetch and use latest (sync mode)
+// Or fetch and use latest version before updating
 const latest = await dataService.getItem({ pk, sk })
-await commandService.publishPartialUpdateSync({
+await commandService.publishPartialUpdateAsync({
   pk, sk,
   version: latest.version,
   name: 'Updated',
@@ -462,6 +464,57 @@ function getMigrationGuideMessages(
 3. **Update imports** if API has changed
 
 4. **Run tests** to verify everything works
+
+## v1.1.x Migration Notes
+
+### v1.1.0 — Breaking Changes (data migration required)
+
+**1. TENANT_COMMON renamed to lowercase**
+\`\`\`typescript
+// Before (v1.0.x)
+const pk = \`MASTER_SETTING#COMMON#\${settingCode}\`
+
+// After (v1.1.0+)
+const pk = \`MASTER_SETTING#common#\${settingCode}\`
+\`\`\`
+- All DynamoDB keys using \`#COMMON\` must be migrated to \`#common\`
+- New utilities: \`normalizeTenantCode()\`, \`isCommonTenant()\`
+
+**2. Deprecated methods removed**
+\`\`\`typescript
+// Removed — compilation error in v1.1.0+
+this.commandService.publish(...)
+this.commandService.publishPartialUpdate(...)
+
+// Use instead
+this.commandService.publishAsync(...)
+this.commandService.publishPartialUpdateAsync(...)
+\`\`\`
+
+### v1.1.4 — publishSync audit trail
+
+\`publishSync\` now writes a full audit trail to Command and History tables (parity with async pipeline):
+- Command table entry: \`syncMode: 'SYNC'\`, status \`publish_sync:STARTED\` → \`finish:FINISHED\`
+- History table is auto-populated
+- No code changes required; behavior is transparent
+
+### v1.1.5 — CSV Import v2 batch architecture
+
+Step Functions state machine changes required:
+\`\`\`json
+{
+  "finalize_parent_job": {
+    "Type": "Task",
+    "Parameters": {
+      "resultPath": "$.processingResults"
+    }
+  }
+}
+\`\`\`
+- \`finalize_parent_job\` state is now **required**
+- Row-level progress tracking via \`import_tmp\` table is removed
+- Counters (\`processedRows\`, \`succeededRows\`, \`failedRows\`) are aggregated at completion
+- Update both CDK and \`serverless.yml\` Step Functions definitions
 
 ## Common Migration Issues
 

--- a/packages/mcp-server/src/prompts/index.ts
+++ b/packages/mcp-server/src/prompts/index.ts
@@ -2,11 +2,14 @@ import { Prompt, PromptMessage } from '@modelcontextprotocol/sdk/types.js'
 
 import { getCqrsPromptMessages, getCqrsPrompts } from './cqrs-guide.js'
 
+const ALL_PROMPTS: Prompt[] = [...getCqrsPrompts()]
+const PROMPT_NAMES = new Set(ALL_PROMPTS.map((p) => p.name))
+
 /**
  * Register all available prompts.
  */
 export function registerPrompts(): Prompt[] {
-  return [...getCqrsPrompts()]
+  return ALL_PROMPTS
 }
 
 /**
@@ -18,13 +21,7 @@ export function handlePromptGet(
 ): { messages: PromptMessage[] } {
   const safeArgs = args || {}
 
-  // CQRS prompts
-  const cqrsPromptNames = [
-    'cqrs_implementation_guide',
-    'debug_command_error',
-    'migration_guide',
-  ]
-  if (cqrsPromptNames.includes(name)) {
+  if (PROMPT_NAMES.has(name)) {
     return getCqrsPromptMessages(name, safeArgs)
   }
 

--- a/packages/mcp-server/src/resources/documentation.ts
+++ b/packages/mcp-server/src/resources/documentation.ts
@@ -1,6 +1,7 @@
 import { Resource } from '@modelcontextprotocol/sdk/types.js'
-import * as fs from 'fs'
 import * as path from 'path'
+
+import { readFileSafe } from '../utils/fs.js'
 
 /**
  * Documentation resources for MBC CQRS Serverless framework.
@@ -50,41 +51,52 @@ export function getDocumentationResources(): Resource[] {
   ]
 }
 
+/**
+ * Resolve the framework root directory.
+ * Uses MBC_FRAMEWORK_ROOT env var when set (e.g. in production installs),
+ * otherwise falls back to two directories above this package (monorepo layout).
+ */
+function getFrameworkRoot(): string {
+  if (process.env.MBC_FRAMEWORK_ROOT) {
+    return process.env.MBC_FRAMEWORK_ROOT
+  }
+  // dist/resources/ → dist/ → packages/mcp-server/ → packages/ → monorepo root
+  return path.resolve(__dirname, '..', '..', '..', '..')
+}
+
 export async function readDocumentation(
   uri: string,
 ): Promise<{ contents: { uri: string; mimeType: string; text: string }[] }> {
-  const frameworkRoot = path.resolve(__dirname, '../../../../..')
+  const frameworkRoot = getFrameworkRoot()
 
   let content: string
   let mimeType = 'text/plain'
 
   switch (uri) {
     case 'mbc://docs/overview':
-      content = await readFileContent(path.join(frameworkRoot, 'llms-full.txt'))
+      content = readFileSafe(path.join(frameworkRoot, 'llms-full.txt'))
       break
     case 'mbc://docs/llms-short':
-      content = await readFileContent(path.join(frameworkRoot, 'llms.txt'))
+      content = readFileSafe(path.join(frameworkRoot, 'llms.txt'))
       break
     case 'mbc://docs/architecture':
-      content = await readFileContent(
+      content = readFileSafe(
         path.join(frameworkRoot, 'docs', 'ARCHITECTURE.md'),
       )
       mimeType = 'text/markdown'
       break
     case 'mbc://docs/faq':
-      content = await readFileContent(
-        path.join(frameworkRoot, 'docs', 'FAQ.md'),
-      )
+      content = readFileSafe(path.join(frameworkRoot, 'docs', 'FAQ.md'))
       mimeType = 'text/markdown'
       break
     case 'mbc://docs/troubleshooting':
-      content = await readFileContent(
+      content = readFileSafe(
         path.join(frameworkRoot, 'docs', 'TROUBLESHOOTING.md'),
       )
       mimeType = 'text/markdown'
       break
     case 'mbc://docs/security':
-      content = await readFileContent(path.join(frameworkRoot, 'SECURITY.md'))
+      content = readFileSafe(path.join(frameworkRoot, 'SECURITY.md'))
       mimeType = 'text/markdown'
       break
     default:
@@ -92,20 +104,6 @@ export async function readDocumentation(
   }
 
   return {
-    contents: [
-      {
-        uri,
-        mimeType,
-        text: content,
-      },
-    ],
-  }
-}
-
-async function readFileContent(filePath: string): Promise<string> {
-  try {
-    return fs.readFileSync(filePath, 'utf-8')
-  } catch (error) {
-    return `Error reading file: ${filePath}. File may not exist.`
+    contents: [{ uri, mimeType, text: content }],
   }
 }

--- a/packages/mcp-server/src/resources/errors.ts
+++ b/packages/mcp-server/src/resources/errors.ts
@@ -1,6 +1,7 @@
 import { Resource } from '@modelcontextprotocol/sdk/types.js'
-import * as fs from 'fs'
 import * as path from 'path'
+
+import { readFileSafe } from '../utils/fs.js'
 
 /**
  * Error catalog resources for MBC CQRS Serverless framework.
@@ -20,33 +21,17 @@ export function getErrorResources(): Resource[] {
 
 export async function readErrorCatalog(
   uri: string,
+  projectPath: string,
 ): Promise<{ contents: { uri: string; mimeType: string; text: string }[] }> {
-  // Use MBC_PROJECT_PATH environment variable or current working directory
-  // プロジェクトパスは環境変数MBC_PROJECT_PATHまたはカレントディレクトリを使用
-  const projectRoot = process.env.MBC_PROJECT_PATH || process.cwd()
-
   if (uri !== 'mbc://docs/errors') {
     throw new Error(`Unknown error resource: ${uri}`)
   }
 
-  let content: string
-  try {
-    content = fs.readFileSync(
-      path.join(projectRoot, 'docs', 'ERROR_CATALOG.md'),
-      'utf-8',
-    )
-  } catch (error) {
-    content =
-      'Error catalog not found. Please ensure docs/ERROR_CATALOG.md exists in your project.'
-  }
+  const content = readFileSafe(
+    path.join(projectPath, 'docs', 'ERROR_CATALOG.md'),
+  )
 
   return {
-    contents: [
-      {
-        uri,
-        mimeType: 'text/markdown',
-        text: content,
-      },
-    ],
+    contents: [{ uri, mimeType: 'text/markdown', text: content }],
   }
 }

--- a/packages/mcp-server/src/resources/index.ts
+++ b/packages/mcp-server/src/resources/index.ts
@@ -26,7 +26,7 @@ export async function handleResourceRead(
   projectPath: string,
 ): Promise<{ contents: { uri: string; mimeType: string; text: string }[] }> {
   if (uri.startsWith('mbc://docs/errors')) {
-    return readErrorCatalog(uri)
+    return readErrorCatalog(uri, projectPath)
   }
 
   if (uri.startsWith('mbc://docs/')) {

--- a/packages/mcp-server/src/resources/project.ts
+++ b/packages/mcp-server/src/resources/project.ts
@@ -2,6 +2,8 @@ import { Resource } from '@modelcontextprotocol/sdk/types.js'
 import * as fs from 'fs'
 import * as path from 'path'
 
+import { findFiles, readFileSafe } from '../utils/fs.js'
+
 /**
  * Project-specific resources for analyzing user's MBC CQRS projects.
  */
@@ -72,79 +74,29 @@ export async function readProjectResource(
 async function findEntities(
   projectPath: string,
 ): Promise<{ name: string; path: string }[]> {
-  const entities: { name: string; path: string }[] = []
   const srcPath = path.join(projectPath, 'src')
+  const files = await findFiles(srcPath, '.entity.ts')
 
-  if (!fs.existsSync(srcPath)) {
-    return entities
-  }
-
-  await findFilesRecursive(srcPath, (filePath) => {
-    if (filePath.endsWith('.entity.ts')) {
-      const relativePath = path.relative(projectPath, filePath)
-      const content = fs.readFileSync(filePath, 'utf-8')
-      const classMatch = content.match(/export\s+class\s+(\w+)/)
-      if (classMatch) {
-        entities.push({
-          name: classMatch[1],
-          path: relativePath,
-        })
-      }
-    }
+  return files.flatMap((filePath) => {
+    const content = readFileSafe(filePath)
+    const classMatch = content.match(/export\s+class\s+(\w+)/)
+    if (!classMatch) return []
+    return [{ name: classMatch[1], path: path.relative(projectPath, filePath) }]
   })
-
-  return entities
 }
 
 async function findModules(
   projectPath: string,
 ): Promise<{ name: string; path: string }[]> {
-  const modules: { name: string; path: string }[] = []
   const srcPath = path.join(projectPath, 'src')
+  const files = await findFiles(srcPath, '.module.ts')
 
-  if (!fs.existsSync(srcPath)) {
-    return modules
-  }
-
-  await findFilesRecursive(srcPath, (filePath) => {
-    if (filePath.endsWith('.module.ts')) {
-      const relativePath = path.relative(projectPath, filePath)
-      const content = fs.readFileSync(filePath, 'utf-8')
-      const classMatch = content.match(/export\s+class\s+(\w+Module)/)
-      if (classMatch) {
-        modules.push({
-          name: classMatch[1],
-          path: relativePath,
-        })
-      }
-    }
+  return files.flatMap((filePath) => {
+    const content = readFileSafe(filePath)
+    const classMatch = content.match(/export\s+class\s+(\w+Module)/)
+    if (!classMatch) return []
+    return [{ name: classMatch[1], path: path.relative(projectPath, filePath) }]
   })
-
-  return modules
-}
-
-async function findFilesRecursive(
-  dir: string,
-  callback: (filePath: string) => void,
-): Promise<void> {
-  if (!fs.existsSync(dir)) {
-    return
-  }
-
-  const entries = fs.readdirSync(dir, { withFileTypes: true })
-
-  for (const entry of entries) {
-    const fullPath = path.join(dir, entry.name)
-    if (
-      entry.isDirectory() &&
-      entry.name !== 'node_modules' &&
-      entry.name !== 'dist'
-    ) {
-      await findFilesRecursive(fullPath, callback)
-    } else if (entry.isFile()) {
-      callback(fullPath)
-    }
-  }
 }
 
 async function getProjectStructure(projectPath: string): Promise<string> {

--- a/packages/mcp-server/src/tools/analyze.ts
+++ b/packages/mcp-server/src/tools/analyze.ts
@@ -217,7 +217,16 @@ async function analyzeProject(projectPath: string): Promise<AnalysisResult> {
   // Check package.json
   const packageJsonPath = path.join(projectPath, 'package.json')
   if (fs.existsSync(packageJsonPath)) {
-    const packageJson = JSON.parse(readFileSafe(packageJsonPath))
+    let packageJson: {
+      name?: string
+      dependencies?: Record<string, string>
+      devDependencies?: Record<string, string>
+    }
+    try {
+      packageJson = JSON.parse(readFileSafe(packageJsonPath))
+    } catch {
+      packageJson = {}
+    }
     result.projectName = packageJson.name || result.projectName
     const deps = { ...packageJson.dependencies, ...packageJson.devDependencies }
 
@@ -539,7 +548,7 @@ const ANTI_PATTERNS = [
     code: 'AP011',
     name: 'Deprecated Method Usage',
     severity: 'high' as const,
-    // Match .publish( and .publishPartialUpdate( but not .publishAsync( or .publishPartialUpdateAsync(
+    // Match .publish( and .publishPartialUpdate( but not the Async/Sync variants
     pattern:
       /\.publish(?!Async|Sync|PartialUpdateAsync|PartialUpdateSync)\s*\(|\.publishPartialUpdate(?!Async|Sync)\s*\(/,
     recommendation:

--- a/packages/mcp-server/src/tools/analyze.ts
+++ b/packages/mcp-server/src/tools/analyze.ts
@@ -3,6 +3,8 @@ import * as fs from 'fs'
 import * as path from 'path'
 import { z } from 'zod'
 
+import { findFiles, readFileSafe } from '../utils/fs.js'
+
 /**
  * Analysis result interface.
  */
@@ -215,7 +217,7 @@ async function analyzeProject(projectPath: string): Promise<AnalysisResult> {
   // Check package.json
   const packageJsonPath = path.join(projectPath, 'package.json')
   if (fs.existsSync(packageJsonPath)) {
-    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
+    const packageJson = JSON.parse(readFileSafe(packageJsonPath))
     result.projectName = packageJson.name || result.projectName
     const deps = { ...packageJson.dependencies, ...packageJson.devDependencies }
 
@@ -238,7 +240,7 @@ async function analyzeProject(projectPath: string): Promise<AnalysisResult> {
   // Analyze modules
   const moduleFiles = await findFiles(srcPath, '.module.ts')
   for (const file of moduleFiles) {
-    const content = fs.readFileSync(file, 'utf-8')
+    const content = readFileSafe(file)
     const classMatch = content.match(/export\s+class\s+(\w+Module)/)
     if (classMatch) {
       const imports: string[] = []
@@ -261,7 +263,7 @@ async function analyzeProject(projectPath: string): Promise<AnalysisResult> {
   // Analyze entities
   const entityFiles = await findFiles(srcPath, '.entity.ts')
   for (const file of entityFiles) {
-    const content = fs.readFileSync(file, 'utf-8')
+    const content = readFileSafe(file)
     const classMatch = content.match(/export\s+class\s+(\w+)/)
     if (classMatch) {
       const type: 'command' | 'data' | 'unknown' = content.includes(
@@ -308,7 +310,7 @@ async function analyzeProject(projectPath: string): Promise<AnalysisResult> {
   // Analyze CQRS patterns
   const allTsFiles = await findFiles(srcPath, '.ts')
   for (const file of allTsFiles) {
-    const content = fs.readFileSync(file, 'utf-8')
+    const content = readFileSafe(file)
     if (content.includes('@CommandHandler'))
       result.cqrsPatterns.commandHandlers++
     if (content.includes('@QueryHandler')) result.cqrsPatterns.queryHandlers++
@@ -317,30 +319,6 @@ async function analyzeProject(projectPath: string): Promise<AnalysisResult> {
   }
 
   return result
-}
-
-async function findFiles(dir: string, suffix: string): Promise<string[]> {
-  const files: string[] = []
-
-  if (!fs.existsSync(dir)) {
-    return files
-  }
-
-  const entries = fs.readdirSync(dir, { withFileTypes: true })
-  for (const entry of entries) {
-    const fullPath = path.join(dir, entry.name)
-    if (
-      entry.isDirectory() &&
-      entry.name !== 'node_modules' &&
-      entry.name !== 'dist'
-    ) {
-      files.push(...(await findFiles(fullPath, suffix)))
-    } else if (entry.isFile() && entry.name.endsWith(suffix)) {
-      files.push(fullPath)
-    }
-  }
-
-  return files
 }
 
 async function lookupError(
@@ -358,7 +336,7 @@ async function lookupError(
     }
   }
 
-  const catalog = fs.readFileSync(errorCatalogPath, 'utf-8')
+  const catalog = readFileSafe(errorCatalogPath)
   const lowerError = errorMessage.toLowerCase()
 
   // Find matching sections
@@ -514,7 +492,7 @@ const ANTI_PATTERNS = [
     severity: 'critical' as const,
     pattern: /['"`]TENANT#\w+['"`]/,
     recommendation:
-      'Use getUserContext(context).tenantCode to get tenant dynamically.',
+      'Use getUserContext(invokeContext).tenantCode to get the tenant code from the authenticated context.',
   },
   {
     code: 'AP006',
@@ -557,6 +535,25 @@ const ANTI_PATTERNS = [
       /^import\s+\*\s+as\s+\w+\s+from\s+['"`](?:aws-sdk|lodash|moment)['"`]/m,
     recommendation: 'Import only what you need to reduce cold start time.',
   },
+  {
+    code: 'AP011',
+    name: 'Deprecated Method Usage',
+    severity: 'high' as const,
+    // Match .publish( and .publishPartialUpdate( but not .publishAsync( or .publishPartialUpdateAsync(
+    pattern:
+      /\.publish(?!Async|Sync|PartialUpdateAsync|PartialUpdateSync)\s*\(|\.publishPartialUpdate(?!Async|Sync)\s*\(/,
+    recommendation:
+      'publish() and publishPartialUpdate() were removed in v1.1.0. Use publishAsync() or publishPartialUpdateAsync() instead.',
+  },
+  {
+    code: 'AP012',
+    name: 'Uppercase COMMON Tenant Key',
+    severity: 'critical' as const,
+    // Detect hardcoded uppercase COMMON in DynamoDB partition keys (pre-v1.1.0 format)
+    pattern: /['"`](?:MASTER_SETTING|MASTER_DATA|TENANT)#COMMON['"`#]/,
+    recommendation:
+      'TENANT_COMMON changed from "COMMON" to "common" (lowercase) in v1.1.0. Update partition keys and migrate existing DynamoDB data.',
+  },
 ]
 
 /**
@@ -586,11 +583,8 @@ async function checkAntiPatterns(
       continue
     }
 
-    let content: string
-    try {
-      content = fs.readFileSync(file, 'utf-8')
-    } catch (err) {
-      // Skip files that cannot be read (permission issues, etc.)
+    const content = readFileSafe(file)
+    if (content.startsWith('Error reading file:')) {
       skippedFiles.push(path.relative(projectPath, file))
       continue
     }
@@ -696,7 +690,7 @@ async function healthCheck(
       devDependencies?: Record<string, string>
     }
     try {
-      pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
+      pkg = JSON.parse(readFileSafe(packageJsonPath))
     } catch (err) {
       result.checks.push({
         name: 'package.json',
@@ -874,7 +868,7 @@ async function explainCode(
     }
   }
 
-  const content = fs.readFileSync(filePath, 'utf-8')
+  const content = readFileSafe(filePath)
   const lines = content.split('\n')
   const fileName = path.basename(filePath)
 

--- a/packages/mcp-server/src/tools/index.ts
+++ b/packages/mcp-server/src/tools/index.ts
@@ -4,33 +4,41 @@ import { getAnalyzeTools, handleAnalyzeTool } from './analyze.js'
 import { getGenerateTools, handleGenerateTool } from './generate.js'
 import { getValidateTools, handleValidateTool } from './validate.js'
 
+const GENERATE_TOOLS = getGenerateTools()
+const VALIDATE_TOOLS = getValidateTools()
+const ANALYZE_TOOLS = getAnalyzeTools()
+
+const ALL_TOOLS: Tool[] = [
+  ...GENERATE_TOOLS,
+  ...VALIDATE_TOOLS,
+  ...ANALYZE_TOOLS,
+]
+const ANALYZE_TOOL_NAMES = new Set(ANALYZE_TOOLS.map((t) => t.name))
+
 /**
  * Register all available tools.
  */
 export function registerTools(): Tool[] {
-  return [...getGenerateTools(), ...getValidateTools(), ...getAnalyzeTools()]
+  return ALL_TOOLS
 }
 
 /**
- * Handle tool calls.
+ * Handle tool calls by routing to the appropriate handler.
  */
 export async function handleToolCall(
   name: string,
   args: Record<string, unknown>,
   projectPath: string,
 ): Promise<{ content: { type: 'text'; text: string }[]; isError?: boolean }> {
-  // Generate tools
   if (name.startsWith('mbc_generate_')) {
     return handleGenerateTool(name, args, projectPath)
   }
 
-  // Validate tools
   if (name.startsWith('mbc_validate_')) {
     return handleValidateTool(name, args, projectPath)
   }
 
-  // Analyze tools
-  if (name.startsWith('mbc_analyze_') || name === 'mbc_lookup_error') {
+  if (ANALYZE_TOOL_NAMES.has(name)) {
     return handleAnalyzeTool(name, args, projectPath)
   }
 

--- a/packages/mcp-server/src/tools/validate.ts
+++ b/packages/mcp-server/src/tools/validate.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 import { z } from 'zod'
 
-import { findFiles } from '../utils/fs.js'
+import { findFiles, readFileSafe } from '../utils/fs.js'
 
 /**
  * Validation result interface.
@@ -98,7 +98,7 @@ async function validateCqrsPatterns(
   // Check for package.json with @mbc-cqrs-serverless/core dependency
   const packageJsonPath = path.join(projectPath, 'package.json')
   if (fs.existsSync(packageJsonPath)) {
-    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
+    const packageJson = JSON.parse(readFileSafe(packageJsonPath))
     const deps = { ...packageJson.dependencies, ...packageJson.devDependencies }
     if (!deps['@mbc-cqrs-serverless/core']) {
       issues.push({
@@ -115,7 +115,7 @@ async function validateCqrsPatterns(
   // Check for entities extending proper base classes
   const entityFiles = await findFiles(srcPath, '.entity.ts')
   for (const file of entityFiles) {
-    const content = fs.readFileSync(file, 'utf-8')
+    const content = readFileSafe(file)
     if (!content.includes('CommandEntity') && !content.includes('DataEntity')) {
       issues.push({
         severity: 'warning',
@@ -131,7 +131,7 @@ async function validateCqrsPatterns(
   // Check for modules with proper command module registration
   const moduleFiles = await findFiles(srcPath, '.module.ts')
   for (const file of moduleFiles) {
-    const content = fs.readFileSync(file, 'utf-8')
+    const content = readFileSafe(file)
     if (
       content.includes('@Module') &&
       !content.includes('CommandModule') &&
@@ -150,7 +150,7 @@ async function validateCqrsPatterns(
   // Check for services using proper patterns
   const serviceFiles = await findFiles(srcPath, '.service.ts')
   for (const file of serviceFiles) {
-    const content = fs.readFileSync(file, 'utf-8')
+    const content = readFileSafe(file)
     if (content.includes('CommandService') || content.includes('DataService')) {
       // Good - using CQRS services
     } else if (

--- a/packages/mcp-server/src/tools/validate.ts
+++ b/packages/mcp-server/src/tools/validate.ts
@@ -3,6 +3,8 @@ import * as fs from 'fs'
 import * as path from 'path'
 import { z } from 'zod'
 
+import { findFiles } from '../utils/fs.js'
+
 /**
  * Validation result interface.
  */
@@ -184,30 +186,6 @@ async function validateCqrsPatterns(
     issues,
     suggestions,
   }
-}
-
-async function findFiles(dir: string, suffix: string): Promise<string[]> {
-  const files: string[] = []
-
-  if (!fs.existsSync(dir)) {
-    return files
-  }
-
-  const entries = fs.readdirSync(dir, { withFileTypes: true })
-  for (const entry of entries) {
-    const fullPath = path.join(dir, entry.name)
-    if (
-      entry.isDirectory() &&
-      entry.name !== 'node_modules' &&
-      entry.name !== 'dist'
-    ) {
-      files.push(...(await findFiles(fullPath, suffix)))
-    } else if (entry.isFile() && entry.name.endsWith(suffix)) {
-      files.push(fullPath)
-    }
-  }
-
-  return files
 }
 
 function formatValidationResult(result: ValidationResult): {

--- a/packages/mcp-server/src/utils/fs.ts
+++ b/packages/mcp-server/src/utils/fs.ts
@@ -1,0 +1,44 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+/**
+ * Recursively find files ending with the given suffix,
+ * skipping node_modules and dist directories.
+ */
+export async function findFiles(
+  dir: string,
+  suffix: string,
+): Promise<string[]> {
+  const files: string[] = []
+
+  if (!fs.existsSync(dir)) {
+    return files
+  }
+
+  const entries = fs.readdirSync(dir, { withFileTypes: true })
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name)
+    if (
+      entry.isDirectory() &&
+      entry.name !== 'node_modules' &&
+      entry.name !== 'dist'
+    ) {
+      files.push(...(await findFiles(fullPath, suffix)))
+    } else if (entry.isFile() && entry.name.endsWith(suffix)) {
+      files.push(fullPath)
+    }
+  }
+
+  return files
+}
+
+/**
+ * Read a file safely, returning a fallback message on error.
+ */
+export function readFileSafe(filePath: string): string {
+  try {
+    return fs.readFileSync(filePath, 'utf-8')
+  } catch {
+    return `Error reading file: ${filePath}. File may not exist.`
+  }
+}


### PR DESCRIPTION
## Summary

- Add AP011 (deprecated `publish()`/`publishPartialUpdate()` removed in v1.1.0) and AP012 (uppercase `#COMMON` → `#common` in v1.1.0) anti-pattern detection
- Fix AP005 recommendation to use `getUserContext(invokeContext).tenantCode`
- Fix `cqrs_implementation_guide` command template (`options.tenantCode` → `getUserContext(options)`)
- Fix `debug_command_error` prompt (`publishPartialUpdateSync` → `publishPartialUpdateAsync`)
- Add v1.1.0/v1.1.4/v1.1.5 migration sections to `migration_guide` prompt
- Extract `utils/fs.ts` with shared `findFiles` and `readFileSafe` to eliminate duplication across 4 files
- Fix `getFrameworkRoot()` path resolution in `documentation.ts` (4 levels, not 5)
- Move `errors.ts` to accept `projectPath` parameter instead of reading from env directly
- Use `Set`-based dispatch in `tools/index.ts` for explicit analyze tool routing
- Unify all `fs.readFileSync` calls in `analyze.ts` and `validate.ts` to use `readFileSafe`
- Add try/catch for `JSON.parse` in `analyzeProject` to handle malformed `package.json`
- Update README with full tool list, AP001–AP012 table, `MBC_FRAMEWORK_ROOT` env var, and migration version coverage

## Test plan

- [ ] `cd packages/mcp-server && npm run build` passes without errors
- [ ] `mbc_check_anti_patterns` detects AP011 on code using `.publish(` (not `.publishAsync(`)
- [ ] `mbc_check_anti_patterns` detects AP012 on code using `#COMMON` partition keys
- [ ] `migration_guide` prompt includes v1.1.0, v1.1.4, v1.1.5 sections
- [ ] `mbc://docs/overview` resource resolves correctly from both monorepo and installed package layouts
- [ ] `mbc://docs/errors` resource reads from `projectPath` (not from env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)