### PR TITLE
feat(mcp-server): add AP016-AP020 anti-patterns, update skills and dependencies for v1.2.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -670,6 +670,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.981.0.tgz",
       "integrity": "sha512-QFM/3LbHzjydyKbuVA+oYPc3QCNH8hjui6Te/AaDO2waw/jLUklzItQZPHRQk6vMKnd7bNDUzNX0UiYTqrU5QA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -723,7 +724,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.980.0.tgz",
       "integrity": "sha512-1rGhAx4cHZy3pMB3R3r84qMT5WEvQ6ajr2UksnD48fjQxwaUcpI6NsPvU5j/5BI5LqGiUO6ThOrMwSMm95twQA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -777,7 +777,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.980.0.tgz",
       "integrity": "sha512-AjKBNEc+rjOZQE1HwcD9aCELqg1GmUj1rtICKuY8cgwB73xJ4U/kNyqKKpN2k9emGqlfDY2D8itIp/vDc6OKpw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.1",
         "@smithy/types": "^4.12.0",
@@ -3037,6 +3036,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -5312,9 +5312,9 @@
       "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw=="
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
-      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -5952,6 +5952,7 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -6236,6 +6237,7 @@
       "version": "10.4.20",
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.4.20.tgz",
       "integrity": "sha512-hxJxZF7jcKGuUzM9EYbuES80Z/36piJbiqmPy86mk8qOn5gglFebBTvcx7PWVbRNSb4gngASYnefBj/Y2HAzpQ==",
