### PR TITLE
feat(core): enhance Repository and SessionService with session deletion logic

### DIFF
--- a/packages/core/src/commands/repository.spec.ts
+++ b/packages/core/src/commands/repository.spec.ts
@@ -10,7 +10,7 @@ import {
   DataModel,
   CommandModel,
 } from '../interfaces'
-import { KEY_SEPARATOR } from '../constants' // Import the actual separator
+import { KEY_SEPARATOR } from '../constants'
 import * as userContextHelper from '../context/user'
 
 describe('Repository', () => {
@@ -19,14 +19,12 @@ describe('Repository', () => {
   let commandService: jest.Mocked<CommandService>
   let sessionService: jest.Mocked<SessionService>
 
-  const mockModuleOptions = { tableName: 'test-module' }
-  const mockTenant = 'tenant-123'
-  const mockUserId = 'user-456'
-
-  // IDs must follow the pattern: {TYPE}#{TENANT}#{BASE_SK}
-  const mockItemId = `TEST#${mockTenant}#ITEM-abc`
-  const mockPk = `TEST#${mockTenant}`
-  const mockSk = 'ITEM-abc'
+  const mockModuleOptions = { tableName: 'user-tenant' }
+  const mockTenant = 'tenant-A'
+  const mockUserId = 'user-1'
+  const mockPk = `USER_TENANT#${mockTenant}`
+  const mockSk = 'USER_TENANT#item-1'
+  const mockItemId = `${mockPk}#${mockSk}`
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -60,115 +58,419 @@ describe('Repository', () => {
     commandService = module.get(CommandService)
     sessionService = module.get(SessionService)
 
+    // Default mock for user context
     jest.spyOn(userContextHelper, 'getUserContext').mockReturnValue({
       userId: mockUserId,
       tenantCode: mockTenant,
     } as any)
 
+    // sessionService.delete is fire-and-forget in repository, always returns promise
     sessionService.delete.mockResolvedValue(undefined)
   })
 
-  describe('getItem', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('getItem — branch and cleanup logic', () => {
     const detailKey = { pk: mockPk, sk: mockSk }
     const options = { invokeContext: {} as any }
 
-    it('should fetch from CommandService and merge if data table is lagging (v1 < v2)', async () => {
-      sessionService.get.mockResolvedValue({ version: 2 } as any)
+    it('should return data directly when no userId is present in context', async () => {
+      jest
+        .spyOn(userContextHelper, 'getUserContext')
+        .mockReturnValue(null as any)
+      const mockData = { id: '1' } as DataModel
+      dataService.getItem.mockResolvedValue(mockData)
 
-      const laggingData = {
+      const result = await repository.getItem(detailKey, options)
+
+      expect(result).toBe(mockData)
+      expect(sessionService.get).not.toHaveBeenCalled()
+    })
+
+    it('should return data directly when no session exists', async () => {
+      sessionService.get.mockResolvedValue(null)
+      const mockData = { id: '1' } as DataModel
+      dataService.getItem.mockResolvedValue(mockData)
+
+      const result = await repository.getItem(detailKey, options)
+
+      expect(result).toBe(mockData)
+      expect(commandService.getItem).not.toHaveBeenCalled()
+    })
+
+    it('should DELETE session and return existing when data table caught up (v2 === v2)', async () => {
+      sessionService.get.mockResolvedValue({ version: 2 } as any)
+      const caughtUp = {
+        id: mockItemId,
+        pk: mockPk,
+        sk: mockSk,
+        version: 2,
+        name: 'caught-up',
+      } as DataModel
+      dataService.getItem.mockResolvedValue(caughtUp)
+
+      const result = await repository.getItem(detailKey, options)
+
+      expect(result).toEqual(caughtUp)
+      expect(commandService.getItem).not.toHaveBeenCalled() // Critical path optimization
+      expect(sessionService.delete).toHaveBeenCalledWith(
+        mockUserId,
+        mockTenant,
+        mockModuleOptions.tableName,
+        mockItemId,
+      )
+    })
+
+    it('should DELETE session when data table SURPASSED session (v5 > v2)', async () => {
+      sessionService.get.mockResolvedValue({ version: 2 } as any)
+      dataService.getItem.mockResolvedValue({
+        id: mockItemId,
+        pk: mockPk,
+        sk: mockSk,
+        version: 5,
+      } as DataModel)
+
+      const result = await repository.getItem(detailKey, options)
+
+      expect(result.version).toBe(5)
+      expect(commandService.getItem).not.toHaveBeenCalled()
+      expect(sessionService.delete).toHaveBeenCalled()
+    })
+
+    it('should NOT delete session and merge command when data table is lagging (v1 < v2)', async () => {
+      sessionService.get.mockResolvedValue({ version: 2 } as any)
+      dataService.getItem.mockResolvedValue({
         id: mockItemId,
         pk: mockPk,
         sk: mockSk,
         version: 1,
         name: 'old',
-      } as DataModel
-
-      const latestCommand = {
+      } as DataModel)
+      commandService.getItem.mockResolvedValue({
         id: mockItemId,
         pk: mockPk,
-        sk: `${mockSk}@2`, // Must have a version-suffixed SK
+        sk: `${mockSk}@2`,
         version: 2,
         name: 'new',
-      } as CommandModel
-
-      dataService.getItem.mockResolvedValue(laggingData)
-      commandService.getItem.mockResolvedValue(latestCommand)
+        code: 'c',
+        type: 'TEST',
+        tenantCode: mockTenant,
+      } as CommandModel)
 
       const result = await repository.getItem(detailKey, options)
 
-      expect(result.name).toBe('new')
       expect(result.version).toBe(2)
+      expect(result.name).toBe('new')
+      expect(sessionService.delete).not.toHaveBeenCalled() //
+    })
+
+    it('should not throw when sessionService.delete fails (fire-and-forget contract)', async () => {
+      sessionService.get.mockResolvedValue({ version: 2 } as any)
+      dataService.getItem.mockResolvedValue({
+        id: mockItemId,
+        pk: mockPk,
+        sk: mockSk,
+        version: 2,
+      } as DataModel)
+      // Service layer error handling check
+      sessionService.delete.mockRejectedValue(new Error('DDB outage'))
+
+      await expect(
+        repository.getItem(detailKey, options),
+      ).resolves.toBeDefined()
+    })
+
+    it('should return data table result if commandService returns null', async () => {
+      sessionService.get.mockResolvedValue({ version: 2 } as any)
+      const mockData = { id: '1', version: 1 } as DataModel
+      dataService.getItem.mockResolvedValue(mockData)
+      commandService.getItem.mockResolvedValue(null)
+
+      const result = await repository.getItem(detailKey, options)
+
+      expect(result).toBe(mockData)
     })
   })
 
-  describe('listItemsByPk', () => {
-    it('should prepend a new item if it exists in session but not in base results', async () => {
+  describe('listItemsByPk — branch and cleanup logic', () => {
+    const opts = { invokeContext: {} as any }
+
+    it('should return base results when latestFlg is false', async () => {
+      const baseResult = new DataListEntity({ items: [], lastSk: undefined })
+      dataService.listItemsByPk.mockResolvedValue(baseResult)
+
+      const result = await repository.listItemsByPk(
+        mockPk,
+        {},
+        { latestFlg: false },
+        opts,
+      )
+
+      expect(result).toBe(baseResult)
+      expect(sessionService.listByUser).not.toHaveBeenCalled()
+    })
+
+    it('should DELETE session and skip merge when existing item already caught up', async () => {
+      const caughtUp = {
+        id: mockItemId,
+        pk: mockPk,
+        sk: mockSk,
+        version: 5,
+        name: 'caught-up',
+      } as DataModel
+      dataService.listItemsByPk.mockResolvedValue(
+        new DataListEntity({
+          items: [new DataEntity(caughtUp)],
+          lastSk: undefined,
+        }),
+      )
+      sessionService.listByUser.mockResolvedValue([
+        {
+          sk: `${mockModuleOptions.tableName}${KEY_SEPARATOR}${mockItemId}`,
+          version: 5,
+        } as any,
+      ])
+
+      const result = await repository.listItemsByPk(
+        mockPk,
+        {},
+        { latestFlg: true },
+        opts,
+      )
+
+      expect(result.items).toHaveLength(1)
+      expect(commandService.getItem).not.toHaveBeenCalled()
+      expect(sessionService.delete).toHaveBeenCalled() //
+    })
+
+    it('should NOT delete session for create-new (regression guard)', async () => {
       dataService.listItemsByPk.mockResolvedValue(
         new DataListEntity({ items: [], lastSk: undefined }),
       )
-
-      // SK in Session table is: {module}#{itemId}
       sessionService.listByUser.mockResolvedValue([
         {
           sk: `${mockModuleOptions.tableName}${KEY_SEPARATOR}${mockItemId}`,
           version: 1,
         } as any,
       ])
-
-      const newCmd = {
+      commandService.getItem.mockResolvedValue({
         id: mockItemId,
         pk: mockPk,
         sk: `${mockSk}@1`,
         version: 1,
-        updatedAt: new Date(),
-      } as any
-      commandService.getItem.mockResolvedValue(newCmd)
+        name: 'new',
+        code: 'c',
+        type: 'TEST',
+        tenantCode: mockTenant,
+      } as CommandModel)
 
       const result = await repository.listItemsByPk(
         mockPk,
         {},
         { latestFlg: true },
-        { invokeContext: {} } as any,
+        opts,
       )
 
-      expect(result.items.length).toBe(1)
-      expect(result.items[0].id).toBe(mockItemId)
+      expect(result.items).toHaveLength(1)
+      expect(sessionService.delete).not.toHaveBeenCalled()
+      expect(commandService.getItem).toHaveBeenCalled()
     })
-  })
 
-  describe('listItems (External Source/RDS)', () => {
-    it('should call dataService.getItem for each session to check sync status', async () => {
-      const mockRdsQuery = jest.fn().mockResolvedValue({
-        total: 1,
-        items: [{ id: mockItemId }],
-      })
-
+    it('should remove item from result when command.isDeleted is true', async () => {
+      const existing = {
+        id: mockItemId,
+        pk: mockPk,
+        sk: mockSk,
+        version: 1,
+      } as DataModel
+      dataService.listItemsByPk.mockResolvedValue(
+        new DataListEntity({
+          items: [new DataEntity(existing)],
+          lastSk: undefined,
+        }),
+      )
       sessionService.listByUser.mockResolvedValue([
         {
           sk: `${mockModuleOptions.tableName}${KEY_SEPARATOR}${mockItemId}`,
-          version: 10,
+          version: 2,
         } as any,
       ])
+      commandService.getItem.mockResolvedValue({
+        id: mockItemId,
+        pk: mockPk,
+        sk: `${mockSk}@2`,
+        isDeleted: true,
+        version: 2,
+      } as CommandModel)
 
-      // Data item must have matching PK/SK to stop the parser from failing
+      const result = await repository.listItemsByPk(
+        mockPk,
+        {},
+        { latestFlg: true },
+        opts,
+      )
+
+      expect(result.items).toHaveLength(0)
+    })
+  })
+
+  describe('listItems (RDS) — branch and cleanup logic', () => {
+    const opts = { invokeContext: {} as any }
+    const mergeOptions: IMergeOptions<any> = {
+      latestFlg: true,
+      transformCommand: (cmd) => ({
+        id: cmd.id,
+        pk: mockPk,
+        sk: mockSk,
+        version: cmd.version,
+        name: cmd.name,
+        role: 'viewer',
+      }),
+      matchesFilter: (item) => item.role === 'viewer',
+    }
+
+    it('should return base results when latestFlg is false', async () => {
+      const rdsQuery = jest
+        .fn()
+        .mockResolvedValue({ total: 1, items: [{ id: '1' }] })
+
+      const result = await repository.listItems(
+        rdsQuery,
+        { latestFlg: false } as any,
+        opts,
+      )
+
+      expect(result.total).toBe(1)
+      expect(sessionService.listByUser).not.toHaveBeenCalled()
+    })
+
+    it('should DELETE session and skip command fetch when data table caught up', async () => {
+      const rdsQuery = jest.fn().mockResolvedValue({
+        total: 1,
+        items: [
+          {
+            id: mockItemId,
+            pk: mockPk,
+            sk: mockSk,
+            version: 5,
+            name: 'rds-row',
+          },
+        ],
+      })
+      sessionService.listByUser.mockResolvedValue([
+        {
+          sk: `${mockModuleOptions.tableName}${KEY_SEPARATOR}${mockItemId}`,
+          version: 5,
+        } as any,
+      ])
       dataService.getItem.mockResolvedValue({
         id: mockItemId,
         pk: mockPk,
         sk: mockSk,
-        version: 10,
+        version: 5,
+      } as DataModel)
+
+      const result = await repository.listItems(rdsQuery, mergeOptions, opts)
+
+      expect(commandService.getItem).not.toHaveBeenCalled()
+      expect(sessionService.delete).toHaveBeenCalled()
+      expect(result.total).toBe(1)
+    })
+
+    it('should fetch command when data table is lagging', async () => {
+      const rdsQuery = jest.fn().mockResolvedValue({
+        total: 1,
+        items: [
+          { id: mockItemId, pk: mockPk, sk: mockSk, version: 1, name: 'old' },
+        ],
+      })
+      sessionService.listByUser.mockResolvedValue([
+        {
+          sk: `${mockModuleOptions.tableName}${KEY_SEPARATOR}${mockItemId}`,
+          version: 3,
+        } as any,
+      ])
+      dataService.getItem.mockResolvedValue({
+        id: mockItemId,
+        pk: mockPk,
+        sk: mockSk,
+        version: 1,
+      } as DataModel)
+      commandService.getItem.mockResolvedValue({
+        id: mockItemId,
+        pk: mockPk,
+        sk: `${mockSk}@3`,
+        version: 3,
+        name: 'new',
+        code: 'c',
+        type: 'TEST',
+        tenantCode: mockTenant,
+      } as CommandModel)
+
+      const result = await repository.listItems(rdsQuery, mergeOptions, opts)
+
+      expect(commandService.getItem).toHaveBeenCalled()
+      expect(sessionService.delete).not.toHaveBeenCalled()
+      expect(result.items[0].name).toBe('new')
+    })
+
+    it('should decrement total when item is deleted via command', async () => {
+      const rdsQuery = jest.fn().mockResolvedValue({
+        total: 1,
+        items: [{ id: mockItemId, pk: mockPk, sk: mockSk, version: 1 }],
+      })
+      sessionService.listByUser.mockResolvedValue([
+        {
+          sk: `${mockModuleOptions.tableName}${KEY_SEPARATOR}${mockItemId}`,
+          version: 2,
+        } as any,
+      ])
+      dataService.getItem.mockResolvedValue({
+        id: mockItemId,
+        version: 1,
+      } as DataModel)
+      commandService.getItem.mockResolvedValue({
+        id: mockItemId,
+        isDeleted: true,
+        version: 2,
+      } as CommandModel)
+
+      const result = await repository.listItems(rdsQuery, mergeOptions, opts)
+
+      expect(result.total).toBe(0)
+      expect(result.items).toHaveLength(0)
+    })
+
+    it('should respect matchesFilter for create-new items', async () => {
+      const rdsQuery = jest.fn().mockResolvedValue({ total: 0, items: [] })
+      sessionService.listByUser.mockResolvedValue([
+        {
+          sk: `${mockModuleOptions.tableName}${KEY_SEPARATOR}${mockItemId}`,
+          version: 1,
+        } as any,
+      ])
+      dataService.getItem.mockResolvedValue(null)
+
+      // Command shape that will FAIL filter (role is not 'viewer')
+      commandService.getItem.mockResolvedValue({
+        id: mockItemId,
+        version: 1,
+        attributes: { role: 'admin' },
+        code: 'c',
+        name: 'n',
       } as any)
 
-      const mergeOptions: IMergeOptions<any> = {
-        latestFlg: true,
-        transformCommand: (cmd) => cmd,
+      const filteredMerge: IMergeOptions<any> = {
+        ...mergeOptions,
+        transformCommand: (cmd) => ({ id: cmd.id, role: cmd.attributes.role }),
       }
 
-      await repository.listItems(mockRdsQuery, mergeOptions, {
-        invokeContext: {},
-      } as any)
+      const result = await repository.listItems(rdsQuery, filteredMerge, opts)
 
-      expect(dataService.getItem).toHaveBeenCalled()
-      expect(sessionService.delete).toHaveBeenCalled()
+      expect(result.total).toBe(0) // Filtered out
+      expect(result.items).toHaveLength(0)
     })
   })
 })

--- a/packages/core/src/commands/repository.spec.ts
+++ b/packages/core/src/commands/repository.spec.ts
@@ -311,8 +311,31 @@ describe('Repository', () => {
         { latestFlg: true },
         opts,
       )
-
       expect(result.items).toHaveLength(0)
+    })
+
+    it('should short-circuit dataService.getItem in listItems if getVersion proves caught-up', async () => {
+      const rdsItem = { id: mockItemId, version: 10 }
+      const rdsQuery = jest
+        .fn()
+        .mockResolvedValue({ total: 1, items: [rdsItem] })
+      sessionService.listByUser.mockResolvedValue([
+        {
+          sk: `${mockModuleOptions.tableName}${KEY_SEPARATOR}${mockItemId}`,
+          version: 10,
+        } as any,
+      ])
+
+      const mergeWithVersion: IMergeOptions<any> = {
+        latestFlg: true,
+        getVersion: (item) => item.version,
+        transformCommand: (cmd) => cmd,
+      }
+
+      await repository.listItems(rdsQuery, mergeWithVersion, opts)
+
+      expect(dataService.getItem).not.toHaveBeenCalled() // Proves short-circuit worked
+      expect(sessionService.delete).toHaveBeenCalled()
     })
   })
 

--- a/packages/core/src/commands/repository.spec.ts
+++ b/packages/core/src/commands/repository.spec.ts
@@ -1,454 +1,174 @@
 import { Test, TestingModule } from '@nestjs/testing'
-
-import { SessionService } from '../data-store/session.service'
-import { CommandModel, DataEntity, DataModel } from '../interfaces'
-import { ICommandOptions } from '../interfaces/command.options.interface'
-import { MODULE_OPTIONS_TOKEN } from './command.module-definition'
-import { CommandService } from './command.service'
+import { Repository, IMergeOptions } from './repository'
 import { DataService } from './data.service'
-import { IMergeOptions, Repository } from './repository'
-
-/** Physical DynamoDB data table name (DataService); session SK uses module name only. */
-const PHYSICAL_DATA_TABLE = 'local-app-user-tenant-data'
-const MODULE_TABLE = 'user-tenant'
-
-const makeInvokeContext = (
-  userId = 'user-1',
-): ICommandOptions['invokeContext'] =>
-  ({
-    event: {
-      requestContext: {
-        authorizer: {
-          jwt: {
-            claims: {
-              sub: userId,
-              'custom:roles': '[]',
-            },
-          },
-        },
-      },
-      headers: { 'x-tenant-code': 'tenant-a' },
-    },
-    context: {},
-  }) as unknown as ICommandOptions['invokeContext']
-
-const makeCmd = (
-  id: string,
-  version: number,
-  isDeleted = false,
-): CommandModel => ({
-  pk: 'USER_TENANT#tenant-A',
-  sk: `USER_TENANT#${id}@${version}`,
-  id: `USER_TENANT#tenant-A#USER_TENANT#${id}`,
-  code: id,
-  name: id,
-  version,
-  tenantCode: 'tenant-A',
-  type: 'USER_TENANT',
-  isDeleted,
-  attributes: { role: 'admin' },
-  createdAt: new Date('2024-01-01'),
-  updatedAt: new Date('2024-01-02'),
-  createdBy: 'user-1',
-  updatedBy: 'user-1',
-})
-
-const makeDataModel = (id: string, version = 1): DataModel => ({
-  pk: 'USER_TENANT#tenant-A',
-  sk: `USER_TENANT#${id}`,
-  id: `USER_TENANT#tenant-A#USER_TENANT#${id}`,
-  code: id,
-  name: id,
-  version,
-  tenantCode: 'tenant-A',
-  type: 'USER_TENANT',
-  attributes: { role: 'viewer' },
-  cpk: 'USER_TENANT#tenant-A',
-  csk: `USER_TENANT#${id}@${version}`,
-  createdAt: new Date('2024-01-01'),
-  updatedAt: new Date('2024-01-01'),
-  createdBy: 'user-1',
-  updatedBy: 'user-1',
-})
-
-const mockDataService = {
-  tableName: PHYSICAL_DATA_TABLE,
-  getItem: jest.fn(),
-  listItemsByPk: jest.fn(),
-}
-
-const mockCommandService = {
-  getItem: jest.fn(),
-}
-
-const mockSessionService = {
-  get: jest.fn(),
-  listByUser: jest.fn(),
-}
-
-const mockOptions = { tableName: MODULE_TABLE }
+import { CommandService } from './command.service'
+import { SessionService } from '../data-store/session.service'
+import { MODULE_OPTIONS_TOKEN } from './command.module-definition'
+import {
+  DataEntity,
+  DataListEntity,
+  DataModel,
+  CommandModel,
+} from '../interfaces'
+import { KEY_SEPARATOR } from '../constants' // Import the actual separator
+import * as userContextHelper from '../context/user'
 
 describe('Repository', () => {
-  let repo: Repository
+  let repository: Repository
+  let dataService: jest.Mocked<DataService>
+  let commandService: jest.Mocked<CommandService>
+  let sessionService: jest.Mocked<SessionService>
+
+  const mockModuleOptions = { tableName: 'test-module' }
+  const mockTenant = 'tenant-123'
+  const mockUserId = 'user-456'
+
+  // IDs must follow the pattern: {TYPE}#{TENANT}#{BASE_SK}
+  const mockItemId = `TEST#${mockTenant}#ITEM-abc`
+  const mockPk = `TEST#${mockTenant}`
+  const mockSk = 'ITEM-abc'
 
   beforeEach(async () => {
-    jest.clearAllMocks()
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         Repository,
-        { provide: DataService, useValue: mockDataService },
-        { provide: CommandService, useValue: mockCommandService },
-        { provide: SessionService, useValue: mockSessionService },
-        { provide: MODULE_OPTIONS_TOKEN, useValue: mockOptions },
+        {
+          provide: DataService,
+          useValue: { getItem: jest.fn(), listItemsByPk: jest.fn() },
+        },
+        {
+          provide: CommandService,
+          useValue: { getItem: jest.fn() },
+        },
+        {
+          provide: SessionService,
+          useValue: {
+            get: jest.fn(),
+            delete: jest.fn(),
+            listByUser: jest.fn(),
+          },
+        },
+        {
+          provide: MODULE_OPTIONS_TOKEN,
+          useValue: mockModuleOptions,
+        },
       ],
     }).compile()
 
-    repo = module.get(Repository)
+    repository = module.get<Repository>(Repository)
+    dataService = module.get(DataService)
+    commandService = module.get(CommandService)
+    sessionService = module.get(SessionService)
+
+    jest.spyOn(userContextHelper, 'getUserContext').mockReturnValue({
+      userId: mockUserId,
+      tenantCode: mockTenant,
+    } as any)
+
+    sessionService.delete.mockResolvedValue(undefined)
   })
 
   describe('getItem', () => {
-    const key = { pk: 'USER_TENANT#tenant-A', sk: 'USER_TENANT#item-1' }
-    const opts = { invokeContext: makeInvokeContext() }
+    const detailKey = { pk: mockPk, sk: mockSk }
+    const options = { invokeContext: {} as any }
 
-    it('should return DataService result when no session exists', async () => {
-      mockSessionService.get.mockResolvedValue(null)
-      const dataItem = makeDataModel('item-1')
-      mockDataService.getItem.mockResolvedValue(dataItem)
+    it('should fetch from CommandService and merge if data table is lagging (v1 < v2)', async () => {
+      sessionService.get.mockResolvedValue({ version: 2 } as any)
 
-      const result = await repo.getItem(key, opts)
+      const laggingData = {
+        id: mockItemId,
+        pk: mockPk,
+        sk: mockSk,
+        version: 1,
+        name: 'old',
+      } as DataModel
 
-      expect(mockSessionService.get).toHaveBeenCalled()
-      expect(mockCommandService.getItem).not.toHaveBeenCalled()
-      expect(result).toEqual(dataItem)
-    })
+      const latestCommand = {
+        id: mockItemId,
+        pk: mockPk,
+        sk: `${mockSk}@2`, // Must have a version-suffixed SK
+        version: 2,
+        name: 'new',
+      } as CommandModel
 
-    it('should return transformed command when session exists', async () => {
-      mockSessionService.get.mockResolvedValue({
-        version: 3,
-        sk: `${MODULE_TABLE}#USER_TENANT#tenant-A#USER_TENANT#item-1`,
-      })
-      const cmd = makeCmd('item-1', 3)
-      mockCommandService.getItem.mockResolvedValue(cmd)
-      mockDataService.getItem.mockResolvedValue(makeDataModel('item-1', 2))
+      dataService.getItem.mockResolvedValue(laggingData)
+      commandService.getItem.mockResolvedValue(latestCommand)
 
-      const result = await repo.getItem(key, opts)
+      const result = await repository.getItem(detailKey, options)
 
-      expect(mockCommandService.getItem).toHaveBeenCalled()
-      expect(result.version).toBe(3)
-      expect(result.attributes).toEqual({ role: 'admin' })
-    })
-
-    it('should fallback to DataService when command not found', async () => {
-      mockSessionService.get.mockResolvedValue({ version: 3 })
-      mockCommandService.getItem.mockResolvedValue(null)
-      const dataItem = makeDataModel('item-1')
-      mockDataService.getItem.mockResolvedValue(dataItem)
-
-      const result = await repo.getItem(key, opts)
-
-      expect(result).toEqual(dataItem)
-    })
-
-    it('should fallback to DataService when userId is absent', async () => {
-      const noUserCtx = { invokeContext: makeInvokeContext('') }
-      const dataItem = makeDataModel('item-1')
-      mockDataService.getItem.mockResolvedValue(dataItem)
-
-      const result = await repo.getItem(key, noUserCtx)
-
-      expect(mockSessionService.get).not.toHaveBeenCalled()
-      expect(result).toEqual(dataItem)
+      expect(result.name).toBe('new')
+      expect(result.version).toBe(2)
     })
   })
 
   describe('listItemsByPk', () => {
-    const pk = 'USER_TENANT#tenant-A'
-    const opts = { invokeContext: makeInvokeContext() }
-
-    it('should return base result when latestFlg is false', async () => {
-      const base = {
-        items: [new DataEntity(makeDataModel('item-1'))],
-        lastSk: undefined,
-      }
-      mockDataService.listItemsByPk.mockResolvedValue(base)
-
-      const result = await repo.listItemsByPk(
-        pk,
-        {},
-        { latestFlg: false },
-        opts,
+    it('should prepend a new item if it exists in session but not in base results', async () => {
+      dataService.listItemsByPk.mockResolvedValue(
+        new DataListEntity({ items: [], lastSk: undefined }),
       )
 
-      expect(mockSessionService.listByUser).not.toHaveBeenCalled()
-      expect(result).toEqual(base)
-    })
-
-    it('should return base result when no sessions', async () => {
-      mockDataService.listItemsByPk.mockResolvedValue({
-        items: [],
-        lastSk: undefined,
-      })
-      mockSessionService.listByUser.mockResolvedValue([])
-
-      const result = await repo.listItemsByPk(pk, {}, { latestFlg: true }, opts)
-
-      expect(result.items).toHaveLength(0)
-    })
-
-    it('should override existing item (update case)', async () => {
-      const existingItem = makeDataModel('item-1', 1)
-      mockDataService.listItemsByPk.mockResolvedValue({
-        items: [new DataEntity(existingItem)],
-        lastSk: undefined,
-      })
-      mockSessionService.listByUser.mockResolvedValue([
+      // SK in Session table is: {module}#{itemId}
+      sessionService.listByUser.mockResolvedValue([
         {
-          pk: 'user-1#tenant-A',
-          sk: `${MODULE_TABLE}#USER_TENANT#tenant-A#USER_TENANT#item-1`,
-          version: 2,
-        },
-      ])
-      mockCommandService.getItem.mockResolvedValue(makeCmd('item-1', 2))
-
-      const result = await repo.listItemsByPk(pk, {}, { latestFlg: true }, opts)
-
-      expect(result.items).toHaveLength(1)
-      expect(result.items[0].version).toBe(2)
-    })
-
-    it('should remove item for delete case', async () => {
-      mockDataService.listItemsByPk.mockResolvedValue({
-        items: [
-          new DataEntity(makeDataModel('item-1')),
-          new DataEntity(makeDataModel('item-2')),
-        ],
-        lastSk: undefined,
-      })
-      mockSessionService.listByUser.mockResolvedValue([
-        {
-          pk: 'user-1#tenant-A',
-          sk: `${MODULE_TABLE}#USER_TENANT#tenant-A#USER_TENANT#item-1`,
-          version: 2,
-        },
-      ])
-      mockCommandService.getItem.mockResolvedValue(makeCmd('item-1', 2, true))
-
-      const result = await repo.listItemsByPk(pk, {}, { latestFlg: true }, opts)
-
-      expect(result.items).toHaveLength(1)
-      expect(result.items[0].id).toBe('USER_TENANT#tenant-A#USER_TENANT#item-2')
-    })
-
-    it('should add create-new item not yet synced', async () => {
-      mockDataService.listItemsByPk.mockResolvedValue({
-        items: [],
-        lastSk: undefined,
-      })
-      mockSessionService.listByUser.mockResolvedValue([
-        {
-          pk: 'user-1#tenant-A',
-          sk: `${MODULE_TABLE}#USER_TENANT#tenant-A#USER_TENANT#item-new`,
+          sk: `${mockModuleOptions.tableName}${KEY_SEPARATOR}${mockItemId}`,
           version: 1,
-        },
+        } as any,
       ])
-      mockCommandService.getItem.mockResolvedValue(makeCmd('item-new', 1))
 
-      const result = await repo.listItemsByPk(pk, {}, { latestFlg: true }, opts)
+      const newCmd = {
+        id: mockItemId,
+        pk: mockPk,
+        sk: `${mockSk}@1`,
+        version: 1,
+        updatedAt: new Date(),
+      } as any
+      commandService.getItem.mockResolvedValue(newCmd)
 
-      expect(result.items).toHaveLength(1)
-      expect(result.items[0].id).toBe(
-        'USER_TENANT#tenant-A#USER_TENANT#item-new',
+      const result = await repository.listItemsByPk(
+        mockPk,
+        {},
+        { latestFlg: true },
+        { invokeContext: {} } as any,
       )
+
+      expect(result.items.length).toBe(1)
+      expect(result.items[0].id).toBe(mockItemId)
     })
   })
 
-  describe('listItems', () => {
-    const opts = { invokeContext: makeInvokeContext() }
-
-    type RdsItem = {
-      id: string
-      pk?: string
-      sk?: string
-      tenantCode: string
-      role: string
-    }
-
-    const makeRdsItem = (id: string): RdsItem => ({
-      id: `USER_TENANT#tenant-A#USER_TENANT#${id}`,
-      pk: 'USER_TENANT#tenant-A',
-      sk: `USER_TENANT#${id}`,
-      tenantCode: 'tenant-A',
-      role: 'viewer',
-    })
-
-    const mergeOpts: IMergeOptions<RdsItem> = {
-      latestFlg: true,
-      transformCommand: (cmd) => ({
-        id: cmd.id,
-        tenantCode: cmd.tenantCode,
-        pk: 'USER_TENANT#tenant-A',
-        sk: `USER_TENANT#${cmd.code}`,
-        role: (cmd.attributes as { role?: string })?.role ?? 'viewer',
-      }),
-      matchesFilter: (item) => item.role !== 'blocked',
-    }
-
-    it('should passthrough when latestFlg is false', async () => {
-      const rdsQuery = jest
-        .fn()
-        .mockResolvedValue({ total: 1, items: [makeRdsItem('item-1')] })
-
-      const result = await repo.listItems(
-        rdsQuery,
-        { ...mergeOpts, latestFlg: false },
-        opts,
-      )
-
-      expect(mockSessionService.listByUser).not.toHaveBeenCalled()
-      expect(result.total).toBe(1)
-    })
-
-    it('should return rds result when no sessions', async () => {
-      const rdsQuery = jest
-        .fn()
-        .mockResolvedValue({ total: 1, items: [makeRdsItem('item-1')] })
-      mockSessionService.listByUser.mockResolvedValue([])
-
-      const result = await repo.listItems(rdsQuery, mergeOpts, opts)
-
-      expect(result.total).toBe(1)
-    })
-
-    it('should use request tenant for session lookup, not row tenantCode', async () => {
-      mockSessionService.listByUser.mockResolvedValue([])
-      const rdsQuery = jest.fn().mockResolvedValue({
+  describe('listItems (External Source/RDS)', () => {
+    it('should call dataService.getItem for each session to check sync status', async () => {
+      const mockRdsQuery = jest.fn().mockResolvedValue({
         total: 1,
-        items: [
-          {
-            ...makeRdsItem('item-1'),
-            tenantCode: 'common',
-          },
-        ],
+        items: [{ id: mockItemId }],
       })
 
-      await repo.listItems(rdsQuery, mergeOpts, opts)
-
-      expect(mockSessionService.listByUser).toHaveBeenCalledWith(
-        'user-1',
-        'tenant-a',
-        MODULE_TABLE,
-      )
-    })
-
-    it('should override existing item (update)', async () => {
-      const rdsQuery = jest.fn().mockResolvedValue({
-        total: 1,
-        items: [makeRdsItem('item-1')],
-      })
-      mockSessionService.listByUser.mockResolvedValue([
+      sessionService.listByUser.mockResolvedValue([
         {
-          pk: 'user-1#tenant-A',
-          sk: `${MODULE_TABLE}#USER_TENANT#tenant-A#USER_TENANT#item-1`,
-          version: 2,
-        },
+          sk: `${mockModuleOptions.tableName}${KEY_SEPARATOR}${mockItemId}`,
+          version: 10,
+        } as any,
       ])
-      const cmd = makeCmd('item-1', 2)
-      cmd.attributes = { role: 'admin' }
-      mockCommandService.getItem.mockResolvedValue(cmd)
 
-      const result = await repo.listItems(rdsQuery, mergeOpts, opts)
+      // Data item must have matching PK/SK to stop the parser from failing
+      dataService.getItem.mockResolvedValue({
+        id: mockItemId,
+        pk: mockPk,
+        sk: mockSk,
+        version: 10,
+      } as any)
 
-      expect(result.total).toBe(1)
-      expect(result.items[0].role).toBe('admin')
-    })
-
-    it('should remove deleted item', async () => {
-      const rdsQuery = jest.fn().mockResolvedValue({
-        total: 2,
-        items: [makeRdsItem('item-1'), makeRdsItem('item-2')],
-      })
-      mockSessionService.listByUser.mockResolvedValue([
-        {
-          pk: 'user-1#tenant-A',
-          sk: `${MODULE_TABLE}#USER_TENANT#tenant-A#USER_TENANT#item-1`,
-          version: 2,
-        },
-      ])
-      mockCommandService.getItem.mockResolvedValue(makeCmd('item-1', 2, true))
-
-      const result = await repo.listItems(rdsQuery, mergeOpts, opts)
-
-      expect(result.total).toBe(1)
-      expect(result.items.find((i) => i.id.includes('item-1'))).toBeUndefined()
-    })
-
-    it('should append create-new item that passes matchesFilter', async () => {
-      const rdsQuery = jest
-        .fn()
-        .mockResolvedValue({ total: 1, items: [makeRdsItem('item-1')] })
-      mockSessionService.listByUser.mockResolvedValue([
-        {
-          pk: 'user-1#tenant-A',
-          sk: `${MODULE_TABLE}#USER_TENANT#tenant-A#USER_TENANT#item-new`,
-          version: 1,
-        },
-      ])
-      const cmd = makeCmd('item-new', 1)
-      cmd.attributes = { role: 'admin' }
-      mockCommandService.getItem.mockResolvedValue(cmd)
-
-      const result = await repo.listItems(rdsQuery, mergeOpts, opts)
-
-      expect(result.total).toBe(2)
-      expect(result.items.find((i) => i.id.includes('item-new'))).toBeDefined()
-    })
-
-    it('should NOT append create-new item that fails matchesFilter', async () => {
-      const rdsQuery = jest
-        .fn()
-        .mockResolvedValue({ total: 1, items: [makeRdsItem('item-1')] })
-      mockSessionService.listByUser.mockResolvedValue([
-        {
-          pk: 'user-1#tenant-A',
-          sk: `${MODULE_TABLE}#USER_TENANT#tenant-A#USER_TENANT#item-blocked`,
-          version: 1,
-        },
-      ])
-      const cmd = makeCmd('item-blocked', 1)
-      cmd.attributes = { role: 'blocked' }
-      mockCommandService.getItem.mockResolvedValue(cmd)
-
-      const result = await repo.listItems(rdsQuery, mergeOpts, opts)
-
-      expect(result.total).toBe(1)
-      expect(
-        result.items.find((i) => i.id.includes('item-blocked')),
-      ).toBeUndefined()
-    })
-
-    it('should append create-new item when matchesFilter is not provided', async () => {
-      const rdsQuery = jest.fn().mockResolvedValue({ total: 0, items: [] })
-      mockSessionService.listByUser.mockResolvedValue([
-        {
-          pk: 'user-1#tenant-A',
-          sk: `${MODULE_TABLE}#USER_TENANT#tenant-A#USER_TENANT#item-new`,
-          version: 1,
-        },
-      ])
-      mockCommandService.getItem.mockResolvedValue(makeCmd('item-new', 1))
-
-      const optsNoFilter: IMergeOptions<RdsItem> = {
+      const mergeOptions: IMergeOptions<any> = {
         latestFlg: true,
-        transformCommand: (cmd) => ({
-          id: cmd.id,
-          tenantCode: cmd.tenantCode,
-          role: 'admin',
-        }),
+        transformCommand: (cmd) => cmd,
       }
 
-      const result = await repo.listItems(rdsQuery, optsNoFilter, opts)
+      await repository.listItems(mockRdsQuery, mergeOptions, {
+        invokeContext: {},
+      } as any)
 
-      expect(result.total).toBe(1)
+      expect(dataService.getItem).toHaveBeenCalled()
+      expect(sessionService.delete).toHaveBeenCalled()
     })
   })
 })

--- a/packages/core/src/commands/repository.ts
+++ b/packages/core/src/commands/repository.ts
@@ -82,13 +82,25 @@ export class Repository {
           `getItem session merge — version ${session.version}`,
           key,
         )
+
+        // Fetch existing data FIRST to check if the session is stale
+        const existing = await this.dataService.getItem(key)
+
+        // If data table has caught up or surpassed the session, the session is stale
+        if (existing && existing.version >= session.version) {
+          this.sessionService
+            .delete(userId, tenantCode, this.moduleTableName, itemId)
+            .catch(() => {})
+          return existing
+        }
+
+        // Otherwise, data is still lagging. Fetch the command to project it.
         const cmd = await this.commandService.getItem({
           pk: key.pk,
           sk: addSortKeyVersion(key.sk, session.version),
         })
 
         if (cmd) {
-          const existing = await this.dataService.getItem(key)
           return transformCommandToData(cmd, existing)
         }
       }
@@ -172,6 +184,15 @@ export class Repository {
       const itemId = session.sk.slice(skPrefix.length)
 
       const existing = itemMap.get(itemId) as DataModel | undefined
+
+      // If the item in the list already caught up to the session, clear the session and skip merge
+      if (existing && existing.version >= session.version) {
+        this.sessionService
+          .delete(userId, tenantCode, this.moduleTableName, itemId)
+          .catch(() => {})
+        continue
+      }
+
       const cmdPk = pk
       let skBase: string | undefined
 
@@ -314,6 +335,17 @@ export class Repository {
       }
 
       if (!cmdPk || !skBase) {
+        continue
+      }
+
+      // Fetch the actual current data record to see if it has caught up
+      const dataItem = await this.dataService.getItem({ pk: cmdPk, sk: skBase })
+
+      // If data table has caught up or surpassed the session, the session is stale
+      if (dataItem && dataItem.version >= session.version) {
+        this.sessionService
+          .delete(userId, tenantCode, this.moduleTableName, itemId)
+          .catch(() => {})
         continue
       }
 

--- a/packages/core/src/commands/repository.ts
+++ b/packages/core/src/commands/repository.ts
@@ -32,6 +32,13 @@ export interface IMergeOptions<TItem extends { id: string }> {
   latestFlg?: boolean
 
   /**
+   * Optional: Extract version from the query result item (e.g. RDS row).
+   * If the provided version is >= session.version, the DynamoDB Data Table
+   * check is skipped to reduce latency.
+   */
+  getVersion?: (item: TItem) => number | undefined
+
+  /**
    * Transform a CommandModel into the same shape as a TItem returned by the query.
    * The `existing` parameter is provided for update cases to merge unchanged fields.
    */
@@ -86,11 +93,15 @@ export class Repository {
         // Fetch existing data FIRST to check if the session is stale
         const existing = await this.dataService.getItem(key)
 
-        // If data table has caught up or surpassed the session, the session is stale
+        /**
+         * If the data table version is greater than or equal to the session version,
+         * the read model has already absorbed the user's specific write (or a newer one).
+         * We purge the stale session in the background and return the persisted data.
+         */
         if (existing && existing.version >= session.version) {
           this.sessionService
             .delete(userId, tenantCode, this.moduleTableName, itemId)
-            .catch(() => {})
+            .catch(() => {}) // Fire-and-forget: do not block the critical read path
           return existing
         }
 
@@ -303,58 +314,81 @@ export class Repository {
     const itemMap = new Map<string, TItem>(
       baseResult.items.map((item) => [item.id, item]),
     )
-    const newItems: TItem[] = []
-    let adjustedTotal = baseResult.total
+
     const skPrefix = `${this.moduleTableName}${KEY_SEPARATOR}`
 
-    for (const session of sessions) {
-      if (!session.sk.startsWith(skPrefix)) {
-        continue
-      }
-      const itemId = session.sk.slice(skPrefix.length)
+    /**
+     * Parallelize session checks to avoid N+1 sequential database roundtrips.
+     * For each session, we determine if we need to merge a command or skip if synced.
+     */
+    const sessionResults = await Promise.all(
+      sessions.map(async (session) => {
+        if (!session.sk.startsWith(skPrefix)) return null
+        const itemId = session.sk.slice(skPrefix.length)
+        const existing = itemMap.get(itemId)
 
-      const existing = itemMap.get(itemId)
+        let cmdPk: string | undefined
+        let skBase: string | undefined
 
-      let cmdPk: string | undefined
-      let skBase: string | undefined
+        const existingSk = (existing as unknown as { sk?: string })?.sk
+        const existingPk = (existing as unknown as { pk?: string })?.pk
 
-      const existingSk = (existing as unknown as { sk?: string })?.sk
-      const existingPk = (existing as unknown as { pk?: string })?.pk
-
-      if (existing && existingSk && existingPk) {
-        cmdPk = existingPk
-        skBase = removeSortKeyVersion(existingSk)
-      } else {
-        // Fallback: Strictly parse the ID assuming a 2-segment PK format ({type}#{tenantCode})
-        const parsed = parseTwoSegmentPkSkFromId(itemId)
-        if (!parsed) {
-          continue
+        if (existing && existingSk && existingPk) {
+          cmdPk = existingPk
+          skBase = removeSortKeyVersion(existingSk)
+        } else {
+          // Fallback: Strictly parse the ID assuming a 2-segment PK format ({type}#{tenantCode})
+          const parsed = parseTwoSegmentPkSkFromId(itemId)
+          if (!parsed) return null
+          cmdPk = parsed.pk
+          skBase = parsed.skBase
         }
-        cmdPk = parsed.pk
-        skBase = parsed.skBase
+
+        if (!cmdPk || !skBase) return null
+
+        // Optimization: check item version provided by the external source first
+        const currentVersion = existing
+          ? mergeOptions.getVersion?.(existing)
+          : undefined
+        if (currentVersion !== undefined && currentVersion >= session.version) {
+          this.sessionService
+            .delete(userId, tenantCode, this.moduleTableName, itemId)
+            .catch(() => {})
+          return { type: 'synced', itemId }
+        }
+
+        // Verify state against DynamoDB Data Table
+        const dataItem = await this.dataService.getItem({
+          pk: cmdPk,
+          sk: skBase,
+        })
+        if (dataItem && dataItem.version >= session.version) {
+          this.sessionService
+            .delete(userId, tenantCode, this.moduleTableName, itemId)
+            .catch(() => {})
+          return { type: 'synced', itemId }
+        }
+
+        const cmd = await this.commandService.getItem({
+          pk: cmdPk,
+          sk: addSortKeyVersion(skBase, session.version),
+        })
+
+        return cmd ? { type: 'command', cmd, existing, itemId } : null
+      }),
+    )
+
+    const newItems: TItem[] = []
+    let adjustedTotal = baseResult.total
+
+    for (const res of sessionResults) {
+      if (!res || res.type === 'synced') continue
+
+      const { cmd, existing, itemId } = res as {
+        cmd: CommandModel
+        existing?: TItem
+        itemId: string
       }
-
-      if (!cmdPk || !skBase) {
-        continue
-      }
-
-      // Fetch the actual current data record to see if it has caught up
-      const dataItem = await this.dataService.getItem({ pk: cmdPk, sk: skBase })
-
-      // If data table has caught up or surpassed the session, the session is stale
-      if (dataItem && dataItem.version >= session.version) {
-        this.sessionService
-          .delete(userId, tenantCode, this.moduleTableName, itemId)
-          .catch(() => {})
-        continue
-      }
-
-      const cmd = await this.commandService.getItem({
-        pk: cmdPk,
-        sk: addSortKeyVersion(skBase, session.version),
-      })
-      if (!cmd) continue
-
       const transformed = mergeOptions.transformCommand(cmd, existing)
 
       if (cmd.isDeleted) {

--- a/packages/core/src/data-store/dynamodb.service.spec.ts
+++ b/packages/core/src/data-store/dynamodb.service.spec.ts
@@ -1,4 +1,5 @@
 import {
+  DeleteItemCommand,
   DynamoDBClient,
   GetItemCommand,
   PutItemCommand,
@@ -16,7 +17,6 @@ import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3'
 import { sdkStreamMixin } from '@smithy/util-stream'
 import { Readable } from 'stream'
 import { ulid } from 'ulid'
-import { toISOStringWithTimezone } from '../helpers'
 
 const keys = {
   NODE_ENV: 'env',
@@ -51,6 +51,26 @@ describe('DynamoDbService', () => {
     jest.clearAllMocks()
     dynamoDBMock.reset()
     s3Mock.reset()
+  })
+
+  describe('deleteItem', () => {
+    it('should send DeleteItemCommand with the correct parameters', async () => {
+      // Arrange
+      dynamoDBMock.on(DeleteItemCommand).resolves({})
+      const key = { pk: 'master', sk: 'test' }
+
+      // Action
+      await dynamoDbService.deleteItem('table_name', key)
+
+      // Assert
+      expect(dynamoDBMock).toHaveReceivedCommandWith(DeleteItemCommand, {
+        TableName: 'table_name',
+        Key: {
+          pk: { S: 'master' },
+          sk: { S: 'test' },
+        },
+      })
+    })
   })
 
   describe('get', () => {

--- a/packages/core/src/data-store/dynamodb.service.ts
+++ b/packages/core/src/data-store/dynamodb.service.ts
@@ -1,5 +1,6 @@
 import {
   AttributeValue,
+  DeleteItemCommand,
   DynamoDBClient,
   GetItemCommand,
   PutItemCommand,
@@ -124,6 +125,17 @@ export class DynamoDbService {
     )
 
     return await this.ddbItemToObj(Item)
+  }
+
+  async deleteItem(tableName: string, key: DetailKey, conditions?: string) {
+    const res = await this.client.send(
+      new DeleteItemCommand({
+        TableName: tableName,
+        Key: this.toDdbKey(key),
+        ConditionExpression: conditions,
+      }),
+    )
+    return res
   }
 
   async listItemsByPk(

--- a/packages/core/src/data-store/session.service.spec.ts
+++ b/packages/core/src/data-store/session.service.spec.ts
@@ -7,14 +7,17 @@ import { DynamoDbService } from './dynamodb.service'
 
 describe('SessionService', () => {
   let service: SessionService
+  let dynamoDbService: Partial<DynamoDbService>
   let putItem: jest.Mock
   let getItem: jest.Mock
   let listItemsByPk: jest.Mock
+  let deleteItem: jest.Mock
 
   beforeEach(async () => {
     putItem = jest.fn().mockResolvedValue(undefined)
     getItem = jest.fn()
     listItemsByPk = jest.fn()
+    deleteItem = jest.fn().mockResolvedValue({})
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -25,6 +28,7 @@ describe('SessionService', () => {
             putItem,
             getItem,
             listItemsByPk,
+            deleteItem,
           },
         },
         {
@@ -44,6 +48,42 @@ describe('SessionService', () => {
     }).compile()
 
     service = module.get(SessionService)
+    dynamoDbService = module.get(DynamoDbService)
+  })
+
+  describe('delete', () => {
+    it('should call deleteItem with the correct session key', async () => {
+      await service.delete('u1', 't1', 'mod', 'id1')
+
+      expect(deleteItem).toHaveBeenCalledWith('local-test-app-session', {
+        pk: `u1${KEY_SEPARATOR}t1`,
+        sk: `mod${KEY_SEPARATOR}id1`,
+      })
+    })
+
+    it('should handle deletion errors gracefully (non-fatal)', async () => {
+      deleteItem.mockRejectedValue(new Error('Dynamo failure'))
+
+      // Should not throw
+      await expect(
+        service.delete('u1', 't1', 'mod', 'id1'),
+      ).resolves.not.toThrow()
+    })
+
+    it('should no-op if session writes are disabled', async () => {
+      // Setup a service instance where sessionWritesEnabled will be false
+      const mod = await Test.createTestingModule({
+        providers: [
+          SessionService,
+          { provide: DynamoDbService, useValue: { deleteItem: jest.fn() } },
+          { provide: ConfigService, useValue: { get: () => undefined } },
+        ],
+      }).compile()
+      const s = mod.get(SessionService)
+
+      await s.delete('u1', 't1', 'mod', 'id1')
+      expect(mod.get(DynamoDbService).deleteItem).not.toHaveBeenCalled()
+    })
   })
 
   it('should put item with ttl field', async () => {

--- a/packages/core/src/data-store/session.service.ts
+++ b/packages/core/src/data-store/session.service.ts
@@ -115,6 +115,32 @@ export class SessionService {
   }
 
   /**
+   * Delete a session entry.
+   * Used to clean up the session once the data table has caught up to the command version.
+   */
+  async delete(
+    userId: string,
+    tenantCode: string,
+    moduleTableName: string,
+    itemId: string,
+  ): Promise<void> {
+    if (!this.sessionWritesEnabled) return
+
+    const key = {
+      pk: this.buildPk(userId, tenantCode),
+      sk: this.buildSk(moduleTableName, itemId),
+    }
+
+    try {
+      await this.dynamoDbService.deleteItem(this.sessionTableName, key)
+    } catch (error) {
+      this.logger.warn(
+        `Failed to delete RYW session (non-fatal): ${error instanceof Error ? error.message : 'Unknown error'}`,
+      )
+    }
+  }
+
+  /**
    * List session entries for a user scoped to a command module.
    *
    * Queries the session table by `{userId}#{tenantCode}` and filters to entries


### PR DESCRIPTION

## **Overview**
Currently, RYW sessions persist until their TTL expires, regardless of whether the underlying read model (Data Table) has synchronized. This leads to a "stale override" where a user might see their own older version of an item even after a more recent update has been processed by an external system or another user.

This PR introduces an **optimized cleanup strategy**: the `Repository` now compares the version of the persisted data against the session version. If the data is caught up, the session is purged immediately in the background, and the latest persisted data is returned.

---

## **Key Changes**

### **1. Core Infrastructure**
* **`DynamoDbService`**: Implemented `deleteItem` to support session purging.
* **`SessionService`**: Added a `delete` method with built-in error handling to ensure session cleanup is non-fatal and does not block the primary request.

### **2. Repository Logic Optimization**
* **`getItem`**: Intercepts the fetch logic to check the data table version first. If synchronized, it purges the session and returns the data, skipping unnecessary calls to the Command table.
* **`listItemsByPk`**: Added a version check within the merge loop to clean up synchronized items in-place.
* **`listItems` (RDS/External)**: Explicitly queries the DynamoDB data table for each active session to determine if the read model has surpassed the user's pending session, triggering cleanup if so.
