### PR TITLE
feat(mcp-server): add v1.2.6 RYW guidance and align detector/skill AP codes

### DIFF
--- a/packages/mcp-server/skills/mbc-debug/SKILL.md
+++ b/packages/mcp-server/skills/mbc-debug/SKILL.md
@@ -294,7 +294,38 @@ export class AppModule {}
 
 ---
 
-### 8. Import Processing Issues
+### 8. RYW Session Disappears Before TTL Expiration (v1.2.6+)
+
+**Symptom:** Session entry deleted from `{NODE_ENV}-{APP_NAME}-session` table before `RYW_SESSION_TTL_MINUTES` elapses.
+
+**Cause (intentional, since v1.2.6):** `Repository` proactively purges sessions once the data table catches up (`existing.version >= session.version`). Once your write is visible in the data table, the session is no longer needed — keeping it would cause stale overrides when external updates arrive.
+
+**How to verify the purge succeeded normally:**
+```typescript
+// Check application logs. Absence of this warning means the delete succeeded:
+//   "Failed to delete RYW session (non-fatal): ..."
+//
+// You can also enable Repository debug logs to see the purge decision:
+//   logger.debug(`getItem session merge — version ${session.version}`, key)
+```
+
+**When it's a real problem:** If sessions disappear *and* `Repository.getItem` still returns stale data, the issue is upstream — DynamoDB Streams sync may be delayed. Check `IteratorAge` on the DynamoDB Streams source; a sustained non-zero value indicates the Stream → `IDataSyncHandler` pipeline is falling behind:
+```bash
+# Inspect Stream lag (high IteratorAge = sync is behind = data table stays stale)
+aws cloudwatch get-metric-statistics \
+  --namespace AWS/Lambda \
+  --metric-name IteratorAge \
+  --dimensions Name=FunctionName,Value=your-data-sync-handler \
+  --start-time $(date -u -v-1H +%Y-%m-%dT%H:%M:%S) \
+  --end-time   $(date -u            +%Y-%m-%dT%H:%M:%S) \
+  --period 60 --statistics Maximum
+```
+
+**Related:** If you maintain RDS read models, supply `mergeOptions.getVersion` in `listItems()` to skip the extra DynamoDB round-trip when the RDS row already carries the latest version (see migration guide v1.2.6).
+
+---
+
+### 9. Import Processing Issues
 
 **Symptom:** Import job fails or gets stuck
 