+      "peer": true,
       "dependencies": {
         "file-type": "20.4.1",
         "iterare": "1.2.1",
@@ -6299,6 +6301,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.4.20.tgz",
       "integrity": "sha512-kRdtyKA3+Tu70N3RQ4JgmO1E3LzAMs/eppj7SfjabC7TgqNWoS4RLhWl4BqmsNVmjj6D5jgfPVtHtgYkU3AfpQ==",
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "@nuxtjs/opencollective": "0.3.2",
         "fast-safe-stringify": "2.1.1",
@@ -7553,6 +7556,7 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -9592,6 +9596,7 @@
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -9768,6 +9773,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.25.tgz",
       "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -9965,6 +9971,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -10470,6 +10477,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -10626,6 +10634,7 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -11242,6 +11251,7 @@
       "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-4.1.0.tgz",
       "integrity": "sha512-h/tOYTkXEsAcV3//6C1/7U4ifSpKyJvb6auveAepqqNJl6TdZaPFEtKjBQNf8UxQdDP850knB2i/whq4zlsxJw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/sinon": "^17.0.3",
         "sinon": "^18.0.1",
@@ -11895,6 +11905,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -12573,6 +12584,7 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "devOptional": true,
+      "peer": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -15101,6 +15113,7 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -15156,6 +15169,7 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.2.tgz",
       "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -15675,6 +15689,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -17466,6 +17481,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.7.tgz",
       "integrity": "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -18837,6 +18853,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -19605,6 +19622,7 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -21294,6 +21312,7 @@
       "resolved": "https://registry.npmjs.org/log/-/log-6.3.2.tgz",
       "integrity": "sha512-ek8NRg/OPvS9ISOJNWNAz5vZcpYacWNFDWNJjj5OXsc6YuKacfey6wF04cXz/tOJIVrZ2nGSkHpAY5qKtF6ISg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "d": "^1.0.2",
         "duration": "^0.2.2",
@@ -23311,6 +23330,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ltd/j-toml": "^1.38.0",
         "@napi-rs/wasm-runtime": "0.2.4",
@@ -24713,6 +24733,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -25475,7 +25496,8 @@
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
-      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "peer": true
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -25788,6 +25810,7 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -26018,6 +26041,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -26162,6 +26186,7 @@
       "integrity": "sha512-6vUSIUqBkhZeIpFz0howqKlT1BNjYxOrucvvSICKCEsxVS9MbTJokGkykDrpr/k4Io3WI8tcvrf25+U5Ynf3lw==",
       "dev": true,
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/client-api-gateway": "^3.588.0",
         "@aws-sdk/client-cognito-identity-provider": "^3.588.0",
@@ -26261,6 +26286,7 @@
       "resolved": "https://registry.npmjs.org/serverless-offline/-/serverless-offline-13.9.0.tgz",
       "integrity": "sha512-r/GU1FcgUbrhUzPJ5BOpni6JXhHVhxksYQH8d3S4alx4IZQo3E9Q8fT2z8Mvh+d0rfQ1Y0kHvyeKJ126rleGfg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/client-lambda": "^3.636.0",
         "@hapi/boom": "^10.0.1",
@@ -29316,6 +29342,7 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -29587,6 +29614,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -30060,7 +30088,6 @@
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -30074,7 +30101,6 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -30083,15 +30109,13 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/webpack/node_modules/schema-utils": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -30479,6 +30503,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -30853,6 +30878,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -30981,7 +31007,7 @@
       "version": "0.1.74-beta.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.0.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.3.6"
       },
       "bin": {

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -35,13 +35,13 @@ Generate code and analyze projects:
 | `mbc_validate_cqrs` | Validate CQRS pattern implementation |
 | `mbc_analyze_project` | Analyze project structure and detect framework usage |
 | `mbc_lookup_error` | Look up error solutions from the error catalog |
-| `mbc_check_anti_patterns` | Detect anti-patterns (AP001–AP014) in project source files |
+| `mbc_check_anti_patterns` | Detect anti-patterns (AP001–AP020) in project source files |
 | `mbc_health_check` | Health check for dependencies, structure, and configuration |
 | `mbc_explain_code` | Explain a file or code section in the MBC CQRS context |
 
 #### Anti-Pattern Detection (`mbc_check_anti_patterns`)
 
-Detects 14 anti-patterns including v1.1.x and v1.2.0 breaking changes:
+Detects 20 anti-patterns including v1.1.x and v1.2.x breaking changes:
 
 | Code | Name | Severity |
 |------|------|----------|
@@ -59,6 +59,12 @@ Detects 14 anti-patterns including v1.1.x and v1.2.0 breaking changes:
 | AP012 | Uppercase COMMON Tenant Key (`#COMMON` → `#common` in v1.1.0) | Critical |
 | AP013 | publishSync Null Return Unchecked (`publishSync` returns `null` on no-op since v1.2.0) | High |
 | AP014 | Deprecated genNewSequence (`SequenceService.genNewSequence()` removed in v1.2.0) | High |
+| AP015 | Duplicate TaskModule Registration (global since v1.2.4) | High |
+| AP016 | Missing Error Logging Before Rethrow | High |
+| AP017 | Incorrect Attribute Merging on Partial Update | High |
+| AP018 | Missing Swagger Documentation | Low |
+| AP019 | Missing Pagination in List Queries | High |
+| AP020 | Missing getCommandSource for Tracing | Low |
 
 ### Prompts
 
@@ -78,6 +84,8 @@ Get guided assistance:
 | v1.1.4 | `publishSync` now writes full audit trail to Command + History tables |
 | v1.1.5 | CSV import batch architecture — `finalize_parent_job` state required in Step Functions |
 | v1.2.0 | `publishSync`/`publishPartialUpdateSync` return `null` on no-op; `genNewSequence()` removed; RYW `Repository` added |
+| v1.2.2 | `CsvBatchProcessor` Smart Retry (Poison Pill fix); `ImportQueueEventHandler` payload fix |
+| v1.2.4 | `TaskModule.register()` is now global — must be called once in host `AppModule` |
 
 ## Installation
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -47,7 +47,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.0.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/mcp-server/skills/mbc-debug/SKILL.md
+++ b/packages/mcp-server/skills/mbc-debug/SKILL.md
@@ -205,7 +205,96 @@ const results = await this.dataService.listByPk({
 
 ---
 
-### 5. Import Processing Issues
+### 5. publishSync Returns null Unexpectedly (v1.2.0+)
+
+**Symptom:** `Cannot read properties of null` when accessing result of `publishSync()`
+
+**Cause:** Since v1.2.0, `publishSync()` and `publishPartialUpdateSync()` return `null` when the command is not dirty (no changes detected — no-op).
+
+**Debug Steps:**
+```typescript
+// Step 1: Check if command has actual changes
+const result = await this.commandService.publishSync(entity, options)
+console.log('publishSync result:', result) // null = no-op (not dirty)
+
+// Step 2: Always null-check before accessing properties
+if (!result) {
+  // Command was a no-op — item already up-to-date
+  return existingItem
+}
+console.log('Published:', result.pk)
+```
+
+**Correct Pattern:**
+```typescript
+const result = await this.commandService.publishSync(command, options)
+if (!result) {
+  // No changes were made — return existing data
+  return await this.dataService.getItem({ pk, sk })
+}
+return result
+```
+
+---
+
+### 6. CSV Batch Import Head-of-Line Blocking (fixed in v1.2.2)
+
+**Symptom (pre-v1.2.2):** Valid CSV rows are never processed because one bad row causes the entire SQS batch to crash and retry indefinitely.
+
+**Root Cause:** A persistent validation error on any row (especially row 1) caused `CsvBatchProcessor` to throw immediately, blocking all subsequent rows until DLQ threshold was reached.
+
+**Status:** Fixed in v1.2.2 via Smart Retry pattern — each row is now processed in an independent try/catch.
+
+**If still on < v1.2.2, workaround:**
+```typescript
+// Pre-validate all rows before processing to identify bad rows
+const validRows = []
+const invalidRows = []
+for (const row of rows) {
+  try {
+    await strategy.compare(row, tenantCode)
+    validRows.push(row)
+  } catch {
+    invalidRows.push(row)
+  }
+}
+// Log invalid rows, then process only valid ones
+```
+
+**Upgrade recommendation:** Update to v1.2.2+ to get automatic per-row error isolation.
+
+---
+
+### 7. TaskModule Dependency Resolution Error (v1.2.4+)
+
+**Symptom:** App crashes at startup with:
+```
+Nest can't resolve dependencies of MyTaskService (?).
+Please make sure that the argument TASK_QUEUE_EVENT_FACTORY at index [0] is available in the MyModule context.
+```
+
+**Cause:** Since v1.2.4, `TaskModule.register()` is global and must be called exactly once in the host `AppModule`. `MasterModule` no longer registers it internally.
+
+**Fix:**
+```typescript
+import { TaskModule, TaskQueueEventFactory } from '@mbc-cqrs-serverless/master'
+
+@Module({
+  imports: [
+    // Register ONCE here in AppModule
+    TaskModule.register({ taskQueueEventFactory: MyTaskQueueEventFactory }),
+    MasterModule.register({ enableController: true, prismaService: PrismaService }),
+    // Remove TaskModule.register() from all feature modules!
+  ],
+})
+export class AppModule {}
+```
+
+**Also check:** `"transformTask is not a function"` at runtime indicates multiple `TaskModule.register()` calls creating conflicting bindings.
+
+---
+
+### 8. Import Processing Issues
 
 **Symptom:** Import job fails or gets stuck
 
@@ -420,11 +509,26 @@ aws logs tail /aws/lambda/YOUR_FUNCTION_NAME --since 1h
 Error Occurred
 │
 ├── Is it a TypeScript compilation error?
+│   ├── "genNewSequence is not a function"?
+│   │   └── Removed in v1.2.0 — use generateSequenceItem() instead
+│   │
 │   └── Check import statements and type definitions
 │
+├── Is it a startup crash?
+│   ├── "Nest can't resolve dependencies of MyTaskService"?
+│   │   └── v1.2.4: Add TaskModule.register() to AppModule (see §7)
+│   │
+│   └── Check module imports and provider registration
+│
 ├── Is it a runtime error?
+│   ├── "Cannot read properties of null" after publishSync?
+│   │   └── v1.2.0+: publishSync returns null on no-op — add null check (see §5)
+│   │
 │   ├── ConditionalCheckFailedException?
-│   │   └── Version mismatch - fetch latest version
+│   │   └── Version mismatch - fetch latest version before updating
+│   │
+│   ├── "transformTask is not a function"?
+│   │   └── v1.2.4: Multiple TaskModule.register() calls — keep only one in AppModule
 │   │
 │   ├── ResourceNotFoundException?
 │   │   └── Table/Item doesn't exist - check table name
@@ -436,6 +540,9 @@ Error Occurred
 │       └── Check CloudWatch logs for stack trace
 │
 ├── Is it a silent failure?
+│   ├── CSV import rows silently blocked (pre-v1.2.2)?
+│   │   └── Poison Pill problem — upgrade to v1.2.2+ (see §6)
+│   │
 │   ├── DataSyncHandler not running?
 │   │   └── Check type matching and registration
 │   │

--- a/packages/mcp-server/skills/mbc-migrate/SKILL.md
+++ b/packages/mcp-server/skills/mbc-migrate/SKILL.md
@@ -32,6 +32,13 @@ This skill helps migrate MBC CQRS Serverless projects between versions.
 | v1.0.20 | v1.0.21 | Medium | ZIP Finalization Hooks |
 | v1.0.21 | v1.0.22 | Low | DynamoDB export filter fix |
 | v1.0.22 | v1.0.23 | Low | sendInlineTemplateEmail() |
+| v1.0.x | v1.1.0 | **High** | TENANT_COMMON → lowercase; publish() removed |
+| v1.1.x | v1.1.4 | Low | publishSync audit trail (transparent) |
+| v1.1.x | v1.1.5 | Medium | CSV import v2 batch architecture |
+| v1.1.x | v1.2.0 | **High** | publishSync null return; genNewSequence() removed |
+| v1.2.0 | v1.2.1 | Low | SqsService added (new feature) |
+| v1.2.1 | v1.2.2 | Low | CsvBatchProcessor Poison Pill fix (transparent) |
+| v1.2.x | v1.2.4 | Medium | TaskModule.register() must be in AppModule |
 
 ## Migration Guides
 
@@ -206,6 +213,128 @@ await notificationService.sendInlineTemplateEmail({
 **Migration Steps:**
 1. No breaking changes
 2. Optional: Use inline templates instead of SES templates for simple emails
+
+---
+
+---
+
+### v1.1.0 — Breaking Changes (data migration required)
+
+**1. TENANT_COMMON renamed to lowercase**
+```typescript
+// Before (v1.0.x)
+const pk = `MASTER_SETTING#COMMON#${settingCode}`
+
+// After (v1.1.0+)
+const pk = `MASTER_SETTING#common#${settingCode}`
+```
+- All DynamoDB keys using `#COMMON` must be migrated to `#common`
+- New utilities: `normalizeTenantCode()`, `isCommonTenant()`
+
+**2. `publish()` and `publishPartialUpdate()` removed**
+```typescript
+// Removed — compilation error in v1.1.0+
+this.commandService.publish(...)
+this.commandService.publishPartialUpdate(...)
+
+// Use instead
+this.commandService.publishAsync(...)
+this.commandService.publishPartialUpdateAsync(...)
+```
+
+---
+
+### v1.1.4 — publishSync audit trail (no code changes required)
+
+`publishSync` now writes a full audit trail to Command and History tables (parity with async pipeline). No migration required; behavior is transparent.
+
+---
+
+### v1.1.5 — CSV Import v2 batch architecture
+
+Step Functions state machine changes required:
+- `finalize_parent_job` state is now **required**
+- Row-level progress tracking via `import_tmp` table is removed
+- Counters (`processedRows`, `succeededRows`, `failedRows`) are aggregated at completion
+
+---
+
+### v1.2.0 — Breaking Changes
+
+**1. publishSync / publishPartialUpdateSync return type change**
+```typescript
+// Before (v1.1.x) — always returned CommandModel
+const result = await commandService.publishSync(entity, options)
+console.log(result.pk) // safe
+
+// After (v1.2.0+) — returns null when command is not dirty (no-op)
+const result = await commandService.publishSync(entity, options)
+if (!result) return // no-op
+console.log(result.pk) // safe after null check
+```
+
+**2. SequenceService.genNewSequence() removed**
+```typescript
+// Removed — compilation error in v1.2.0+
+await sequenceService.genNewSequence(...)
+
+// Use instead
+await sequenceService.generateSequenceItem(...)
+// or
+await sequenceService.generateSequenceItemWithProvideSetting(...)
+```
+
+**3. Read-Your-Writes (RYW) consistency (new optional feature)**
+```typescript
+import { DetailKey, Repository } from '@mbc-cqrs-serverless/core'
+
+// Enable: set RYW_SESSION_TTL_MINUTES env var (e.g. "5")
+// Session table {NODE_ENV}-{APP_NAME}-session must be created
+// No effect if unset — zero impact on existing projects
+```
+
+---
+
+### v1.2.2 — Bug fixes (no code changes required)
+
+- **CsvBatchProcessor Poison Pill fix**: Per-row try/catch now prevents Head-of-Line Blocking in SQS batches
+- **ImportQueueEventHandler**: `singleImportProcessor.process()` now receives `event.importEvent` instead of `event.payload`
+
+Both fixes are transparent — no migration steps needed.
+
+---
+
+### v1.2.4 — TaskModule global registration
+
+**Breaking for apps using `@mbc-cqrs-serverless/master`**
+
+`TaskModule.register()` is now global (`global: true`) and must be called **exactly once** in the host `AppModule`. `MasterModule` no longer registers `TaskModule` internally.
+
+```typescript
+// Before (v1.2.3 and earlier) — worked automatically
+@Module({
+  imports: [MasterModule.register({ enableController: true, prismaService: PrismaService })],
+})
+export class AppModule {}
+
+// After (v1.2.4+) — must register explicitly
+import { TaskModule, TaskQueueEventFactory } from '@mbc-cqrs-serverless/master'
+
+@Module({
+  imports: [
+    TaskModule.register({ taskQueueEventFactory: MyTaskQueueEventFactory }),
+    MasterModule.register({ enableController: true, prismaService: PrismaService }),
+  ],
+})
+export class AppModule {}
+```
+
+**Migration steps:**
+1. Create a factory extending `TaskQueueEventFactory` from `@mbc-cqrs-serverless/master`
+2. Call `TaskModule.register()` once in `AppModule`
+3. Remove `TaskModule.register()` from all feature modules
+
+**Symptom if skipped:** App crashes at startup with `Nest can't resolve dependencies of MyTaskService (?)`.
 
 ---
 

--- a/packages/mcp-server/src/tools/analyze.ts
+++ b/packages/mcp-server/src/tools/analyze.ts
@@ -592,6 +592,55 @@ const ANTI_PATTERNS = [
     recommendation:
       'TaskModule.register() is global since v1.2.4 and must be called exactly once in the host AppModule. Multiple calls cause conflicting TASK_QUEUE_EVENT_FACTORY bindings and result in "transformTask is not a function" at runtime. Remove all TaskModule.register() calls from feature modules and keep only the one in the host AppModule.',
   },
+  {
+    code: 'AP016',
+    name: 'Missing Error Logging Before Rethrow',
+    severity: 'high' as const,
+    // Detect catch blocks that rethrow without logging (throw error; or throw new XxxException without logger.error)
+    pattern:
+      /catch\s*\(\s*(?:error|err|e)\s*\)\s*\{(?:(?!logger\.(error|warn)).)*throw\s+(?:error|err|e|new\s+\w+Exception)/s,
+    recommendation:
+      'Always log errors with context before rethrowing. Use this.logger.error() with the error message and stack trace for debugging.',
+  },
+  {
+    code: 'AP017',
+    name: 'Incorrect Attribute Merging on Partial Update',
+    severity: 'high' as const,
+    // Detect publishPartialUpdateAsync/Sync where attributes: dto.attributes (not spread merged)
+    pattern:
+      /publishPartialUpdate(?:Async|Sync)\s*\(\s*\{[^}]*attributes\s*:\s*(?:dto|input|body|data)\s*\.\s*attributes(?!\s*}?\s*,?\s*\.\.\.)(?![^}]*\.\.\.[^}]*attributes)/,
+    recommendation:
+      'When updating attributes, merge existing attributes with new ones: { ...existingItem.attributes, ...dto.attributes }. Passing dto.attributes directly overwrites all existing attributes.',
+  },
+  {
+    code: 'AP018',
+    name: 'Missing Swagger Documentation',
+    severity: 'low' as const,
+    // Detect @Controller classes that have no @ApiTags decorator
+    pattern: /@Controller\s*\([^)]*\)(?:(?!@ApiTags).){0,200}export\s+class/,
+    recommendation:
+      'Add @ApiTags() to controllers and @ApiOperation({ summary: ... }) / @ApiResponse() to endpoint methods for API documentation.',
+  },
+  {
+    code: 'AP019',
+    name: 'Missing Pagination in List Queries',
+    severity: 'high' as const,
+    // Detect listByPk/listItemsByPk/listItems calls without limit parameter
+    pattern:
+      /\.(?:listByPk|listItemsByPk|listItems)\s*\(\s*\{(?:(?!limit).)*\}\s*\)/,
+    recommendation:
+      'Always include limit and cursor parameters in list queries to avoid returning unbounded result sets and causing performance issues.',
+  },
+  {
+    code: 'AP020',
+    name: 'Missing getCommandSource for Tracing',
+    severity: 'low' as const,
+    // Detect publishAsync/publishSync called with options object that has invokeContext but no source
+    pattern:
+      /commandService\.publish(?:Async|Sync|PartialUpdateAsync|PartialUpdateSync)\s*\([^)]*invokeContext[^)]*\)/,
+    recommendation:
+      'Include source in publish options using getCommandSource(basename(__dirname), this.constructor.name, methodName) for debugging and audit trails.',
+  },
 ]
 
 /**


### PR DESCRIPTION
## Summary

- Add 5 new anti-pattern detectors (AP016–AP020) to `mbc_check_anti_patterns` tool, bringing total to 20 patterns
- Update `mbc-migrate` and `mbc-debug` skills with v1.1.x and v1.2.x breaking changes
- Update `@modelcontextprotocol/sdk` from 1.26.0 to 1.29.0

## Changes

### New Anti-Patterns (AP016–AP020)
| Code | Name | Severity |
|------|------|----------|
| AP016 | Missing Error Logging Before Rethrow | High |
| AP017 | Incorrect Attribute Merging on Partial Update | High |
| AP018 | Missing Swagger Documentation (`@ApiTags`) | Low |
| AP019 | Missing Pagination in List Queries | High |
| AP020 | Missing `getCommandSource` for Tracing | Low |

### Skills Updates

**`mbc-migrate` skill:**
- Added migration matrix rows for v1.1.0 through v1.2.4
- Added detailed migration guides for each version including breaking changes

**`mbc-debug` skill:**
- §5: `publishSync` returns `null` on no-op (v1.2.0+)
- §6: CSV batch Poison Pill / Head-of-Line Blocking fix (v1.2.2)
- §7: `TaskModule` dependency resolution error (v1.2.4+)
- Updated troubleshooting decision tree

### README Updates
- Updated anti-pattern count from 14 to 20
- Added AP015–AP020 to anti-pattern table
- Added v1.2.2 and v1.2.4 to `migration_guide` prompt coverage table

## Test plan

- [ ] Verify `mbc_check_anti_patterns` detects AP016–AP020 patterns
- [ ] Verify `mbc-migrate` skill covers v1.1.0–v1.2.4 migration steps
- [ ] Verify `mbc-debug` skill includes v1.2.0/v1.2.2/v1.2.4 debugging guidance
- [ ] Verify `@modelcontextprotocol/sdk` upgrade does not break MCP server startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)