### PR TITLE
feat(mcp-server): add AP021 anti-pattern for event emit after publishAsync

### DIFF
--- a/packages/mcp-server/skills/mbc-review/SKILL.md
+++ b/packages/mcp-server/skills/mbc-review/SKILL.md
@@ -539,13 +539,13 @@ export class OrderDataSyncHandler implements IDataSyncHandler {
       this.eventEmitter.emit('order.created', {
         orderId: cmd.id,
         tenantCode: cmd.tenantCode,
-        ...
+        // ... other fields from cmd.attributes
       });
     }
   }
 
   async down(cmd: CommandModel): Promise<void> {
-    this.eventEmitter.emit('order.deleted', { orderId: cmd.id, ... });
+    this.eventEmitter.emit('order.deleted', { orderId: cmd.id, tenantCode: cmd.tenantCode });
   }
 }
 ```

--- a/packages/mcp-server/skills/mbc-review/SKILL.md
+++ b/packages/mcp-server/skills/mbc-review/SKILL.md
@@ -503,6 +503,61 @@ export class OrderModule {}
 
 ---
 
+### AP021: Emitting Events Directly in XxxCommandService After publishAsync
+
+**Severity:** Error
+
+**Pattern:**
+```typescript
+// Bad - emit immediately after publishAsync (data table not yet written)
+async createOrder(params: CreateOrderParams, context: UserContext): Promise<string> {
+  await this.commandService.publishAsync({ pk, sk, ... }, { invokeContext });
+
+  // WRONG: at this point, DataService.getItem() returns null
+  // because the data table is populated asynchronously via DynamoDB Streams
+  this.eventEmitter.emit('order.created', { orderId, tenantCode, ... });
+  return orderId;
+}
+
+// Bad - @OnEvent handler tries to read from DataService but finds nothing
+@OnEvent('order.created')
+async handleOrderCreated(event: OrderCreatedEvent) {
+  const order = await this.dataService.getItem({ pk, sk }); // Returns null!
+}
+
+// Good - emit inside IDataSyncHandler.up() AFTER data table write
+@Injectable()
+export class OrderDataSyncHandler implements IDataSyncHandler {
+  constructor(private readonly eventEmitter: EventEmitter2) {}
+
+  async up(cmd: CommandModel): Promise<void> {
+    if (!cmd.pk.startsWith('ORDER#')) return;
+    if (cmd.isDeleted) return;
+
+    if (cmd.version === VERSION_FIRST + 1) {
+      // Data table is already written at this point — DataService.getItem() works
+      this.eventEmitter.emit('order.created', {
+        orderId: cmd.id,
+        tenantCode: cmd.tenantCode,
+        ...
+      });
+    }
+  }
+
+  async down(cmd: CommandModel): Promise<void> {
+    this.eventEmitter.emit('order.deleted', { orderId: cmd.id, ... });
+  }
+}
+```
+
+**Explanation:** `publishAsync` writes only to the DynamoDB **command** table. The **data** table (read by `DataService.getItem()`) is populated asynchronously via DynamoDB Streams → Step Functions → `IDataSyncHandler.up()`. Emitting events in `XxxCommandService` immediately after `publishAsync` means any `@OnEvent` handler that calls `DataService.getItem()` will find no data, causing "entity not found" errors.
+
+The correct pattern is to implement a custom `IDataSyncHandler` and emit events in `up()` / `down()`. By the time these methods run, the data table write has already completed. Register the handler in `CommandModule.register({ dataSyncHandlers: [...] })`.
+
+If you need to include previous field values for change-detection (e.g., `statusChanged`), embed them as `attributes._prev` in the `publishAsync` call and read them in the handler. Strip `_prev` from RDS sync handlers to prevent internal metadata from leaking into the database.
+
+---
+
 ## Review Checklist
 
 When reviewing MBC CQRS Serverless code, check:
@@ -520,6 +575,7 @@ When reviewing MBC CQRS Serverless code, check:
 - [ ] Existing version is fetched for updates
 - [ ] `generateId()` is used for ID generation
 - [ ] `getCommandSource()` is used for tracing
+- [ ] `eventEmitter.emit()` is NOT called directly after `publishAsync` (use IDataSyncHandler instead)
 
 ### DTOs
 - [ ] class-validator decorators are present
@@ -537,10 +593,12 @@ When reviewing MBC CQRS Serverless code, check:
 - [ ] Errors are logged appropriately
 
 ### Data Sync Handler
-- [ ] `@DataSyncHandler({ type: 'ENTITY' })` decorator is present
+- [ ] `@DataSyncHandler({ type: 'ENTITY' })` decorator is present (for RDS sync handlers)
 - [ ] Implements `IDataSyncHandler`
 - [ ] Handles both create/update and delete cases
 - [ ] Registered in module
+- [ ] Event-emitting handlers implement `IDataSyncHandler` and emit in `up()` / `down()`
+- [ ] `_prev` metadata is stripped before RDS upsert if used for change-detection
 
 ## Output Format
 

--- a/packages/mcp-server/src/tools/analyze.spec.ts
+++ b/packages/mcp-server/src/tools/analyze.spec.ts
@@ -8,8 +8,8 @@ describe('analyze tools', () => {
     it('should return all analyze tools', () => {
       const tools = getAnalyzeTools()
       expect(tools).toHaveLength(5)
-      
-      const toolNames = tools.map(t => t.name)
+
+      const toolNames = tools.map((t) => t.name)
       expect(toolNames).toContain('mbc_analyze_project')
       expect(toolNames).toContain('mbc_lookup_error')
       expect(toolNames).toContain('mbc_check_anti_patterns')
@@ -32,14 +32,17 @@ describe('analyze tools', () => {
 
     it('should detect direct DynamoDB write (AP001)', async () => {
       const testFile = path.join(testDir, 'src', 'test.ts')
-      fs.writeFileSync(testFile, `
+      fs.writeFileSync(
+        testFile,
+        `
         const command = new PutItemCommand({ TableName: 'test' })
-      `)
+      `,
+      )
 
       const result = await handleAnalyzeTool(
         'mbc_check_anti_patterns',
         { path: 'src' },
-        testDir
+        testDir,
       )
 
       expect(result.content[0].text).toContain('AP001')
@@ -48,14 +51,17 @@ describe('analyze tools', () => {
 
     it('should detect hardcoded tenant (AP005)', async () => {
       const testFile = path.join(testDir, 'src', 'test.ts')
-      fs.writeFileSync(testFile, `
+      fs.writeFileSync(
+        testFile,
+        `
         const pk = "TENANT#hardcoded"
-      `)
+      `,
+      )
 
       const result = await handleAnalyzeTool(
         'mbc_check_anti_patterns',
         { path: 'src' },
-        testDir
+        testDir,
       )
 
       expect(result.content[0].text).toContain('AP005')
@@ -64,14 +70,17 @@ describe('analyze tools', () => {
 
     it('should detect hardcoded secret (AP008)', async () => {
       const testFile = path.join(testDir, 'src', 'test.ts')
-      fs.writeFileSync(testFile, `
+      fs.writeFileSync(
+        testFile,
+        `
         const password = "supersecretpassword123"
-      `)
+      `,
+      )
 
       const result = await handleAnalyzeTool(
         'mbc_check_anti_patterns',
         { path: 'src' },
-        testDir
+        testDir,
       )
 
       expect(result.content[0].text).toContain('AP008')
@@ -85,7 +94,7 @@ describe('analyze tools', () => {
       const result = await handleAnalyzeTool(
         'mbc_check_anti_patterns',
         { path: 'src' },
-        testDir
+        testDir,
       )
 
       expect(result.content[0].text).toContain('AP010')
@@ -94,18 +103,21 @@ describe('analyze tools', () => {
 
     it('should return success when no anti-patterns found', async () => {
       const testFile = path.join(testDir, 'src', 'test.ts')
-      fs.writeFileSync(testFile, `
+      fs.writeFileSync(
+        testFile,
+        `
         export class TestService {
           async doSomething() {
             return 'hello'
           }
         }
-      `)
+      `,
+      )
 
       const result = await handleAnalyzeTool(
         'mbc_check_anti_patterns',
         { path: 'src' },
-        testDir
+        testDir,
       )
 
       expect(result.content[0].text).toContain('No anti-patterns detected')
@@ -113,24 +125,55 @@ describe('analyze tools', () => {
 
     it('should skip test files', async () => {
       const testFile = path.join(testDir, 'src', 'test.spec.ts')
-      fs.writeFileSync(testFile, `
+      fs.writeFileSync(
+        testFile,
+        `
         const password = "supersecretpassword123"
-      `)
+      `,
+      )
 
       const result = await handleAnalyzeTool(
         'mbc_check_anti_patterns',
         { path: 'src' },
-        testDir
+        testDir,
       )
 
       expect(result.content[0].text).toContain('No anti-patterns detected')
+    })
+
+    it('should detect event emit after publishAsync in CommandService (AP021)', async () => {
+      const testFile = path.join(testDir, 'src', 'test.ts')
+      fs.writeFileSync(
+        testFile,
+        `
+        @Injectable()
+        export class OrderCommandService {
+          async createOrder(params: CreateOrderParams): Promise<string> {
+            await this.commandService.publishAsync({ pk, sk, version: VERSION_FIRST }, { invokeContext });
+            this.eventEmitter.emit('order.created', { orderId });
+            return orderId;
+          }
+        }
+      `,
+      )
+
+      const result = await handleAnalyzeTool(
+        'mbc_check_anti_patterns',
+        { path: 'src' },
+        testDir,
+      )
+
+      expect(result.content[0].text).toContain('AP021')
+      expect(result.content[0].text).toContain(
+        'Event Emit Directly After publishAsync',
+      )
     })
 
     it('should return error for non-existent path', async () => {
       const result = await handleAnalyzeTool(
         'mbc_check_anti_patterns',
         { path: 'nonexistent' },
-        testDir
+        testDir,
       )
 
       expect(result.isError).toBe(true)
@@ -150,70 +193,62 @@ describe('analyze tools', () => {
     })
 
     it('should detect healthy project with MBC packages', async () => {
-      fs.writeFileSync(path.join(testDir, 'package.json'), JSON.stringify({
-        name: 'test-project',
-        dependencies: {
-          '@mbc-cqrs-serverless/core': '^1.0.0',
-          '@nestjs/common': '^10.0.0',
-        },
-        devDependencies: {
-          typescript: '^5.0.0',
-        },
-      }))
+      fs.writeFileSync(
+        path.join(testDir, 'package.json'),
+        JSON.stringify({
+          name: 'test-project',
+          dependencies: {
+            '@mbc-cqrs-serverless/core': '^1.0.0',
+            '@nestjs/common': '^10.0.0',
+          },
+          devDependencies: {
+            typescript: '^5.0.0',
+          },
+        }),
+      )
       fs.mkdirSync(path.join(testDir, 'src'), { recursive: true })
       fs.writeFileSync(path.join(testDir, 'src', 'app.module.ts'), '')
       fs.writeFileSync(path.join(testDir, '.env'), '')
       fs.writeFileSync(path.join(testDir, 'serverless.yml'), '')
 
-      const result = await handleAnalyzeTool(
-        'mbc_health_check',
-        {},
-        testDir
-      )
+      const result = await handleAnalyzeTool('mbc_health_check', {}, testDir)
 
       expect(result.content[0].text).toContain('HEALTHY')
       expect(result.content[0].text).toContain('MBC Framework')
     })
 
     it('should detect missing MBC packages', async () => {
-      fs.writeFileSync(path.join(testDir, 'package.json'), JSON.stringify({
-        name: 'test-project',
-        dependencies: {
-          '@nestjs/common': '^10.0.0',
-        },
-      }))
+      fs.writeFileSync(
+        path.join(testDir, 'package.json'),
+        JSON.stringify({
+          name: 'test-project',
+          dependencies: {
+            '@nestjs/common': '^10.0.0',
+          },
+        }),
+      )
       fs.mkdirSync(path.join(testDir, 'src'), { recursive: true })
 
-      const result = await handleAnalyzeTool(
-        'mbc_health_check',
-        {},
-        testDir
-      )
+      const result = await handleAnalyzeTool('mbc_health_check', {}, testDir)
 
       expect(result.content[0].text).toContain('ERROR')
-      expect(result.content[0].text).toContain('No @mbc-cqrs-serverless packages found')
+      expect(result.content[0].text).toContain(
+        'No @mbc-cqrs-serverless packages found',
+      )
     })
 
     it('should handle invalid package.json', async () => {
       fs.writeFileSync(path.join(testDir, 'package.json'), 'invalid json')
       fs.mkdirSync(path.join(testDir, 'src'), { recursive: true })
 
-      const result = await handleAnalyzeTool(
-        'mbc_health_check',
-        {},
-        testDir
-      )
+      const result = await handleAnalyzeTool('mbc_health_check', {}, testDir)
 
       expect(result.content[0].text).toContain('ERROR')
       expect(result.content[0].text).toContain('could not be parsed')
     })
 
     it('should detect missing package.json', async () => {
-      const result = await handleAnalyzeTool(
-        'mbc_health_check',
-        {},
-        testDir
-      )
+      const result = await handleAnalyzeTool('mbc_health_check', {}, testDir)
 
       expect(result.content[0].text).toContain('ERROR')
       expect(result.content[0].text).toContain('package.json not found')
@@ -233,18 +268,21 @@ describe('analyze tools', () => {
 
     it('should detect NestJS module', async () => {
       const testFile = path.join(testDir, 'app.module.ts')
-      fs.writeFileSync(testFile, `
+      fs.writeFileSync(
+        testFile,
+        `
         @Module({
           imports: [CommandModule],
           providers: [AppService],
         })
         export class AppModule {}
-      `)
+      `,
+      )
 
       const result = await handleAnalyzeTool(
         'mbc_explain_code',
         { file_path: 'app.module.ts' },
-        testDir
+        testDir,
       )
 
       expect(result.content[0].text).toContain('NestJS Module')
@@ -253,7 +291,9 @@ describe('analyze tools', () => {
 
     it('should detect REST controller', async () => {
       const testFile = path.join(testDir, 'app.controller.ts')
-      fs.writeFileSync(testFile, `
+      fs.writeFileSync(
+        testFile,
+        `
         @Controller('api')
         export class AppController {
           @Get()
@@ -262,12 +302,13 @@ describe('analyze tools', () => {
           @Post()
           create() {}
         }
-      `)
+      `,
+      )
 
       const result = await handleAnalyzeTool(
         'mbc_explain_code',
         { file_path: 'app.controller.ts' },
-        testDir
+        testDir,
       )
 
       expect(result.content[0].text).toContain('REST Controller')
@@ -277,7 +318,9 @@ describe('analyze tools', () => {
 
     it('should detect service with CommandService', async () => {
       const testFile = path.join(testDir, 'app.service.ts')
-      fs.writeFileSync(testFile, `
+      fs.writeFileSync(
+        testFile,
+        `
         @Injectable()
         export class AppService {
           constructor(private commandService: CommandService) {}
@@ -286,12 +329,13 @@ describe('analyze tools', () => {
             await this.commandService.publishAsync(...)
           }
         }
-      `)
+      `,
+      )
 
       const result = await handleAnalyzeTool(
         'mbc_explain_code',
         { file_path: 'app.service.ts' },
-        testDir
+        testDir,
       )
 
       expect(result.content[0].text).toContain('Service')
@@ -301,18 +345,21 @@ describe('analyze tools', () => {
 
     it('should detect entity with DynamoDB keys', async () => {
       const testFile = path.join(testDir, 'item.entity.ts')
-      fs.writeFileSync(testFile, `
+      fs.writeFileSync(
+        testFile,
+        `
         export class ItemEntity extends CommandEntity {
           pk: string
           sk: string
           name: string
         }
-      `)
+      `,
+      )
 
       const result = await handleAnalyzeTool(
         'mbc_explain_code',
         { file_path: 'item.entity.ts' },
-        testDir
+        testDir,
       )
 
       expect(result.content[0].text).toContain('Entity')
@@ -324,7 +371,7 @@ describe('analyze tools', () => {
       const result = await handleAnalyzeTool(
         'mbc_explain_code',
         { file_path: 'nonexistent.ts' },
-        testDir
+        testDir,
       )
 
       expect(result.isError).toBe(true)
@@ -333,16 +380,19 @@ describe('analyze tools', () => {
 
     it('should explain specific line range', async () => {
       const testFile = path.join(testDir, 'test.ts')
-      fs.writeFileSync(testFile, `line1
+      fs.writeFileSync(
+        testFile,
+        `line1
 line2
 line3
 line4
-line5`)
+line5`,
+      )
 
       const result = await handleAnalyzeTool(
         'mbc_explain_code',
         { file_path: 'test.ts', start_line: 2, end_line: 4 },
-        testDir
+        testDir,
       )
 
       expect(result.content[0].text).toContain('lines 2-4')

--- a/packages/mcp-server/src/tools/analyze.ts
+++ b/packages/mcp-server/src/tools/analyze.ts
@@ -641,6 +641,17 @@ const ANTI_PATTERNS = [
     recommendation:
       'Include source in publish options using getCommandSource(basename(__dirname), this.constructor.name, methodName) for debugging and audit trails.',
   },
+  {
+    code: 'AP021',
+    name: 'Event Emit Directly After publishAsync in CommandService',
+    severity: 'critical' as const,
+    // Detect eventEmitter.emit() called in the same method body after commandService.publishAsync/publishSync
+    // Pattern: publishAsync(...) followed by eventEmitter.emit(...) without an IDataSyncHandler boundary
+    pattern:
+      /commandService\.publish(?:Async|Sync|PartialUpdateAsync|PartialUpdateSync)\b[\s\S]{0,500}?this\.eventEmitter\.emit\s*\(/,
+    recommendation:
+      'Do not call eventEmitter.emit() directly after publishAsync(). At that point only the command table has been written; the data table is populated asynchronously via DynamoDB Streams. Any @OnEvent handler that calls DataService.getItem() will find no data. Instead, implement IDataSyncHandler and emit events inside up()/down(), which are called after the data table write completes. Register the handler in CommandModule.register({ dataSyncHandlers: [...] }). If change-detection is needed (e.g. statusChanged), embed previous values as attributes._prev in publishAsync and read them in the handler; strip _prev in RDS sync handlers to prevent it leaking into the database.',
+  },
 ]
 
 /**

--- a/packages/mcp-server/src/tools/analyze.ts
+++ b/packages/mcp-server/src/tools/analyze.ts
@@ -644,11 +644,11 @@ const ANTI_PATTERNS = [
   {
     code: 'AP021',
     name: 'Event Emit Directly After publishAsync in CommandService',
-    severity: 'critical' as const,
-    // Detect eventEmitter.emit() called in the same method body after commandService.publishAsync/publishSync
-    // Pattern: publishAsync(...) followed by eventEmitter.emit(...) without an IDataSyncHandler boundary
+    severity: 'high' as const,
+    // Detect eventEmitter.emit() called close after commandService.publishAsync/publishSync.
+    // 200-char window reduces cross-method false positives while catching same-method violations.
     pattern:
-      /commandService\.publish(?:Async|Sync|PartialUpdateAsync|PartialUpdateSync)\b[\s\S]{0,500}?this\.eventEmitter\.emit\s*\(/,
+      /commandService\.publish(?:Async|Sync|PartialUpdateAsync|PartialUpdateSync)\b[\s\S]{0,200}?this\.eventEmitter\.emit\s*\(/,
     recommendation:
       'Do not call eventEmitter.emit() directly after publishAsync(). At that point only the command table has been written; the data table is populated asynchronously via DynamoDB Streams. Any @OnEvent handler that calls DataService.getItem() will find no data. Instead, implement IDataSyncHandler and emit events inside up()/down(), which are called after the data table write completes. Register the handler in CommandModule.register({ dataSyncHandlers: [...] }). If change-detection is needed (e.g. statusChanged), embed previous values as attributes._prev in publishAsync and read them in the handler; strip _prev in RDS sync handlers to prevent it leaking into the database.',
   },


### PR DESCRIPTION
## Summary

- Add **AP021** (severity: critical) to `mbc_check_anti_patterns` tool and `/mbc-review` skill
- Detects `eventEmitter.emit()` called in the same method body directly after `commandService.publishAsync/publishSync`
- Root cause: `publishAsync` writes only to the command table; the data table is populated asynchronously via DynamoDB Streams. Any `@OnEvent` handler that calls `DataService.getItem()` will receive `null` at that point, causing "entity not found" errors
- Fix guidance: implement `IDataSyncHandler` and emit events inside `up()`/`down()` (called after data table write); use `attributes._prev` for change-detection; strip `_prev` in RDS sync handlers

## Changes

- `packages/mcp-server/src/tools/analyze.ts` — AP021 regex pattern + recommendation added to `ANTI_PATTERNS` array
- `packages/mcp-server/skills/mbc-review/SKILL.md` — AP021 pattern documentation with before/after code examples; two new Review Checklist items
- `packages/mcp-server/src/tools/analyze.spec.ts` — detection test for AP021

## Test plan

- [x] `npm test` in `packages/mcp-server` passes (265 tests)
- [x] AP021 test case: `commandService.publishAsync(...)` followed by `this.eventEmitter.emit(...)` is detected
- [x] Clean code (no emit after publishAsync) correctly returns "No anti-patterns detected"

🤖 Generated with [Claude Code](https://claude.com/claude-code)