@@ -340,7 +371,7 @@ const validateCsv = async (filePath: string) => {
 
 ---
 
-### 6. Performance Issues
+### 10. Performance Issues
 
 **Symptom:** Slow API responses
 

--- a/packages/mcp-server/skills/mbc-migrate/SKILL.md
+++ b/packages/mcp-server/skills/mbc-migrate/SKILL.md
@@ -39,6 +39,8 @@ This skill helps migrate MBC CQRS Serverless projects between versions.
 | v1.2.0 | v1.2.1 | Low | SqsService added (new feature) |
 | v1.2.1 | v1.2.2 | Low | CsvBatchProcessor Poison Pill fix (transparent) |
 | v1.2.x | v1.2.4 | Medium | TaskModule.register() must be in AppModule |
+| v1.2.4 | v1.2.5 | Low | ZIP import refactor (transparent); MCP AP016–AP020 added |
+| v1.2.5 | v1.2.6 | Low | Repository RYW improvements (transparent); `getVersion` API |
 
 ## Migration Guides
 
@@ -335,6 +337,64 @@ export class AppModule {}
 3. Remove `TaskModule.register()` from all feature modules
 
 **Symptom if skipped:** App crashes at startup with `Nest can't resolve dependencies of MyTaskService (?)`.
+
+---
+
+### v1.2.5 — ZIP import refactor + MCP anti-pattern expansion (no migration steps required)
+
+**Framework changes (transparent):**
+
+- `ZipImportQueueEventHandler` removed; ZIP import jobs are now processed directly inside `ImportService`.
+- `ImportEventHandler` no longer publishes SQS messages for `ZIP_MASTER_JOB` events.
+- Enhanced ZIP import validation in `CreateZipImportDto` and improved error handling/logging.
+
+No application code changes are required. If you previously imported `ZipImportQueueEventHandler` directly (uncommon), remove the import.
+
+**MCP server changes:**
+
+- `mbc_check_anti_patterns` tool expanded from 15 to 20 detectors (AP016–AP020 added):
+  - AP016: Missing Error Logging Before Rethrow (High)
+  - AP017: Incorrect Attribute Merging on Partial Update (High)
+  - AP018: Missing Swagger Documentation / `@ApiTags` (Low)
+  - AP019: Missing Pagination in List Queries (High)
+  - AP020: Missing `getCommandSource` for Tracing (Low)
+- `@modelcontextprotocol/sdk` updated 1.26.0 → 1.29.0.
+
+---
+
+### v1.2.6 — Repository RYW improvements (no migration steps required)
+
+The `Repository` class now actively purges stale RYW sessions when the data table catches up to or surpasses the session version. This eliminates the "stale override" issue where a user could see their own older write even after an external update was already absorbed into the data table.
+
+**Behavior changes (transparent — no code changes required):**
+
+- `getItem`: when `existing.version >= session.version`, the session is purged in the background and the persisted data is returned directly (skipping the unnecessary command-table read).
+- `listItemsByPk`: synchronized sessions are cleaned up in-place during the merge loop.
+- `listItems` (RDS path): per-session checks are now parallelized via `Promise.all`, eliminating sequential N+1 latency.
+
+**New optional optimization for `listItems`:**
+
+```typescript
+// If your RDS rows already carry `version`, supply `getVersion` to skip the
+// extra DynamoDB GetItem entirely when the existing RDS row proves caught-up.
+await repository.listItems(
+  () => rdsQuery(),
+  {
+    latestFlg: true,
+    transformCommand: (cmd) => ({
+      id: cmd.id,
+      version: cmd.version,
+      // ...map other CommandModel fields to your RDS row shape
+    }),
+    getVersion: (item) => item.version,  // ← new in v1.2.6
+  },
+  options,
+)
+```
+
+**Note:** `getVersion` only short-circuits the **update path** (when the session's `itemId` matches an existing RDS row). Create-new items (session present but not yet reflected in RDS) still fetch the command as before — there is no existing row to derive a version from.
+
+All changes are backward-compatible: `getVersion` is optional, and the cleanup behavior is automatic when `RYW_SESSION_TTL_MINUTES` is enabled. Projects with RYW disabled (env var unset) are unaffected.
 
 ---
 

--- a/packages/mcp-server/skills/mbc-review/SKILL.md
+++ b/packages/mcp-server/skills/mbc-review/SKILL.md
@@ -21,6 +21,43 @@ Before executing this skill, check for updates:
 
 This skill reviews code for MBC CQRS Serverless best practices and identifies anti-patterns.
 
+## ⚠️ Important: Two Anti-Pattern Code Systems
+
+This codebase currently has **two independent `AP00X` numbering systems** that are NOT interchangeable:
+
+1. **Skill `AP` codes** (this document) — used in human-facing reviews and documentation. Stable identifiers for discussion.
+2. **Detector `AP` codes** (output of the `mbc_check_anti_patterns` tool, defined in `src/tools/analyze.ts`) — used by the static analysis tool. Numbered in detector implementation order.
+
+**Only AP016, AP017, AP018, AP019, and AP021 happen to refer to the same concept in both systems.** All other AP numbers diverge — for example, the detector's `AP005: Hardcoded Tenant` corresponds to this document's `AP002: Missing tenantCode`. Do not assume the codes match.
+
+**Cross-reference table** (detector → skill doc):
+
+| Detector code (analyze.ts) | Skill doc code (this file) | Topic |
+|---|---|---|
+| AP001 Direct DynamoDB Write | AP012 | Bypassing CommandService / DataService |
+| AP002 Ignored Version Mismatch | AP005 | ConditionalCheckFailedException handling |
+| AP003 N+1 Query Pattern | — (detector only) | Query in a loop |
+| AP004 Full Table Scan | — (detector only) | `.scan()` usage |
+| AP005 Hardcoded Tenant | AP002 | Multi-tenant code/key handling |
+| AP006 Missing Tenant Validation | AP002 | Trusting client-provided `tenantCode` |
+| AP007 Throwing in Sync Handler | — (detector only) | DataSyncHandler error escape |
+| AP008 Hardcoded Secret | — (detector only) | Secrets in code |
+| AP009 Manual JWT Parsing | — (detector only) | Bypassing Cognito authorizer |
+| AP010 Heavy Module Import | — (detector only) | Cold-start optimization |
+| AP011 Deprecated Method Usage | AP010 | `publish()` / `publishPartialUpdate()` removal |
+| AP012 Uppercase COMMON Tenant Key | — (detector only) | v1.1.0 tenant key migration |
+| AP013 publishSync Null Return Unchecked | AP001 (related) | `publishSync` v1.2.0+ return |
+| AP014 Deprecated genNewSequence | AP010 (related) | v1.2.0 sequence API change |
+| AP015 Duplicate TaskModule Registration | — (detector only) | v1.2.4 global TaskModule |
+| AP016 Missing Error Logging Before Rethrow | AP016 | ✅ same code |
+| AP017 Incorrect Attribute Merging | AP017 | ✅ same code |
+| AP018 Missing Swagger Documentation | AP018 | ✅ same code |
+| AP019 Missing Pagination in List Queries | AP019 | ✅ same code |
+| AP020 Missing getCommandSource for Tracing | AP011 | Tracing/audit |
+| AP021 Event Emit After publishAsync | AP021 | ✅ same code |
+
+When you receive `mbc_check_anti_patterns` output, look up the detector code in this table to find the corresponding skill-doc section for full context and recommended fixes. Future versions of this framework should consolidate the two systems; until then, treat them as separate identifier spaces.
+
 ## Anti-Patterns to Detect
 
 ### AP001: Using publishSync Instead of publishAsync
@@ -555,6 +592,10 @@ export class OrderDataSyncHandler implements IDataSyncHandler {
 The correct pattern is to implement a custom `IDataSyncHandler` and emit events in `up()` / `down()`. By the time these methods run, the data table write has already completed. Register the handler in `CommandModule.register({ dataSyncHandlers: [...] })`.
 
 If you need to include previous field values for change-detection (e.g., `statusChanged`), embed them as `attributes._prev` in the `publishAsync` call and read them in the handler. Strip `_prev` from RDS sync handlers to prevent internal metadata from leaking into the database.
+
+**Related (v1.2.6+):** If you only need read-your-writes consistency for the **same user within the same request flow** (e.g. POST → immediate GET in the API client), the Repository's RYW session mechanism (when `RYW_SESSION_TTL_MINUTES` is enabled) is sufficient — it merges the pending command-table write into the next read by the originating user, no event handler required.
+
+The `IDataSyncHandler.up()` pattern above is still required when other users, background jobs, or cross-module event subscribers need to react to the change — RYW only covers the writer's own subsequent reads.
 
 ---
 

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -11,10 +11,24 @@ import {
   McpError,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js'
+import { readFileSync } from 'fs'
+import { join } from 'path'
 
 import { handlePromptGet, registerPrompts } from './prompts/index.js'
 import { handleResourceRead, registerResources } from './resources/index.js'
 import { handleToolCall, registerTools } from './tools/index.js'
+
+// Read version from package.json so it stays in sync after `lerna version` bumps.
+const PACKAGE_VERSION: string = (() => {
+  try {
+    const pkg = JSON.parse(
+      readFileSync(join(__dirname, '..', 'package.json'), 'utf8'),
+    )
+    return pkg.version ?? '0.0.0'
+  } catch {
+    return '0.0.0'
+  }
+})()
 
 /**
  * MCP Server for MBC CQRS Serverless framework.
@@ -30,7 +44,7 @@ export class McpServer {
     this.server = new Server(
       {
         name: 'mbc-cqrs-serverless',
-        version: '0.1.74-beta.0',
+        version: PACKAGE_VERSION,
       },
       {
         capabilities: {

--- a/packages/mcp-server/src/tools/analyze.ts
+++ b/packages/mcp-server/src/tools/analyze.ts
@@ -460,7 +460,17 @@ interface AntiPatternMatch {
 
 /**
  * Anti-patterns to check for.
- * Codes are sequential from AP001 to AP010.
+ *
+ * Codes are sequential from AP001 to AP021 in detector-implementation order.
+ *
+ * IMPORTANT: These detector codes are a SEPARATE numbering system from the AP codes
+ * used in `skills/mbc-review/SKILL.md`. Only AP016, AP017, AP018, AP019, and AP021
+ * happen to refer to the same concept in both systems. See the cross-reference
+ * table at the top of `skills/mbc-review/SKILL.md` to map a detector code to its
+ * corresponding skill-doc section.
+ *
+ * When adding a new detector, append at the end (do not renumber) and update the
+ * cross-reference table in `skills/mbc-review/SKILL.md`.
  */
 const ANTI_PATTERNS = [
   {
@@ -655,6 +665,30 @@ const ANTI_PATTERNS = [
 ]
 
 /**
+ * Maps a detector AP code (this file) to the corresponding skill-doc AP code in
+ * `skills/mbc-review/SKILL.md`. Used to annotate detector output so users can
+ * navigate from a detector hit to the human-readable explanation.
+ *
+ * Codes not present in the map are detector-only (no skill-doc counterpart).
+ * Keep this table in sync with the cross-reference table in SKILL.md.
+ */
+const DETECTOR_TO_SKILL_AP: Record<string, string> = {
+  AP001: 'AP012', // Direct DynamoDB Write → Direct DynamoDB Access Instead of DataService
+  AP002: 'AP005', // Ignored Version Mismatch → Not Handling ConditionalCheckFailedException
+  AP005: 'AP002', // Hardcoded Tenant → Missing tenantCode in Multi-Tenant Operations
+  AP006: 'AP002', // Missing Tenant Validation → Missing tenantCode in Multi-Tenant Operations
+  AP011: 'AP010', // Deprecated Method Usage → Deprecated Method Usage
+  AP013: 'AP001', // publishSync Null Return Unchecked → Using publishSync Instead of publishAsync (related)
+  AP014: 'AP010', // Deprecated genNewSequence → Deprecated Method Usage (related)
+  AP016: 'AP016', // Missing Error Logging Before Rethrow ✅
+  AP017: 'AP017', // Incorrect Attribute Merging ✅
+  AP018: 'AP018', // Missing Swagger Documentation ✅
+  AP019: 'AP019', // Missing Pagination in List Queries ✅
+  AP020: 'AP011', // Missing getCommandSource for Tracing → Missing getCommandSource for Tracing
+  AP021: 'AP021', // Event Emit After publishAsync ✅
+}
+
+/**
  * Check for anti-patterns in code.
  */
 async function checkAntiPatterns(
@@ -733,6 +767,8 @@ async function checkAntiPatterns(
   text += `| 🟠 High | ${high.length} |\n`
   text += `| 🟡 Medium | ${medium.length} |\n`
   text += `| 🟢 Low | ${low.length} |\n\n`
+  text +=
+    '> **Note:** AP codes below are *detector codes* (from `analyze.ts`). They are a separate numbering system from the AP codes in `mbc-review` skill documentation. See the cross-reference table at the top of `skills/mbc-review/SKILL.md` to map a detector code to its corresponding skill-doc section.\n\n'
 
   for (const m of matches) {
     const icon =
@@ -743,7 +779,9 @@ async function checkAntiPatterns(
           : m.severity === 'medium'
             ? '🟡'
             : '🟢'
-    text += `### ${icon} ${m.code}: ${m.name}\n\n`
+    const skillRef = DETECTOR_TO_SKILL_AP[m.code]
+    const skillRefSuffix = skillRef ? ` _(skill-doc: ${skillRef})_` : ''
+    text += `### ${icon} ${m.code}: ${m.name}${skillRefSuffix}\n\n`
     text += `**File:** \`${m.file}:${m.line}\`\n`
     text += `**Snippet:** \`${m.snippet}\`\n\n`
     text += `**Recommendation:** ${m.recommendation}\n\n`


### PR DESCRIPTION
## Summary

- Add v1.2.5 and v1.2.6 sections to `mbc-migrate` skill (covers PR #410 RYW improvements + ZIP import refactor)
- Add `mbc-debug` troubleshooting entry for early RYW session purge (intentional behavior in v1.2.6)
- Cross-reference RYW vs `IDataSyncHandler` guidance in `mbc-review` AP021
- **Disambiguate detector AP codes vs skill-doc AP codes** — these are two independent numbering systems where only AP016–AP019 and AP021 happen to share codes. Output of `mbc_check_anti_patterns` now annotates each hit with the corresponding skill-doc AP code (e.g. `AP005: Hardcoded Tenant (skill-doc: AP002)`).
- Fix bug: `server.ts` was hardcoding the package version, which silently drifts on every `lerna version` bump. Now read at runtime from `package.json`.

## Why

PR #410 (Repository RYW improvements, scheduled for v1.2.6) needs accompanying skill documentation so AI tooling users can understand the new behavior (proactive session cleanup, `getVersion` short-circuit, parallelized `listItems`).

While auditing the skills, found that `mbc_check_anti_patterns` tool output uses `AP00X` codes that differ from the `AP00X` codes in `mbc-review/SKILL.md` for the same concepts — a user looking up `AP005` in the skill doc after seeing it in detector output would land on a completely unrelated topic. Added a cross-reference table on both sides plus inline annotation in detector output to make this navigable until the two systems can be properly consolidated in a future refactor.

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (265/265)
- [x] Verified `package.json` version resolves correctly from the `dist/` runtime location
- [ ] Reviewer: spot-check that `mbc_check_anti_patterns` output now shows `(skill-doc: APXXX)` annotations
- [ ] Reviewer: verify cross-reference table accuracy in `skills/mbc-review/SKILL.md`

## Out of scope (follow-up issues to file)

- Pre-flight Check block is duplicated across all 4 SKILL.md files (should extract to a common preamble)
- `analyze.ts` is 1126 lines — split into `pattern.ts` / `analyzer.ts` / `handler.ts`
- `errors` resource is thin (37 lines) compared to debug skill — consolidate into a shared data source
- No golden-file tests for anti-pattern regex detectors
- Long-term: consolidate detector AP codes and skill-doc AP codes into a single numbering system

🤖 Generated with [Claude Code](https://claude.com/claude-code)