### PR TITLE
release: v1.2.6 — Repository RYW improvements + MCP detector/skill alignment

### DIFF
--- a/packages/core/src/commands/repository.spec.ts
+++ b/packages/core/src/commands/repository.spec.ts
@@ -10,7 +10,7 @@ import {
   DataModel,
   CommandModel,
 } from '../interfaces'
-import { KEY_SEPARATOR } from '../constants' // Import the actual separator
+import { KEY_SEPARATOR } from '../constants'
 import * as userContextHelper from '../context/user'
 
 describe('Repository', () => {
@@ -19,14 +19,12 @@ describe('Repository', () => {
   let commandService: jest.Mocked<CommandService>
   let sessionService: jest.Mocked<SessionService>
 
-  const mockModuleOptions = { tableName: 'test-module' }
-  const mockTenant = 'tenant-123'
-  const mockUserId = 'user-456'
-
-  // IDs must follow the pattern: {TYPE}#{TENANT}#{BASE_SK}
-  const mockItemId = `TEST#${mockTenant}#ITEM-abc`
-  const mockPk = `TEST#${mockTenant}`
-  const mockSk = 'ITEM-abc'
+  const mockModuleOptions = { tableName: 'user-tenant' }
+  const mockTenant = 'tenant-A'
+  const mockUserId = 'user-1'
+  const mockPk = `USER_TENANT#${mockTenant}`
+  const mockSk = 'USER_TENANT#item-1'
+  const mockItemId = `${mockPk}#${mockSk}`
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -60,115 +58,419 @@ describe('Repository', () => {
     commandService = module.get(CommandService)
     sessionService = module.get(SessionService)
 
+    // Default mock for user context
     jest.spyOn(userContextHelper, 'getUserContext').mockReturnValue({
       userId: mockUserId,
       tenantCode: mockTenant,
     } as any)
 
+    // sessionService.delete is fire-and-forget in repository, always returns promise
     sessionService.delete.mockResolvedValue(undefined)
   })
 
-  describe('getItem', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('getItem — branch and cleanup logic', () => {
     const detailKey = { pk: mockPk, sk: mockSk }
     const options = { invokeContext: {} as any }
 
-    it('should fetch from CommandService and merge if data table is lagging (v1 < v2)', async () => {
-      sessionService.get.mockResolvedValue({ version: 2 } as any)
+    it('should return data directly when no userId is present in context', async () => {
+      jest
+        .spyOn(userContextHelper, 'getUserContext')
+        .mockReturnValue(null as any)
+      const mockData = { id: '1' } as DataModel
+      dataService.getItem.mockResolvedValue(mockData)
 
-      const laggingData = {
+      const result = await repository.getItem(detailKey, options)
+
+      expect(result).toBe(mockData)
+      expect(sessionService.get).not.toHaveBeenCalled()
+    })
+
+    it('should return data directly when no session exists', async () => {
+      sessionService.get.mockResolvedValue(null)
+      const mockData = { id: '1' } as DataModel
+      dataService.getItem.mockResolvedValue(mockData)
+
+      const result = await repository.getItem(detailKey, options)
+
+      expect(result).toBe(mockData)
+      expect(commandService.getItem).not.toHaveBeenCalled()
+    })
+
+    it('should DELETE session and return existing when data table caught up (v2 === v2)', async () => {
+      sessionService.get.mockResolvedValue({ version: 2 } as any)
+      const caughtUp = {
+        id: mockItemId,
+        pk: mockPk,
+        sk: mockSk,
+        version: 2,
+        name: 'caught-up',
+      } as DataModel
+      dataService.getItem.mockResolvedValue(caughtUp)
+
+      const result = await repository.getItem(detailKey, options)
+
+      expect(result).toEqual(caughtUp)
+      expect(commandService.getItem).not.toHaveBeenCalled() // Critical path optimization
+      expect(sessionService.delete).toHaveBeenCalledWith(
+        mockUserId,
+        mockTenant,
+        mockModuleOptions.tableName,
+        mockItemId,
+      )
+    })
+
+    it('should DELETE session when data table SURPASSED session (v5 > v2)', async () => {
+      sessionService.get.mockResolvedValue({ version: 2 } as any)
+      dataService.getItem.mockResolvedValue({
+        id: mockItemId,
+        pk: mockPk,
+        sk: mockSk,
+        version: 5,
+      } as DataModel)
+
+      const result = await repository.getItem(detailKey, options)
+
+      expect(result.version).toBe(5)
+      expect(commandService.getItem).not.toHaveBeenCalled()
+      expect(sessionService.delete).toHaveBeenCalled()
+    })
+
+    it('should NOT delete session and merge command when data table is lagging (v1 < v2)', async () => {
+      sessionService.get.mockResolvedValue({ version: 2 } as any)
+      dataService.getItem.mockResolvedValue({
         id: mockItemId,
         pk: mockPk,
         sk: mockSk,
         version: 1,
         name: 'old',
-      } as DataModel
-
-      const latestCommand = {
+      } as DataModel)
+      commandService.getItem.mockResolvedValue({
         id: mockItemId,
         pk: mockPk,
-        sk: `${mockSk}@2`, // Must have a version-suffixed SK
+        sk: `${mockSk}@2`,
         version: 2,
         name: 'new',
-      } as CommandModel
-
-      dataService.getItem.mockResolvedValue(laggingData)
-      commandService.getItem.mockResolvedValue(latestCommand)
+        code: 'c',
+        type: 'TEST',
+        tenantCode: mockTenant,
+      } as CommandModel)
 
       const result = await repository.getItem(detailKey, options)
 
-      expect(result.name).toBe('new')
       expect(result.version).toBe(2)
+      expect(result.name).toBe('new')
+      expect(sessionService.delete).not.toHaveBeenCalled() //
+    })
+
+    it('should not throw when sessionService.delete fails (fire-and-forget contract)', async () => {
+      sessionService.get.mockResolvedValue({ version: 2 } as any)
+      dataService.getItem.mockResolvedValue({
+        id: mockItemId,
+        pk: mockPk,
+        sk: mockSk,
+        version: 2,
+      } as DataModel)
+      // Service layer error handling check
+      sessionService.delete.mockRejectedValue(new Error('DDB outage'))
+
+      await expect(
+        repository.getItem(detailKey, options),
+      ).resolves.toBeDefined()
+    })
+
+    it('should return data table result if commandService returns null', async () => {
+      sessionService.get.mockResolvedValue({ version: 2 } as any)
+      const mockData = { id: '1', version: 1 } as DataModel
+      dataService.getItem.mockResolvedValue(mockData)
+      commandService.getItem.mockResolvedValue(null)
+
+      const result = await repository.getItem(detailKey, options)
+
+      expect(result).toBe(mockData)
     })
   })
 
-  describe('listItemsByPk', () => {
-    it('should prepend a new item if it exists in session but not in base results', async () => {
+  describe('listItemsByPk — branch and cleanup logic', () => {
+    const opts = { invokeContext: {} as any }
+
+    it('should return base results when latestFlg is false', async () => {
+      const baseResult = new DataListEntity({ items: [], lastSk: undefined })
+      dataService.listItemsByPk.mockResolvedValue(baseResult)
+
+      const result = await repository.listItemsByPk(
+        mockPk,
+        {},
+        { latestFlg: false },
+        opts,
+      )
+
+      expect(result).toBe(baseResult)
+      expect(sessionService.listByUser).not.toHaveBeenCalled()
+    })
+
+    it('should DELETE session and skip merge when existing item already caught up', async () => {
+      const caughtUp = {
+        id: mockItemId,
+        pk: mockPk,
+        sk: mockSk,
+        version: 5,
+        name: 'caught-up',
+      } as DataModel
+      dataService.listItemsByPk.mockResolvedValue(
+        new DataListEntity({
+          items: [new DataEntity(caughtUp)],
+          lastSk: undefined,
+        }),
+      )
+      sessionService.listByUser.mockResolvedValue([
+        {
+          sk: `${mockModuleOptions.tableName}${KEY_SEPARATOR}${mockItemId}`,
+          version: 5,
+        } as any,
+      ])
+
+      const result = await repository.listItemsByPk(
+        mockPk,
+        {},
+        { latestFlg: true },
+        opts,
+      )
+
+      expect(result.items).toHaveLength(1)
+      expect(commandService.getItem).not.toHaveBeenCalled()
+      expect(sessionService.delete).toHaveBeenCalled() //
+    })
+
+    it('should NOT delete session for create-new (regression guard)', async () => {
       dataService.listItemsByPk.mockResolvedValue(
         new DataListEntity({ items: [], lastSk: undefined }),
       )
-
-      // SK in Session table is: {module}#{itemId}
       sessionService.listByUser.mockResolvedValue([
         {
           sk: `${mockModuleOptions.tableName}${KEY_SEPARATOR}${mockItemId}`,
           version: 1,
         } as any,
       ])
-
-      const newCmd = {
+      commandService.getItem.mockResolvedValue({
         id: mockItemId,
         pk: mockPk,
         sk: `${mockSk}@1`,
         version: 1,
-        updatedAt: new Date(),
-      } as any
-      commandService.getItem.mockResolvedValue(newCmd)
+        name: 'new',
+        code: 'c',
+        type: 'TEST',
+        tenantCode: mockTenant,
+      } as CommandModel)
 
       const result = await repository.listItemsByPk(
         mockPk,
         {},
         { latestFlg: true },
-        { invokeContext: {} } as any,
+        opts,
       )
 
-      expect(result.items.length).toBe(1)
-      expect(result.items[0].id).toBe(mockItemId)
+      expect(result.items).toHaveLength(1)
+      expect(sessionService.delete).not.toHaveBeenCalled()
+      expect(commandService.getItem).toHaveBeenCalled()
     })
-  })
 
-  describe('listItems (External Source/RDS)', () => {
-    it('should call dataService.getItem for each session to check sync status', async () => {
-      const mockRdsQuery = jest.fn().mockResolvedValue({
-        total: 1,
-        items: [{ id: mockItemId }],
-      })
-
+    it('should remove item from result when command.isDeleted is true', async () => {
+      const existing = {
+        id: mockItemId,
+        pk: mockPk,
+        sk: mockSk,
+        version: 1,
+      } as DataModel
+      dataService.listItemsByPk.mockResolvedValue(
+        new DataListEntity({
+          items: [new DataEntity(existing)],
+          lastSk: undefined,
+        }),
+      )
       sessionService.listByUser.mockResolvedValue([
         {
           sk: `${mockModuleOptions.tableName}${KEY_SEPARATOR}${mockItemId}`,
-          version: 10,
+          version: 2,
         } as any,
       ])
+      commandService.getItem.mockResolvedValue({
+        id: mockItemId,
+        pk: mockPk,
+        sk: `${mockSk}@2`,
+        isDeleted: true,
+        version: 2,
+      } as CommandModel)
 
-      // Data item must have matching PK/SK to stop the parser from failing
+      const result = await repository.listItemsByPk(
+        mockPk,
+        {},
+        { latestFlg: true },
+        opts,
+      )
+
+      expect(result.items).toHaveLength(0)
+    })
+  })
+
+  describe('listItems (RDS) — branch and cleanup logic', () => {
+    const opts = { invokeContext: {} as any }
+    const mergeOptions: IMergeOptions<any> = {
+      latestFlg: true,
+      transformCommand: (cmd) => ({
+        id: cmd.id,
+        pk: mockPk,
+        sk: mockSk,
+        version: cmd.version,
+        name: cmd.name,
+        role: 'viewer',
+      }),
+      matchesFilter: (item) => item.role === 'viewer',
+    }
+
+    it('should return base results when latestFlg is false', async () => {
+      const rdsQuery = jest
+        .fn()
+        .mockResolvedValue({ total: 1, items: [{ id: '1' }] })
+
+      const result = await repository.listItems(
+        rdsQuery,
+        { latestFlg: false } as any,
+        opts,
+      )
+
+      expect(result.total).toBe(1)
+      expect(sessionService.listByUser).not.toHaveBeenCalled()
+    })
+
+    it('should DELETE session and skip command fetch when data table caught up', async () => {
+      const rdsQuery = jest.fn().mockResolvedValue({
+        total: 1,
+        items: [
+          {
+            id: mockItemId,
+            pk: mockPk,
+            sk: mockSk,
+            version: 5,
+            name: 'rds-row',
+          },
+        ],
+      })
+      sessionService.listByUser.mockResolvedValue([
+        {
+          sk: `${mockModuleOptions.tableName}${KEY_SEPARATOR}${mockItemId}`,
+          version: 5,
+        } as any,
+      ])
       dataService.getItem.mockResolvedValue({
         id: mockItemId,
         pk: mockPk,
         sk: mockSk,
-        version: 10,
+        version: 5,
+      } as DataModel)
+
+      const result = await repository.listItems(rdsQuery, mergeOptions, opts)
+
+      expect(commandService.getItem).not.toHaveBeenCalled()
+      expect(sessionService.delete).toHaveBeenCalled()
+      expect(result.total).toBe(1)
+    })
+
+    it('should fetch command when data table is lagging', async () => {
+      const rdsQuery = jest.fn().mockResolvedValue({
+        total: 1,
+        items: [
+          { id: mockItemId, pk: mockPk, sk: mockSk, version: 1, name: 'old' },
+        ],
+      })
+      sessionService.listByUser.mockResolvedValue([
+        {
+          sk: `${mockModuleOptions.tableName}${KEY_SEPARATOR}${mockItemId}`,
+          version: 3,
+        } as any,
+      ])
+      dataService.getItem.mockResolvedValue({
+        id: mockItemId,
+        pk: mockPk,
+        sk: mockSk,
+        version: 1,
+      } as DataModel)
+      commandService.getItem.mockResolvedValue({
+        id: mockItemId,
+        pk: mockPk,
+        sk: `${mockSk}@3`,
+        version: 3,
+        name: 'new',
+        code: 'c',
+        type: 'TEST',
+        tenantCode: mockTenant,
+      } as CommandModel)
+
+      const result = await repository.listItems(rdsQuery, mergeOptions, opts)
+
+      expect(commandService.getItem).toHaveBeenCalled()
+      expect(sessionService.delete).not.toHaveBeenCalled()
+      expect(result.items[0].name).toBe('new')
+    })
+
+    it('should decrement total when item is deleted via command', async () => {
+      const rdsQuery = jest.fn().mockResolvedValue({
+        total: 1,
+        items: [{ id: mockItemId, pk: mockPk, sk: mockSk, version: 1 }],
+      })
+      sessionService.listByUser.mockResolvedValue([
+        {
+          sk: `${mockModuleOptions.tableName}${KEY_SEPARATOR}${mockItemId}`,
+          version: 2,
+        } as any,
+      ])
+      dataService.getItem.mockResolvedValue({
+        id: mockItemId,
+        version: 1,
+      } as DataModel)
+      commandService.getItem.mockResolvedValue({
+        id: mockItemId,
+        isDeleted: true,
+        version: 2,
+      } as CommandModel)
+
+      const result = await repository.listItems(rdsQuery, mergeOptions, opts)
+
+      expect(result.total).toBe(0)
+      expect(result.items).toHaveLength(0)
+    })
+
+    it('should respect matchesFilter for create-new items', async () => {
+      const rdsQuery = jest.fn().mockResolvedValue({ total: 0, items: [] })
+      sessionService.listByUser.mockResolvedValue([
+        {
+          sk: `${mockModuleOptions.tableName}${KEY_SEPARATOR}${mockItemId}`,
+          version: 1,
+        } as any,
+      ])
+      dataService.getItem.mockResolvedValue(null)
+
+      // Command shape that will FAIL filter (role is not 'viewer')
+      commandService.getItem.mockResolvedValue({
+        id: mockItemId,
+        version: 1,
+        attributes: { role: 'admin' },
+        code: 'c',
+        name: 'n',
       } as any)
 
-      const mergeOptions: IMergeOptions<any> = {
-        latestFlg: true,
-        transformCommand: (cmd) => cmd,
+      const filteredMerge: IMergeOptions<any> = {
+        ...mergeOptions,
+        transformCommand: (cmd) => ({ id: cmd.id, role: cmd.attributes.role }),
       }
 
-      await repository.listItems(mockRdsQuery, mergeOptions, {
-        invokeContext: {},
-      } as any)
+      const result = await repository.listItems(rdsQuery, filteredMerge, opts)
 
-      expect(dataService.getItem).toHaveBeenCalled()
-      expect(sessionService.delete).toHaveBeenCalled()
+      expect(result.total).toBe(0) // Filtered out
+      expect(result.items).toHaveLength(0)
     })
   })
 })

--- a/packages/core/src/commands/repository.spec.ts
+++ b/packages/core/src/commands/repository.spec.ts
@@ -311,8 +311,31 @@ describe('Repository', () => {
         { latestFlg: true },
         opts,
       )
-
       expect(result.items).toHaveLength(0)
+    })
+
+    it('should short-circuit dataService.getItem in listItems if getVersion proves caught-up', async () => {
+      const rdsItem = { id: mockItemId, version: 10 }
+      const rdsQuery = jest
+        .fn()
+        .mockResolvedValue({ total: 1, items: [rdsItem] })
+      sessionService.listByUser.mockResolvedValue([
+        {
+          sk: `${mockModuleOptions.tableName}${KEY_SEPARATOR}${mockItemId}`,
+          version: 10,
+        } as any,
+      ])
+
+      const mergeWithVersion: IMergeOptions<any> = {
+        latestFlg: true,
+        getVersion: (item) => item.version,
+        transformCommand: (cmd) => cmd,
+      }
+
+      await repository.listItems(rdsQuery, mergeWithVersion, opts)
+
+      expect(dataService.getItem).not.toHaveBeenCalled() // Proves short-circuit worked
+      expect(sessionService.delete).toHaveBeenCalled()
     })
   })
 

--- a/packages/core/src/commands/repository.spec.ts
+++ b/packages/core/src/commands/repository.spec.ts
@@ -1,454 +1,174 @@
 import { Test, TestingModule } from '@nestjs/testing'
-
-import { SessionService } from '../data-store/session.service'
-import { CommandModel, DataEntity, DataModel } from '../interfaces'
-import { ICommandOptions } from '../interfaces/command.options.interface'
-import { MODULE_OPTIONS_TOKEN } from './command.module-definition'
-import { CommandService } from './command.service'
+import { Repository, IMergeOptions } from './repository'
 import { DataService } from './data.service'
-import { IMergeOptions, Repository } from './repository'
-
-/** Physical DynamoDB data table name (DataService); session SK uses module name only. */
-const PHYSICAL_DATA_TABLE = 'local-app-user-tenant-data'
-const MODULE_TABLE = 'user-tenant'
-
-const makeInvokeContext = (
-  userId = 'user-1',
-): ICommandOptions['invokeContext'] =>
-  ({
-    event: {
-      requestContext: {
-        authorizer: {
-          jwt: {
-            claims: {
-              sub: userId,
-              'custom:roles': '[]',
-            },
-          },
-        },
-      },
-      headers: { 'x-tenant-code': 'tenant-a' },
-    },
-    context: {},
-  }) as unknown as ICommandOptions['invokeContext']
-
-const makeCmd = (
-  id: string,
-  version: number,
-  isDeleted = false,
-): CommandModel => ({
-  pk: 'USER_TENANT#tenant-A',
-  sk: `USER_TENANT#${id}@${version}`,
-  id: `USER_TENANT#tenant-A#USER_TENANT#${id}`,
-  code: id,
-  name: id,
-  version,
-  tenantCode: 'tenant-A',
-  type: 'USER_TENANT',
-  isDeleted,
-  attributes: { role: 'admin' },
-  createdAt: new Date('2024-01-01'),
-  updatedAt: new Date('2024-01-02'),
-  createdBy: 'user-1',
-  updatedBy: 'user-1',
-})
-
-const makeDataModel = (id: string, version = 1): DataModel => ({
-  pk: 'USER_TENANT#tenant-A',
-  sk: `USER_TENANT#${id}`,
-  id: `USER_TENANT#tenant-A#USER_TENANT#${id}`,
-  code: id,
-  name: id,
-  version,
-  tenantCode: 'tenant-A',
-  type: 'USER_TENANT',
-  attributes: { role: 'viewer' },
-  cpk: 'USER_TENANT#tenant-A',
-  csk: `USER_TENANT#${id}@${version}`,
-  createdAt: new Date('2024-01-01'),
-  updatedAt: new Date('2024-01-01'),
-  createdBy: 'user-1',
-  updatedBy: 'user-1',
-})
-
-const mockDataService = {
-  tableName: PHYSICAL_DATA_TABLE,
-  getItem: jest.fn(),
-  listItemsByPk: jest.fn(),
-}
-
-const mockCommandService = {
-  getItem: jest.fn(),
-}
-
-const mockSessionService = {
-  get: jest.fn(),
-  listByUser: jest.fn(),
-}
-
-const mockOptions = { tableName: MODULE_TABLE }
+import { CommandService } from './command.service'
+import { SessionService } from '../data-store/session.service'
+import { MODULE_OPTIONS_TOKEN } from './command.module-definition'
+import {
+  DataEntity,
+  DataListEntity,
+  DataModel,
+  CommandModel,
+} from '../interfaces'
+import { KEY_SEPARATOR } from '../constants' // Import the actual separator
+import * as userContextHelper from '../context/user'
 
 describe('Repository', () => {
-  let repo: Repository
+  let repository: Repository
+  let dataService: jest.Mocked<DataService>
+  let commandService: jest.Mocked<CommandService>
+  let sessionService: jest.Mocked<SessionService>
+
+  const mockModuleOptions = { tableName: 'test-module' }
+  const mockTenant = 'tenant-123'
+  const mockUserId = 'user-456'
+
+  // IDs must follow the pattern: {TYPE}#{TENANT}#{BASE_SK}
+  const mockItemId = `TEST#${mockTenant}#ITEM-abc`
+  const mockPk = `TEST#${mockTenant}`
+  const mockSk = 'ITEM-abc'
 
   beforeEach(async () => {
-    jest.clearAllMocks()
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         Repository,
-        { provide: DataService, useValue: mockDataService },
-        { provide: CommandService, useValue: mockCommandService },
-        { provide: SessionService, useValue: mockSessionService },
-        { provide: MODULE_OPTIONS_TOKEN, useValue: mockOptions },
+        {
+          provide: DataService,
+          useValue: { getItem: jest.fn(), listItemsByPk: jest.fn() },
+        },
+        {
+          provide: CommandService,
+          useValue: { getItem: jest.fn() },
+        },
+        {
+          provide: SessionService,
+          useValue: {
+            get: jest.fn(),
+            delete: jest.fn(),
+            listByUser: jest.fn(),
+          },
+        },
+        {
+          provide: MODULE_OPTIONS_TOKEN,
+          useValue: mockModuleOptions,
+        },
       ],
     }).compile()
 
-    repo = module.get(Repository)
+    repository = module.get<Repository>(Repository)
+    dataService = module.get(DataService)
+    commandService = module.get(CommandService)
+    sessionService = module.get(SessionService)
+
+    jest.spyOn(userContextHelper, 'getUserContext').mockReturnValue({
+      userId: mockUserId,
+      tenantCode: mockTenant,
+    } as any)
+
+    sessionService.delete.mockResolvedValue(undefined)
   })
 
   describe('getItem', () => {
-    const key = { pk: 'USER_TENANT#tenant-A', sk: 'USER_TENANT#item-1' }
-    const opts = { invokeContext: makeInvokeContext() }
+    const detailKey = { pk: mockPk, sk: mockSk }
+    const options = { invokeContext: {} as any }
 
-    it('should return DataService result when no session exists', async () => {
-      mockSessionService.get.mockResolvedValue(null)
-      const dataItem = makeDataModel('item-1')
-      mockDataService.getItem.mockResolvedValue(dataItem)
+    it('should fetch from CommandService and merge if data table is lagging (v1 < v2)', async () => {
+      sessionService.get.mockResolvedValue({ version: 2 } as any)
 
-      const result = await repo.getItem(key, opts)
+      const laggingData = {
+        id: mockItemId,
+        pk: mockPk,
+        sk: mockSk,
+        version: 1,
+        name: 'old',
+      } as DataModel
 
-      expect(mockSessionService.get).toHaveBeenCalled()
-      expect(mockCommandService.getItem).not.toHaveBeenCalled()
-      expect(result).toEqual(dataItem)
-    })
+      const latestCommand = {
+        id: mockItemId,
+        pk: mockPk,
+        sk: `${mockSk}@2`, // Must have a version-suffixed SK
+        version: 2,
+        name: 'new',
+      } as CommandModel
 
-    it('should return transformed command when session exists', async () => {
-      mockSessionService.get.mockResolvedValue({
-        version: 3,
-        sk: `${MODULE_TABLE}#USER_TENANT#tenant-A#USER_TENANT#item-1`,
-      })
-      const cmd = makeCmd('item-1', 3)
-      mockCommandService.getItem.mockResolvedValue(cmd)
-      mockDataService.getItem.mockResolvedValue(makeDataModel('item-1', 2))
+      dataService.getItem.mockResolvedValue(laggingData)
+      commandService.getItem.mockResolvedValue(latestCommand)
 
-      const result = await repo.getItem(key, opts)
+      const result = await repository.getItem(detailKey, options)
 
-      expect(mockCommandService.getItem).toHaveBeenCalled()
-      expect(result.version).toBe(3)
-      expect(result.attributes).toEqual({ role: 'admin' })
-    })
-
-    it('should fallback to DataService when command not found', async () => {
-      mockSessionService.get.mockResolvedValue({ version: 3 })
-      mockCommandService.getItem.mockResolvedValue(null)
-      const dataItem = makeDataModel('item-1')
-      mockDataService.getItem.mockResolvedValue(dataItem)
-
-      const result = await repo.getItem(key, opts)
-
-      expect(result).toEqual(dataItem)
-    })
-
-    it('should fallback to DataService when userId is absent', async () => {
-      const noUserCtx = { invokeContext: makeInvokeContext('') }
-      const dataItem = makeDataModel('item-1')
-      mockDataService.getItem.mockResolvedValue(dataItem)
-
-      const result = await repo.getItem(key, noUserCtx)
-
-      expect(mockSessionService.get).not.toHaveBeenCalled()
-      expect(result).toEqual(dataItem)
+      expect(result.name).toBe('new')
+      expect(result.version).toBe(2)
     })
   })
 
   describe('listItemsByPk', () => {
-    const pk = 'USER_TENANT#tenant-A'
-    const opts = { invokeContext: makeInvokeContext() }
-
-    it('should return base result when latestFlg is false', async () => {
-      const base = {
-        items: [new DataEntity(makeDataModel('item-1'))],
-        lastSk: undefined,
-      }
-      mockDataService.listItemsByPk.mockResolvedValue(base)
-
-      const result = await repo.listItemsByPk(
-        pk,
-        {},
-        { latestFlg: false },
-        opts,
+    it('should prepend a new item if it exists in session but not in base results', async () => {
+      dataService.listItemsByPk.mockResolvedValue(
+        new DataListEntity({ items: [], lastSk: undefined }),
       )
 
-      expect(mockSessionService.listByUser).not.toHaveBeenCalled()
-      expect(result).toEqual(base)
-    })
-
-    it('should return base result when no sessions', async () => {
-      mockDataService.listItemsByPk.mockResolvedValue({
-        items: [],
-        lastSk: undefined,
-      })
-      mockSessionService.listByUser.mockResolvedValue([])
-
-      const result = await repo.listItemsByPk(pk, {}, { latestFlg: true }, opts)
-
-      expect(result.items).toHaveLength(0)
-    })
-
-    it('should override existing item (update case)', async () => {
-      const existingItem = makeDataModel('item-1', 1)
-      mockDataService.listItemsByPk.mockResolvedValue({
-        items: [new DataEntity(existingItem)],
-        lastSk: undefined,
-      })
-      mockSessionService.listByUser.mockResolvedValue([
+      // SK in Session table is: {module}#{itemId}
+      sessionService.listByUser.mockResolvedValue([
         {
-          pk: 'user-1#tenant-A',
-          sk: `${MODULE_TABLE}#USER_TENANT#tenant-A#USER_TENANT#item-1`,
-          version: 2,
-        },
-      ])
-      mockCommandService.getItem.mockResolvedValue(makeCmd('item-1', 2))
-
-      const result = await repo.listItemsByPk(pk, {}, { latestFlg: true }, opts)
-
-      expect(result.items).toHaveLength(1)
-      expect(result.items[0].version).toBe(2)
-    })
-
-    it('should remove item for delete case', async () => {
-      mockDataService.listItemsByPk.mockResolvedValue({
-        items: [
-          new DataEntity(makeDataModel('item-1')),
-          new DataEntity(makeDataModel('item-2')),
-        ],
-        lastSk: undefined,
-      })
-      mockSessionService.listByUser.mockResolvedValue([
-        {
-          pk: 'user-1#tenant-A',
-          sk: `${MODULE_TABLE}#USER_TENANT#tenant-A#USER_TENANT#item-1`,
-          version: 2,
-        },
-      ])
-      mockCommandService.getItem.mockResolvedValue(makeCmd('item-1', 2, true))
-
-      const result = await repo.listItemsByPk(pk, {}, { latestFlg: true }, opts)
-
-      expect(result.items).toHaveLength(1)
-      expect(result.items[0].id).toBe('USER_TENANT#tenant-A#USER_TENANT#item-2')
-    })
-
-    it('should add create-new item not yet synced', async () => {
-      mockDataService.listItemsByPk.mockResolvedValue({
-        items: [],
-        lastSk: undefined,
-      })
-      mockSessionService.listByUser.mockResolvedValue([
-        {
-          pk: 'user-1#tenant-A',
-          sk: `${MODULE_TABLE}#USER_TENANT#tenant-A#USER_TENANT#item-new`,
+          sk: `${mockModuleOptions.tableName}${KEY_SEPARATOR}${mockItemId}`,
           version: 1,
-        },
+        } as any,
       ])
-      mockCommandService.getItem.mockResolvedValue(makeCmd('item-new', 1))
 
-      const result = await repo.listItemsByPk(pk, {}, { latestFlg: true }, opts)
+      const newCmd = {
+        id: mockItemId,
+        pk: mockPk,
+        sk: `${mockSk}@1`,
+        version: 1,
+        updatedAt: new Date(),
+      } as any
+      commandService.getItem.mockResolvedValue(newCmd)
 
-      expect(result.items).toHaveLength(1)
-      expect(result.items[0].id).toBe(
-        'USER_TENANT#tenant-A#USER_TENANT#item-new',
+      const result = await repository.listItemsByPk(
+        mockPk,
+        {},
+        { latestFlg: true },
+        { invokeContext: {} } as any,
       )
+
+      expect(result.items.length).toBe(1)
+      expect(result.items[0].id).toBe(mockItemId)
     })
   })
 
-  describe('listItems', () => {
-    const opts = { invokeContext: makeInvokeContext() }
-
-    type RdsItem = {
-      id: string
-      pk?: string
-      sk?: string
-      tenantCode: string
-      role: string
-    }
-
-    const makeRdsItem = (id: string): RdsItem => ({
-      id: `USER_TENANT#tenant-A#USER_TENANT#${id}`,
-      pk: 'USER_TENANT#tenant-A',
-      sk: `USER_TENANT#${id}`,
-      tenantCode: 'tenant-A',
-      role: 'viewer',
-    })
-
-    const mergeOpts: IMergeOptions<RdsItem> = {
-      latestFlg: true,
-      transformCommand: (cmd) => ({
-        id: cmd.id,
-        tenantCode: cmd.tenantCode,
-        pk: 'USER_TENANT#tenant-A',
-        sk: `USER_TENANT#${cmd.code}`,
-        role: (cmd.attributes as { role?: string })?.role ?? 'viewer',
-      }),
-      matchesFilter: (item) => item.role !== 'blocked',
-    }
-
-    it('should passthrough when latestFlg is false', async () => {
-      const rdsQuery = jest
-        .fn()
-        .mockResolvedValue({ total: 1, items: [makeRdsItem('item-1')] })
-
-      const result = await repo.listItems(
-        rdsQuery,
-        { ...mergeOpts, latestFlg: false },
-        opts,
-      )
-
-      expect(mockSessionService.listByUser).not.toHaveBeenCalled()
-      expect(result.total).toBe(1)
-    })
-
-    it('should return rds result when no sessions', async () => {
-      const rdsQuery = jest
-        .fn()
-        .mockResolvedValue({ total: 1, items: [makeRdsItem('item-1')] })
-      mockSessionService.listByUser.mockResolvedValue([])
-
-      const result = await repo.listItems(rdsQuery, mergeOpts, opts)
-
-      expect(result.total).toBe(1)
-    })
-
-    it('should use request tenant for session lookup, not row tenantCode', async () => {
-      mockSessionService.listByUser.mockResolvedValue([])
-      const rdsQuery = jest.fn().mockResolvedValue({
+  describe('listItems (External Source/RDS)', () => {
+    it('should call dataService.getItem for each session to check sync status', async () => {
+      const mockRdsQuery = jest.fn().mockResolvedValue({
         total: 1,
-        items: [
-          {
-            ...makeRdsItem('item-1'),
-            tenantCode: 'common',
-          },
-        ],
+        items: [{ id: mockItemId }],
       })
 
-      await repo.listItems(rdsQuery, mergeOpts, opts)
-
-      expect(mockSessionService.listByUser).toHaveBeenCalledWith(
-        'user-1',
-        'tenant-a',
-        MODULE_TABLE,
-      )
-    })
-
-    it('should override existing item (update)', async () => {
-      const rdsQuery = jest.fn().mockResolvedValue({
-        total: 1,
-        items: [makeRdsItem('item-1')],
-      })
-      mockSessionService.listByUser.mockResolvedValue([
+      sessionService.listByUser.mockResolvedValue([
         {
-          pk: 'user-1#tenant-A',
-          sk: `${MODULE_TABLE}#USER_TENANT#tenant-A#USER_TENANT#item-1`,
-          version: 2,
-        },
+          sk: `${mockModuleOptions.tableName}${KEY_SEPARATOR}${mockItemId}`,
+          version: 10,
+        } as any,
       ])
-      const cmd = makeCmd('item-1', 2)
-      cmd.attributes = { role: 'admin' }
-      mockCommandService.getItem.mockResolvedValue(cmd)
 
-      const result = await repo.listItems(rdsQuery, mergeOpts, opts)
+      // Data item must have matching PK/SK to stop the parser from failing
+      dataService.getItem.mockResolvedValue({
+        id: mockItemId,
+        pk: mockPk,
+        sk: mockSk,
+        version: 10,
+      } as any)
 
-      expect(result.total).toBe(1)
-      expect(result.items[0].role).toBe('admin')
-    })
-
-    it('should remove deleted item', async () => {
-      const rdsQuery = jest.fn().mockResolvedValue({
-        total: 2,
-        items: [makeRdsItem('item-1'), makeRdsItem('item-2')],
-      })
-      mockSessionService.listByUser.mockResolvedValue([
-        {
-          pk: 'user-1#tenant-A',
-          sk: `${MODULE_TABLE}#USER_TENANT#tenant-A#USER_TENANT#item-1`,
-          version: 2,
-        },
-      ])
-      mockCommandService.getItem.mockResolvedValue(makeCmd('item-1', 2, true))
-
-      const result = await repo.listItems(rdsQuery, mergeOpts, opts)
-
-      expect(result.total).toBe(1)
-      expect(result.items.find((i) => i.id.includes('item-1'))).toBeUndefined()
-    })
-
-    it('should append create-new item that passes matchesFilter', async () => {
-      const rdsQuery = jest
-        .fn()
-        .mockResolvedValue({ total: 1, items: [makeRdsItem('item-1')] })
-      mockSessionService.listByUser.mockResolvedValue([
-        {
-          pk: 'user-1#tenant-A',
-          sk: `${MODULE_TABLE}#USER_TENANT#tenant-A#USER_TENANT#item-new`,
-          version: 1,
-        },
-      ])
-      const cmd = makeCmd('item-new', 1)
-      cmd.attributes = { role: 'admin' }
-      mockCommandService.getItem.mockResolvedValue(cmd)
-
-      const result = await repo.listItems(rdsQuery, mergeOpts, opts)
-
-      expect(result.total).toBe(2)
-      expect(result.items.find((i) => i.id.includes('item-new'))).toBeDefined()
-    })
-
-    it('should NOT append create-new item that fails matchesFilter', async () => {
-      const rdsQuery = jest
-        .fn()
-        .mockResolvedValue({ total: 1, items: [makeRdsItem('item-1')] })
-      mockSessionService.listByUser.mockResolvedValue([
-        {
-          pk: 'user-1#tenant-A',
-          sk: `${MODULE_TABLE}#USER_TENANT#tenant-A#USER_TENANT#item-blocked`,
-          version: 1,
-        },
-      ])
-      const cmd = makeCmd('item-blocked', 1)
-      cmd.attributes = { role: 'blocked' }
-      mockCommandService.getItem.mockResolvedValue(cmd)
-
-      const result = await repo.listItems(rdsQuery, mergeOpts, opts)
-
-      expect(result.total).toBe(1)
-      expect(
-        result.items.find((i) => i.id.includes('item-blocked')),
-      ).toBeUndefined()
-    })
-
-    it('should append create-new item when matchesFilter is not provided', async () => {
-      const rdsQuery = jest.fn().mockResolvedValue({ total: 0, items: [] })
-      mockSessionService.listByUser.mockResolvedValue([
-        {
-          pk: 'user-1#tenant-A',
-          sk: `${MODULE_TABLE}#USER_TENANT#tenant-A#USER_TENANT#item-new`,
-          version: 1,
-        },
-      ])
-      mockCommandService.getItem.mockResolvedValue(makeCmd('item-new', 1))
-
-      const optsNoFilter: IMergeOptions<RdsItem> = {
+      const mergeOptions: IMergeOptions<any> = {
         latestFlg: true,
-        transformCommand: (cmd) => ({
-          id: cmd.id,
-          tenantCode: cmd.tenantCode,
-          role: 'admin',
-        }),
+        transformCommand: (cmd) => cmd,
       }
 
-      const result = await repo.listItems(rdsQuery, optsNoFilter, opts)
+      await repository.listItems(mockRdsQuery, mergeOptions, {
+        invokeContext: {},
+      } as any)
 
-      expect(result.total).toBe(1)
+      expect(dataService.getItem).toHaveBeenCalled()
+      expect(sessionService.delete).toHaveBeenCalled()
     })
   })
 })

--- a/packages/core/src/commands/repository.ts
+++ b/packages/core/src/commands/repository.ts
@@ -82,13 +82,25 @@ export class Repository {
           `getItem session merge — version ${session.version}`,
           key,
         )
+
+        // Fetch existing data FIRST to check if the session is stale
+        const existing = await this.dataService.getItem(key)
+
+        // If data table has caught up or surpassed the session, the session is stale
+        if (existing && existing.version >= session.version) {
+          this.sessionService
+            .delete(userId, tenantCode, this.moduleTableName, itemId)
+            .catch(() => {})
+          return existing
+        }
+
+        // Otherwise, data is still lagging. Fetch the command to project it.
         const cmd = await this.commandService.getItem({
           pk: key.pk,
           sk: addSortKeyVersion(key.sk, session.version),
         })
 
         if (cmd) {
-          const existing = await this.dataService.getItem(key)
           return transformCommandToData(cmd, existing)
         }
       }
@@ -172,6 +184,15 @@ export class Repository {
       const itemId = session.sk.slice(skPrefix.length)
 
       const existing = itemMap.get(itemId) as DataModel | undefined
+
+      // If the item in the list already caught up to the session, clear the session and skip merge
+      if (existing && existing.version >= session.version) {
+        this.sessionService
+          .delete(userId, tenantCode, this.moduleTableName, itemId)
+          .catch(() => {})
+        continue
+      }
+
       const cmdPk = pk
       let skBase: string | undefined
 
@@ -314,6 +335,17 @@ export class Repository {
       }
 
       if (!cmdPk || !skBase) {
+        continue
+      }
+
+      // Fetch the actual current data record to see if it has caught up
+      const dataItem = await this.dataService.getItem({ pk: cmdPk, sk: skBase })
+
+      // If data table has caught up or surpassed the session, the session is stale
+      if (dataItem && dataItem.version >= session.version) {
+        this.sessionService
+          .delete(userId, tenantCode, this.moduleTableName, itemId)
+          .catch(() => {})
         continue
       }
 

--- a/packages/core/src/commands/repository.ts
+++ b/packages/core/src/commands/repository.ts
@@ -32,6 +32,13 @@ export interface IMergeOptions<TItem extends { id: string }> {
   latestFlg?: boolean
 
   /**
+   * Optional: Extract version from the query result item (e.g. RDS row).
+   * If the provided version is >= session.version, the DynamoDB Data Table
+   * check is skipped to reduce latency.
+   */
+  getVersion?: (item: TItem) => number | undefined
+
+  /**
    * Transform a CommandModel into the same shape as a TItem returned by the query.
    * The `existing` parameter is provided for update cases to merge unchanged fields.
    */
@@ -86,11 +93,15 @@ export class Repository {
         // Fetch existing data FIRST to check if the session is stale
         const existing = await this.dataService.getItem(key)
 
-        // If data table has caught up or surpassed the session, the session is stale
+        /**
+         * If the data table version is greater than or equal to the session version,
+         * the read model has already absorbed the user's specific write (or a newer one).
+         * We purge the stale session in the background and return the persisted data.
+         */
         if (existing && existing.version >= session.version) {
           this.sessionService
             .delete(userId, tenantCode, this.moduleTableName, itemId)
-            .catch(() => {})
+            .catch(() => {}) // Fire-and-forget: do not block the critical read path
           return existing
         }
 
@@ -303,58 +314,81 @@ export class Repository {
     const itemMap = new Map<string, TItem>(
       baseResult.items.map((item) => [item.id, item]),
     )
-    const newItems: TItem[] = []
-    let adjustedTotal = baseResult.total
+
     const skPrefix = `${this.moduleTableName}${KEY_SEPARATOR}`
 
-    for (const session of sessions) {
-      if (!session.sk.startsWith(skPrefix)) {
-        continue
-      }
-      const itemId = session.sk.slice(skPrefix.length)
+    /**
+     * Parallelize session checks to avoid N+1 sequential database roundtrips.
+     * For each session, we determine if we need to merge a command or skip if synced.
+     */
+    const sessionResults = await Promise.all(
+      sessions.map(async (session) => {
+        if (!session.sk.startsWith(skPrefix)) return null
+        const itemId = session.sk.slice(skPrefix.length)
+        const existing = itemMap.get(itemId)
 
-      const existing = itemMap.get(itemId)
+        let cmdPk: string | undefined
+        let skBase: string | undefined
 
-      let cmdPk: string | undefined
-      let skBase: string | undefined
+        const existingSk = (existing as unknown as { sk?: string })?.sk
+        const existingPk = (existing as unknown as { pk?: string })?.pk
 
-      const existingSk = (existing as unknown as { sk?: string })?.sk
-      const existingPk = (existing as unknown as { pk?: string })?.pk
-
-      if (existing && existingSk && existingPk) {
-        cmdPk = existingPk
-        skBase = removeSortKeyVersion(existingSk)
-      } else {
-        // Fallback: Strictly parse the ID assuming a 2-segment PK format ({type}#{tenantCode})
-        const parsed = parseTwoSegmentPkSkFromId(itemId)
-        if (!parsed) {
-          continue
+        if (existing && existingSk && existingPk) {
+          cmdPk = existingPk
+          skBase = removeSortKeyVersion(existingSk)
+        } else {
+          // Fallback: Strictly parse the ID assuming a 2-segment PK format ({type}#{tenantCode})
+          const parsed = parseTwoSegmentPkSkFromId(itemId)
+          if (!parsed) return null
+          cmdPk = parsed.pk
+          skBase = parsed.skBase
         }
-        cmdPk = parsed.pk
-        skBase = parsed.skBase
+
+        if (!cmdPk || !skBase) return null
+
+        // Optimization: check item version provided by the external source first
+        const currentVersion = existing
+          ? mergeOptions.getVersion?.(existing)
+          : undefined
+        if (currentVersion !== undefined && currentVersion >= session.version) {
+          this.sessionService
+            .delete(userId, tenantCode, this.moduleTableName, itemId)
+            .catch(() => {})
+          return { type: 'synced', itemId }
+        }
+
+        // Verify state against DynamoDB Data Table
+        const dataItem = await this.dataService.getItem({
+          pk: cmdPk,
+          sk: skBase,
+        })
+        if (dataItem && dataItem.version >= session.version) {
+          this.sessionService
+            .delete(userId, tenantCode, this.moduleTableName, itemId)
+            .catch(() => {})
+          return { type: 'synced', itemId }
+        }
+
+        const cmd = await this.commandService.getItem({
+          pk: cmdPk,
+          sk: addSortKeyVersion(skBase, session.version),
+        })
+
+        return cmd ? { type: 'command', cmd, existing, itemId } : null
+      }),
+    )
+
+    const newItems: TItem[] = []
+    let adjustedTotal = baseResult.total
+
+    for (const res of sessionResults) {
+      if (!res || res.type === 'synced') continue
+
+      const { cmd, existing, itemId } = res as {
+        cmd: CommandModel
+        existing?: TItem
+        itemId: string
       }
-
-      if (!cmdPk || !skBase) {
-        continue
-      }
-
-      // Fetch the actual current data record to see if it has caught up
-      const dataItem = await this.dataService.getItem({ pk: cmdPk, sk: skBase })
-
-      // If data table has caught up or surpassed the session, the session is stale
-      if (dataItem && dataItem.version >= session.version) {
-        this.sessionService
-          .delete(userId, tenantCode, this.moduleTableName, itemId)
-          .catch(() => {})
-        continue
-      }
-
-      const cmd = await this.commandService.getItem({
-        pk: cmdPk,
-        sk: addSortKeyVersion(skBase, session.version),
-      })
-      if (!cmd) continue
-
       const transformed = mergeOptions.transformCommand(cmd, existing)
 
       if (cmd.isDeleted) {

--- a/packages/core/src/data-store/dynamodb.service.spec.ts
+++ b/packages/core/src/data-store/dynamodb.service.spec.ts
@@ -1,4 +1,5 @@
 import {
+  DeleteItemCommand,
   DynamoDBClient,
   GetItemCommand,
   PutItemCommand,
@@ -16,7 +17,6 @@ import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3'
 import { sdkStreamMixin } from '@smithy/util-stream'
 import { Readable } from 'stream'
 import { ulid } from 'ulid'
-import { toISOStringWithTimezone } from '../helpers'
 
 const keys = {
   NODE_ENV: 'env',
@@ -51,6 +51,26 @@ describe('DynamoDbService', () => {
     jest.clearAllMocks()
     dynamoDBMock.reset()
     s3Mock.reset()
+  })
+
+  describe('deleteItem', () => {
+    it('should send DeleteItemCommand with the correct parameters', async () => {
+      // Arrange
+      dynamoDBMock.on(DeleteItemCommand).resolves({})
+      const key = { pk: 'master', sk: 'test' }
+
+      // Action
+      await dynamoDbService.deleteItem('table_name', key)
+
+      // Assert
+      expect(dynamoDBMock).toHaveReceivedCommandWith(DeleteItemCommand, {
+        TableName: 'table_name',
+        Key: {
+          pk: { S: 'master' },
+          sk: { S: 'test' },
+        },
+      })
+    })
   })
 
   describe('get', () => {

--- a/packages/core/src/data-store/dynamodb.service.ts
+++ b/packages/core/src/data-store/dynamodb.service.ts
@@ -1,5 +1,6 @@
 import {
   AttributeValue,
+  DeleteItemCommand,
   DynamoDBClient,
   GetItemCommand,
   PutItemCommand,
@@ -124,6 +125,17 @@ export class DynamoDbService {
     )
 
     return await this.ddbItemToObj(Item)
+  }
+
+  async deleteItem(tableName: string, key: DetailKey, conditions?: string) {
+    const res = await this.client.send(
+      new DeleteItemCommand({
+        TableName: tableName,
+        Key: this.toDdbKey(key),
+        ConditionExpression: conditions,
+      }),
+    )
+    return res
   }
 
   async listItemsByPk(

--- a/packages/core/src/data-store/session.service.spec.ts
+++ b/packages/core/src/data-store/session.service.spec.ts
@@ -7,14 +7,17 @@ import { DynamoDbService } from './dynamodb.service'
 
 describe('SessionService', () => {
   let service: SessionService
+  let dynamoDbService: Partial<DynamoDbService>
   let putItem: jest.Mock
   let getItem: jest.Mock
   let listItemsByPk: jest.Mock
+  let deleteItem: jest.Mock
 
   beforeEach(async () => {
     putItem = jest.fn().mockResolvedValue(undefined)
     getItem = jest.fn()
     listItemsByPk = jest.fn()
+    deleteItem = jest.fn().mockResolvedValue({})
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -25,6 +28,7 @@ describe('SessionService', () => {
             putItem,
             getItem,
             listItemsByPk,
+            deleteItem,
           },
         },
         {
@@ -44,6 +48,42 @@ describe('SessionService', () => {
     }).compile()
 
     service = module.get(SessionService)
+    dynamoDbService = module.get(DynamoDbService)
+  })
+
+  describe('delete', () => {
+    it('should call deleteItem with the correct session key', async () => {
+      await service.delete('u1', 't1', 'mod', 'id1')
+
+      expect(deleteItem).toHaveBeenCalledWith('local-test-app-session', {
+        pk: `u1${KEY_SEPARATOR}t1`,
+        sk: `mod${KEY_SEPARATOR}id1`,
+      })
+    })
+
+    it('should handle deletion errors gracefully (non-fatal)', async () => {
+      deleteItem.mockRejectedValue(new Error('Dynamo failure'))
+
+      // Should not throw
+      await expect(
+        service.delete('u1', 't1', 'mod', 'id1'),
+      ).resolves.not.toThrow()
+    })
+
+    it('should no-op if session writes are disabled', async () => {
+      // Setup a service instance where sessionWritesEnabled will be false
+      const mod = await Test.createTestingModule({
+        providers: [
+          SessionService,
+          { provide: DynamoDbService, useValue: { deleteItem: jest.fn() } },
+          { provide: ConfigService, useValue: { get: () => undefined } },
+        ],
+      }).compile()
+      const s = mod.get(SessionService)
+
+      await s.delete('u1', 't1', 'mod', 'id1')
+      expect(mod.get(DynamoDbService).deleteItem).not.toHaveBeenCalled()
+    })
   })
 
   it('should put item with ttl field', async () => {

--- a/packages/core/src/data-store/session.service.ts
+++ b/packages/core/src/data-store/session.service.ts
@@ -115,6 +115,32 @@ export class SessionService {
   }
 
   /**
+   * Delete a session entry.
+   * Used to clean up the session once the data table has caught up to the command version.
+   */
+  async delete(
+    userId: string,
+    tenantCode: string,
+    moduleTableName: string,
+    itemId: string,
+  ): Promise<void> {
+    if (!this.sessionWritesEnabled) return
+
+    const key = {
+      pk: this.buildPk(userId, tenantCode),
+      sk: this.buildSk(moduleTableName, itemId),
+    }
+
+    try {
+      await this.dynamoDbService.deleteItem(this.sessionTableName, key)
+    } catch (error) {
+      this.logger.warn(
+        `Failed to delete RYW session (non-fatal): ${error instanceof Error ? error.message : 'Unknown error'}`,
+      )
+    }
+  }
+
+  /**
    * List session entries for a user scoped to a command module.
    *
    * Queries the session table by `{userId}#{tenantCode}` and filters to entries

--- a/packages/mcp-server/skills/mbc-debug/SKILL.md
+++ b/packages/mcp-server/skills/mbc-debug/SKILL.md
@@ -294,7 +294,38 @@ export class AppModule {}
 
 ---
 
-### 8. Import Processing Issues
+### 8. RYW Session Disappears Before TTL Expiration (v1.2.6+)
+
+**Symptom:** Session entry deleted from `{NODE_ENV}-{APP_NAME}-session` table before `RYW_SESSION_TTL_MINUTES` elapses.
+
+**Cause (intentional, since v1.2.6):** `Repository` proactively purges sessions once the data table catches up (`existing.version >= session.version`). Once your write is visible in the data table, the session is no longer needed — keeping it would cause stale overrides when external updates arrive.
+
+**How to verify the purge succeeded normally:**
+```typescript
+// Check application logs. Absence of this warning means the delete succeeded:
+//   "Failed to delete RYW session (non-fatal): ..."
+//
+// You can also enable Repository debug logs to see the purge decision:
+//   logger.debug(`getItem session merge — version ${session.version}`, key)
+```
+
+**When it's a real problem:** If sessions disappear *and* `Repository.getItem` still returns stale data, the issue is upstream — DynamoDB Streams sync may be delayed. Check `IteratorAge` on the DynamoDB Streams source; a sustained non-zero value indicates the Stream → `IDataSyncHandler` pipeline is falling behind:
+```bash
+# Inspect Stream lag (high IteratorAge = sync is behind = data table stays stale)
+aws cloudwatch get-metric-statistics \
+  --namespace AWS/Lambda \
+  --metric-name IteratorAge \
+  --dimensions Name=FunctionName,Value=your-data-sync-handler \
+  --start-time $(date -u -v-1H +%Y-%m-%dT%H:%M:%S) \
+  --end-time   $(date -u            +%Y-%m-%dT%H:%M:%S) \
+  --period 60 --statistics Maximum
+```
+
+**Related:** If you maintain RDS read models, supply `mergeOptions.getVersion` in `listItems()` to skip the extra DynamoDB round-trip when the RDS row already carries the latest version (see migration guide v1.2.6).
+
+---
+
+### 9. Import Processing Issues
 
 **Symptom:** Import job fails or gets stuck
 
@@ -340,7 +371,7 @@ const validateCsv = async (filePath: string) => {
 
 ---
 
-### 6. Performance Issues
+### 10. Performance Issues
 
 **Symptom:** Slow API responses
 

--- a/packages/mcp-server/skills/mbc-migrate/SKILL.md
+++ b/packages/mcp-server/skills/mbc-migrate/SKILL.md
@@ -39,6 +39,8 @@ This skill helps migrate MBC CQRS Serverless projects between versions.
 | v1.2.0 | v1.2.1 | Low | SqsService added (new feature) |
 | v1.2.1 | v1.2.2 | Low | CsvBatchProcessor Poison Pill fix (transparent) |
 | v1.2.x | v1.2.4 | Medium | TaskModule.register() must be in AppModule |
+| v1.2.4 | v1.2.5 | Low | ZIP import refactor (transparent); MCP AP016–AP020 added |
+| v1.2.5 | v1.2.6 | Low | Repository RYW improvements (transparent); `getVersion` API |
 
 ## Migration Guides
 
@@ -335,6 +337,64 @@ export class AppModule {}
 3. Remove `TaskModule.register()` from all feature modules
 
 **Symptom if skipped:** App crashes at startup with `Nest can't resolve dependencies of MyTaskService (?)`.
+
+---
+
+### v1.2.5 — ZIP import refactor + MCP anti-pattern expansion (no migration steps required)
+
+**Framework changes (transparent):**
+
+- `ZipImportQueueEventHandler` removed; ZIP import jobs are now processed directly inside `ImportService`.
+- `ImportEventHandler` no longer publishes SQS messages for `ZIP_MASTER_JOB` events.
+- Enhanced ZIP import validation in `CreateZipImportDto` and improved error handling/logging.
+
+No application code changes are required. If you previously imported `ZipImportQueueEventHandler` directly (uncommon), remove the import.
+
+**MCP server changes:**
+
+- `mbc_check_anti_patterns` tool expanded from 15 to 20 detectors (AP016–AP020 added):
+  - AP016: Missing Error Logging Before Rethrow (High)
+  - AP017: Incorrect Attribute Merging on Partial Update (High)
+  - AP018: Missing Swagger Documentation / `@ApiTags` (Low)
+  - AP019: Missing Pagination in List Queries (High)
+  - AP020: Missing `getCommandSource` for Tracing (Low)
+- `@modelcontextprotocol/sdk` updated 1.26.0 → 1.29.0.
+
+---
+
+### v1.2.6 — Repository RYW improvements (no migration steps required)
+
+The `Repository` class now actively purges stale RYW sessions when the data table catches up to or surpasses the session version. This eliminates the "stale override" issue where a user could see their own older write even after an external update was already absorbed into the data table.
+
+**Behavior changes (transparent — no code changes required):**
+
+- `getItem`: when `existing.version >= session.version`, the session is purged in the background and the persisted data is returned directly (skipping the unnecessary command-table read).
+- `listItemsByPk`: synchronized sessions are cleaned up in-place during the merge loop.
+- `listItems` (RDS path): per-session checks are now parallelized via `Promise.all`, eliminating sequential N+1 latency.
+
+**New optional optimization for `listItems`:**
+
+```typescript
+// If your RDS rows already carry `version`, supply `getVersion` to skip the
+// extra DynamoDB GetItem entirely when the existing RDS row proves caught-up.
+await repository.listItems(
+  () => rdsQuery(),
+  {
+    latestFlg: true,
+    transformCommand: (cmd) => ({
+      id: cmd.id,
+      version: cmd.version,
+      // ...map other CommandModel fields to your RDS row shape
+    }),
+    getVersion: (item) => item.version,  // ← new in v1.2.6
+  },
+  options,
+)
+```
+
+**Note:** `getVersion` only short-circuits the **update path** (when the session's `itemId` matches an existing RDS row). Create-new items (session present but not yet reflected in RDS) still fetch the command as before — there is no existing row to derive a version from.
+
+All changes are backward-compatible: `getVersion` is optional, and the cleanup behavior is automatic when `RYW_SESSION_TTL_MINUTES` is enabled. Projects with RYW disabled (env var unset) are unaffected.
 
 ---
 

--- a/packages/mcp-server/skills/mbc-review/SKILL.md
+++ b/packages/mcp-server/skills/mbc-review/SKILL.md
@@ -539,13 +539,13 @@ export class OrderDataSyncHandler implements IDataSyncHandler {
       this.eventEmitter.emit('order.created', {
         orderId: cmd.id,
         tenantCode: cmd.tenantCode,
-        ...
+        // ... other fields from cmd.attributes
       });
     }
   }
 
   async down(cmd: CommandModel): Promise<void> {
-    this.eventEmitter.emit('order.deleted', { orderId: cmd.id, ... });
+    this.eventEmitter.emit('order.deleted', { orderId: cmd.id, tenantCode: cmd.tenantCode });
   }
 }
 ```

--- a/packages/mcp-server/skills/mbc-review/SKILL.md
+++ b/packages/mcp-server/skills/mbc-review/SKILL.md
@@ -503,6 +503,61 @@ export class OrderModule {}
 
 ---
 
+### AP021: Emitting Events Directly in XxxCommandService After publishAsync
+
+**Severity:** Error
+
+**Pattern:**
+```typescript
+// Bad - emit immediately after publishAsync (data table not yet written)
+async createOrder(params: CreateOrderParams, context: UserContext): Promise<string> {
+  await this.commandService.publishAsync({ pk, sk, ... }, { invokeContext });
+
+  // WRONG: at this point, DataService.getItem() returns null
+  // because the data table is populated asynchronously via DynamoDB Streams
+  this.eventEmitter.emit('order.created', { orderId, tenantCode, ... });
+  return orderId;
+}
+
+// Bad - @OnEvent handler tries to read from DataService but finds nothing
+@OnEvent('order.created')
+async handleOrderCreated(event: OrderCreatedEvent) {
+  const order = await this.dataService.getItem({ pk, sk }); // Returns null!
+}
+
+// Good - emit inside IDataSyncHandler.up() AFTER data table write
+@Injectable()
+export class OrderDataSyncHandler implements IDataSyncHandler {
+  constructor(private readonly eventEmitter: EventEmitter2) {}
+
+  async up(cmd: CommandModel): Promise<void> {
+    if (!cmd.pk.startsWith('ORDER#')) return;
+    if (cmd.isDeleted) return;
+
+    if (cmd.version === VERSION_FIRST + 1) {
+      // Data table is already written at this point — DataService.getItem() works
+      this.eventEmitter.emit('order.created', {
+        orderId: cmd.id,
+        tenantCode: cmd.tenantCode,
+        ...
+      });
+    }
+  }
+
+  async down(cmd: CommandModel): Promise<void> {
+    this.eventEmitter.emit('order.deleted', { orderId: cmd.id, ... });
+  }
+}
+```
+
+**Explanation:** `publishAsync` writes only to the DynamoDB **command** table. The **data** table (read by `DataService.getItem()`) is populated asynchronously via DynamoDB Streams → Step Functions → `IDataSyncHandler.up()`. Emitting events in `XxxCommandService` immediately after `publishAsync` means any `@OnEvent` handler that calls `DataService.getItem()` will find no data, causing "entity not found" errors.
+
+The correct pattern is to implement a custom `IDataSyncHandler` and emit events in `up()` / `down()`. By the time these methods run, the data table write has already completed. Register the handler in `CommandModule.register({ dataSyncHandlers: [...] })`.
+
+If you need to include previous field values for change-detection (e.g., `statusChanged`), embed them as `attributes._prev` in the `publishAsync` call and read them in the handler. Strip `_prev` from RDS sync handlers to prevent internal metadata from leaking into the database.
+
+---
+
 ## Review Checklist
 
 When reviewing MBC CQRS Serverless code, check:
@@ -520,6 +575,7 @@ When reviewing MBC CQRS Serverless code, check:
 - [ ] Existing version is fetched for updates
 - [ ] `generateId()` is used for ID generation
 - [ ] `getCommandSource()` is used for tracing
+- [ ] `eventEmitter.emit()` is NOT called directly after `publishAsync` (use IDataSyncHandler instead)
 
 ### DTOs
 - [ ] class-validator decorators are present
@@ -537,10 +593,12 @@ When reviewing MBC CQRS Serverless code, check:
 - [ ] Errors are logged appropriately
 
 ### Data Sync Handler
-- [ ] `@DataSyncHandler({ type: 'ENTITY' })` decorator is present
+- [ ] `@DataSyncHandler({ type: 'ENTITY' })` decorator is present (for RDS sync handlers)
 - [ ] Implements `IDataSyncHandler`
 - [ ] Handles both create/update and delete cases
 - [ ] Registered in module
+- [ ] Event-emitting handlers implement `IDataSyncHandler` and emit in `up()` / `down()`
+- [ ] `_prev` metadata is stripped before RDS upsert if used for change-detection
 
 ## Output Format
 

--- a/packages/mcp-server/skills/mbc-review/SKILL.md
+++ b/packages/mcp-server/skills/mbc-review/SKILL.md
@@ -21,6 +21,43 @@ Before executing this skill, check for updates:
 
 This skill reviews code for MBC CQRS Serverless best practices and identifies anti-patterns.
 
+## ⚠️ Important: Two Anti-Pattern Code Systems
+
+This codebase currently has **two independent `AP00X` numbering systems** that are NOT interchangeable:
+
+1. **Skill `AP` codes** (this document) — used in human-facing reviews and documentation. Stable identifiers for discussion.
+2. **Detector `AP` codes** (output of the `mbc_check_anti_patterns` tool, defined in `src/tools/analyze.ts`) — used by the static analysis tool. Numbered in detector implementation order.
+
+**Only AP016, AP017, AP018, AP019, and AP021 happen to refer to the same concept in both systems.** All other AP numbers diverge — for example, the detector's `AP005: Hardcoded Tenant` corresponds to this document's `AP002: Missing tenantCode`. Do not assume the codes match.
+
+**Cross-reference table** (detector → skill doc):
+
+| Detector code (analyze.ts) | Skill doc code (this file) | Topic |
+|---|---|---|
+| AP001 Direct DynamoDB Write | AP012 | Bypassing CommandService / DataService |
+| AP002 Ignored Version Mismatch | AP005 | ConditionalCheckFailedException handling |
+| AP003 N+1 Query Pattern | — (detector only) | Query in a loop |
+| AP004 Full Table Scan | — (detector only) | `.scan()` usage |
+| AP005 Hardcoded Tenant | AP002 | Multi-tenant code/key handling |
+| AP006 Missing Tenant Validation | AP002 | Trusting client-provided `tenantCode` |
+| AP007 Throwing in Sync Handler | — (detector only) | DataSyncHandler error escape |
+| AP008 Hardcoded Secret | — (detector only) | Secrets in code |
+| AP009 Manual JWT Parsing | — (detector only) | Bypassing Cognito authorizer |
+| AP010 Heavy Module Import | — (detector only) | Cold-start optimization |
+| AP011 Deprecated Method Usage | AP010 | `publish()` / `publishPartialUpdate()` removal |
+| AP012 Uppercase COMMON Tenant Key | — (detector only) | v1.1.0 tenant key migration |
+| AP013 publishSync Null Return Unchecked | AP001 (related) | `publishSync` v1.2.0+ return |
+| AP014 Deprecated genNewSequence | AP010 (related) | v1.2.0 sequence API change |
+| AP015 Duplicate TaskModule Registration | — (detector only) | v1.2.4 global TaskModule |
+| AP016 Missing Error Logging Before Rethrow | AP016 | ✅ same code |
+| AP017 Incorrect Attribute Merging | AP017 | ✅ same code |
+| AP018 Missing Swagger Documentation | AP018 | ✅ same code |
+| AP019 Missing Pagination in List Queries | AP019 | ✅ same code |
+| AP020 Missing getCommandSource for Tracing | AP011 | Tracing/audit |
+| AP021 Event Emit After publishAsync | AP021 | ✅ same code |
+
+When you receive `mbc_check_anti_patterns` output, look up the detector code in this table to find the corresponding skill-doc section for full context and recommended fixes. Future versions of this framework should consolidate the two systems; until then, treat them as separate identifier spaces.
+
 ## Anti-Patterns to Detect
 
 ### AP001: Using publishSync Instead of publishAsync
@@ -555,6 +592,10 @@ export class OrderDataSyncHandler implements IDataSyncHandler {
 The correct pattern is to implement a custom `IDataSyncHandler` and emit events in `up()` / `down()`. By the time these methods run, the data table write has already completed. Register the handler in `CommandModule.register({ dataSyncHandlers: [...] })`.
 
 If you need to include previous field values for change-detection (e.g., `statusChanged`), embed them as `attributes._prev` in the `publishAsync` call and read them in the handler. Strip `_prev` from RDS sync handlers to prevent internal metadata from leaking into the database.
+
+**Related (v1.2.6+):** If you only need read-your-writes consistency for the **same user within the same request flow** (e.g. POST → immediate GET in the API client), the Repository's RYW session mechanism (when `RYW_SESSION_TTL_MINUTES` is enabled) is sufficient — it merges the pending command-table write into the next read by the originating user, no event handler required.
+
+The `IDataSyncHandler.up()` pattern above is still required when other users, background jobs, or cross-module event subscribers need to react to the change — RYW only covers the writer's own subsequent reads.
 
 ---
 

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -11,10 +11,24 @@ import {
   McpError,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js'
+import { readFileSync } from 'fs'
+import { join } from 'path'
 
 import { handlePromptGet, registerPrompts } from './prompts/index.js'
 import { handleResourceRead, registerResources } from './resources/index.js'
 import { handleToolCall, registerTools } from './tools/index.js'
+
+// Read version from package.json so it stays in sync after `lerna version` bumps.
+const PACKAGE_VERSION: string = (() => {
+  try {
+    const pkg = JSON.parse(
+      readFileSync(join(__dirname, '..', 'package.json'), 'utf8'),
+    )
+    return pkg.version ?? '0.0.0'
+  } catch {
+    return '0.0.0'
+  }
+})()
 
 /**
  * MCP Server for MBC CQRS Serverless framework.
@@ -30,7 +44,7 @@ export class McpServer {
     this.server = new Server(
       {
         name: 'mbc-cqrs-serverless',
-        version: '0.1.74-beta.0',
+        version: PACKAGE_VERSION,
       },
       {
         capabilities: {

--- a/packages/mcp-server/src/tools/analyze.spec.ts
+++ b/packages/mcp-server/src/tools/analyze.spec.ts
@@ -8,8 +8,8 @@ describe('analyze tools', () => {
     it('should return all analyze tools', () => {
       const tools = getAnalyzeTools()
       expect(tools).toHaveLength(5)
-      
-      const toolNames = tools.map(t => t.name)
+
+      const toolNames = tools.map((t) => t.name)
       expect(toolNames).toContain('mbc_analyze_project')
       expect(toolNames).toContain('mbc_lookup_error')
       expect(toolNames).toContain('mbc_check_anti_patterns')
@@ -32,14 +32,17 @@ describe('analyze tools', () => {
 
     it('should detect direct DynamoDB write (AP001)', async () => {
       const testFile = path.join(testDir, 'src', 'test.ts')
-      fs.writeFileSync(testFile, `
+      fs.writeFileSync(
+        testFile,
+        `
         const command = new PutItemCommand({ TableName: 'test' })
-      `)
+      `,
+      )
 
       const result = await handleAnalyzeTool(
         'mbc_check_anti_patterns',
         { path: 'src' },
-        testDir
+        testDir,
       )
 
       expect(result.content[0].text).toContain('AP001')
@@ -48,14 +51,17 @@ describe('analyze tools', () => {
 
     it('should detect hardcoded tenant (AP005)', async () => {
       const testFile = path.join(testDir, 'src', 'test.ts')
-      fs.writeFileSync(testFile, `
+      fs.writeFileSync(
+        testFile,
+        `
         const pk = "TENANT#hardcoded"
-      `)
+      `,
+      )
 
       const result = await handleAnalyzeTool(
         'mbc_check_anti_patterns',
         { path: 'src' },
-        testDir
+        testDir,
       )
 
       expect(result.content[0].text).toContain('AP005')
@@ -64,14 +70,17 @@ describe('analyze tools', () => {
 
     it('should detect hardcoded secret (AP008)', async () => {
       const testFile = path.join(testDir, 'src', 'test.ts')
-      fs.writeFileSync(testFile, `
+      fs.writeFileSync(
+        testFile,
+        `
         const password = "supersecretpassword123"
-      `)
+      `,
+      )
 
       const result = await handleAnalyzeTool(
         'mbc_check_anti_patterns',
         { path: 'src' },
-        testDir
+        testDir,
       )
 
       expect(result.content[0].text).toContain('AP008')
@@ -85,7 +94,7 @@ describe('analyze tools', () => {
       const result = await handleAnalyzeTool(
         'mbc_check_anti_patterns',
         { path: 'src' },
-        testDir
+        testDir,
       )
 
       expect(result.content[0].text).toContain('AP010')
@@ -94,18 +103,21 @@ describe('analyze tools', () => {
 
     it('should return success when no anti-patterns found', async () => {
       const testFile = path.join(testDir, 'src', 'test.ts')
-      fs.writeFileSync(testFile, `
+      fs.writeFileSync(
+        testFile,
+        `
         export class TestService {
           async doSomething() {
             return 'hello'
           }
         }
-      `)
+      `,
+      )
 
       const result = await handleAnalyzeTool(
         'mbc_check_anti_patterns',
         { path: 'src' },
-        testDir
+        testDir,
       )
 
       expect(result.content[0].text).toContain('No anti-patterns detected')
@@ -113,24 +125,55 @@ describe('analyze tools', () => {
 
     it('should skip test files', async () => {
       const testFile = path.join(testDir, 'src', 'test.spec.ts')
-      fs.writeFileSync(testFile, `
+      fs.writeFileSync(
+        testFile,
+        `
         const password = "supersecretpassword123"
-      `)
+      `,
+      )
 
       const result = await handleAnalyzeTool(
         'mbc_check_anti_patterns',
         { path: 'src' },
-        testDir
+        testDir,
       )
 
       expect(result.content[0].text).toContain('No anti-patterns detected')
+    })
+
+    it('should detect event emit after publishAsync in CommandService (AP021)', async () => {
+      const testFile = path.join(testDir, 'src', 'test.ts')
+      fs.writeFileSync(
+        testFile,
+        `
+        @Injectable()
+        export class OrderCommandService {
+          async createOrder(params: CreateOrderParams): Promise<string> {
+            await this.commandService.publishAsync({ pk, sk, version: VERSION_FIRST }, { invokeContext });
+            this.eventEmitter.emit('order.created', { orderId });
+            return orderId;
+          }
+        }
+      `,
+      )
+
+      const result = await handleAnalyzeTool(
+        'mbc_check_anti_patterns',
+        { path: 'src' },
+        testDir,
+      )
+
+      expect(result.content[0].text).toContain('AP021')
+      expect(result.content[0].text).toContain(
+        'Event Emit Directly After publishAsync',
+      )
     })
 
     it('should return error for non-existent path', async () => {
       const result = await handleAnalyzeTool(
         'mbc_check_anti_patterns',
         { path: 'nonexistent' },
-        testDir
+        testDir,
       )
 
       expect(result.isError).toBe(true)
@@ -150,70 +193,62 @@ describe('analyze tools', () => {
     })
 
     it('should detect healthy project with MBC packages', async () => {
-      fs.writeFileSync(path.join(testDir, 'package.json'), JSON.stringify({
-        name: 'test-project',
-        dependencies: {
-          '@mbc-cqrs-serverless/core': '^1.0.0',
-          '@nestjs/common': '^10.0.0',
-        },
-        devDependencies: {
-          typescript: '^5.0.0',
-        },
-      }))
+      fs.writeFileSync(
+        path.join(testDir, 'package.json'),
+        JSON.stringify({
+          name: 'test-project',
+          dependencies: {
+            '@mbc-cqrs-serverless/core': '^1.0.0',
+            '@nestjs/common': '^10.0.0',
+          },
+          devDependencies: {
+            typescript: '^5.0.0',
+          },
+        }),
+      )
       fs.mkdirSync(path.join(testDir, 'src'), { recursive: true })
       fs.writeFileSync(path.join(testDir, 'src', 'app.module.ts'), '')
       fs.writeFileSync(path.join(testDir, '.env'), '')
       fs.writeFileSync(path.join(testDir, 'serverless.yml'), '')
 
-      const result = await handleAnalyzeTool(
-        'mbc_health_check',
-        {},
-        testDir
-      )
+      const result = await handleAnalyzeTool('mbc_health_check', {}, testDir)
 
       expect(result.content[0].text).toContain('HEALTHY')
       expect(result.content[0].text).toContain('MBC Framework')
     })
 
     it('should detect missing MBC packages', async () => {
-      fs.writeFileSync(path.join(testDir, 'package.json'), JSON.stringify({
-        name: 'test-project',
-        dependencies: {
-          '@nestjs/common': '^10.0.0',
-        },
-      }))
+      fs.writeFileSync(
+        path.join(testDir, 'package.json'),
+        JSON.stringify({
+          name: 'test-project',
+          dependencies: {
+            '@nestjs/common': '^10.0.0',
+          },
+        }),
+      )
       fs.mkdirSync(path.join(testDir, 'src'), { recursive: true })
 
-      const result = await handleAnalyzeTool(
-        'mbc_health_check',
-        {},
-        testDir
-      )
+      const result = await handleAnalyzeTool('mbc_health_check', {}, testDir)
 
       expect(result.content[0].text).toContain('ERROR')
-      expect(result.content[0].text).toContain('No @mbc-cqrs-serverless packages found')
+      expect(result.content[0].text).toContain(
+        'No @mbc-cqrs-serverless packages found',
+      )
     })
 
     it('should handle invalid package.json', async () => {
       fs.writeFileSync(path.join(testDir, 'package.json'), 'invalid json')
       fs.mkdirSync(path.join(testDir, 'src'), { recursive: true })
 
-      const result = await handleAnalyzeTool(
-        'mbc_health_check',
-        {},
-        testDir
-      )
+      const result = await handleAnalyzeTool('mbc_health_check', {}, testDir)
 
       expect(result.content[0].text).toContain('ERROR')
       expect(result.content[0].text).toContain('could not be parsed')
     })
 
     it('should detect missing package.json', async () => {
-      const result = await handleAnalyzeTool(
-        'mbc_health_check',
-        {},
-        testDir
-      )
+      const result = await handleAnalyzeTool('mbc_health_check', {}, testDir)
 
       expect(result.content[0].text).toContain('ERROR')
       expect(result.content[0].text).toContain('package.json not found')
@@ -233,18 +268,21 @@ describe('analyze tools', () => {
 
     it('should detect NestJS module', async () => {
       const testFile = path.join(testDir, 'app.module.ts')
-      fs.writeFileSync(testFile, `
+      fs.writeFileSync(
+        testFile,
+        `
         @Module({
           imports: [CommandModule],
           providers: [AppService],
         })
         export class AppModule {}
-      `)
+      `,
+      )
 
       const result = await handleAnalyzeTool(
         'mbc_explain_code',
         { file_path: 'app.module.ts' },
-        testDir
+        testDir,
       )
 
       expect(result.content[0].text).toContain('NestJS Module')
@@ -253,7 +291,9 @@ describe('analyze tools', () => {
 
     it('should detect REST controller', async () => {
       const testFile = path.join(testDir, 'app.controller.ts')
-      fs.writeFileSync(testFile, `
+      fs.writeFileSync(
+        testFile,
+        `
         @Controller('api')
         export class AppController {
           @Get()
@@ -262,12 +302,13 @@ describe('analyze tools', () => {
           @Post()
           create() {}
         }
-      `)
+      `,
+      )
 
       const result = await handleAnalyzeTool(
         'mbc_explain_code',
         { file_path: 'app.controller.ts' },
-        testDir
+        testDir,
       )
 
       expect(result.content[0].text).toContain('REST Controller')
@@ -277,7 +318,9 @@ describe('analyze tools', () => {
 
     it('should detect service with CommandService', async () => {
       const testFile = path.join(testDir, 'app.service.ts')
-      fs.writeFileSync(testFile, `
+      fs.writeFileSync(
+        testFile,
+        `
         @Injectable()
         export class AppService {
           constructor(private commandService: CommandService) {}
@@ -286,12 +329,13 @@ describe('analyze tools', () => {
             await this.commandService.publishAsync(...)
           }
         }
-      `)
+      `,
+      )
 
       const result = await handleAnalyzeTool(
         'mbc_explain_code',
         { file_path: 'app.service.ts' },
-        testDir
+        testDir,
       )
 
       expect(result.content[0].text).toContain('Service')
@@ -301,18 +345,21 @@ describe('analyze tools', () => {
 
     it('should detect entity with DynamoDB keys', async () => {
       const testFile = path.join(testDir, 'item.entity.ts')
-      fs.writeFileSync(testFile, `
+      fs.writeFileSync(
+        testFile,
+        `
         export class ItemEntity extends CommandEntity {
           pk: string
           sk: string
           name: string
         }
-      `)
+      `,
+      )
 
       const result = await handleAnalyzeTool(
         'mbc_explain_code',
         { file_path: 'item.entity.ts' },
-        testDir
+        testDir,
       )
 
       expect(result.content[0].text).toContain('Entity')
@@ -324,7 +371,7 @@ describe('analyze tools', () => {
       const result = await handleAnalyzeTool(
         'mbc_explain_code',
         { file_path: 'nonexistent.ts' },
-        testDir
+        testDir,
       )
 
       expect(result.isError).toBe(true)
@@ -333,16 +380,19 @@ describe('analyze tools', () => {
 
     it('should explain specific line range', async () => {
       const testFile = path.join(testDir, 'test.ts')
-      fs.writeFileSync(testFile, `line1
+      fs.writeFileSync(
+        testFile,
+        `line1
 line2
 line3
 line4
-line5`)
+line5`,
+      )
 
       const result = await handleAnalyzeTool(
         'mbc_explain_code',
         { file_path: 'test.ts', start_line: 2, end_line: 4 },
-        testDir
+        testDir,
       )
 
       expect(result.content[0].text).toContain('lines 2-4')

--- a/packages/mcp-server/src/tools/analyze.ts
+++ b/packages/mcp-server/src/tools/analyze.ts
@@ -641,6 +641,17 @@ const ANTI_PATTERNS = [
     recommendation:
       'Include source in publish options using getCommandSource(basename(__dirname), this.constructor.name, methodName) for debugging and audit trails.',
   },
+  {
+    code: 'AP021',
+    name: 'Event Emit Directly After publishAsync in CommandService',
+    severity: 'critical' as const,
+    // Detect eventEmitter.emit() called in the same method body after commandService.publishAsync/publishSync
+    // Pattern: publishAsync(...) followed by eventEmitter.emit(...) without an IDataSyncHandler boundary
+    pattern:
+      /commandService\.publish(?:Async|Sync|PartialUpdateAsync|PartialUpdateSync)\b[\s\S]{0,500}?this\.eventEmitter\.emit\s*\(/,
+    recommendation:
+      'Do not call eventEmitter.emit() directly after publishAsync(). At that point only the command table has been written; the data table is populated asynchronously via DynamoDB Streams. Any @OnEvent handler that calls DataService.getItem() will find no data. Instead, implement IDataSyncHandler and emit events inside up()/down(), which are called after the data table write completes. Register the handler in CommandModule.register({ dataSyncHandlers: [...] }). If change-detection is needed (e.g. statusChanged), embed previous values as attributes._prev in publishAsync and read them in the handler; strip _prev in RDS sync handlers to prevent it leaking into the database.',
+  },
 ]
 
 /**

--- a/packages/mcp-server/src/tools/analyze.ts
+++ b/packages/mcp-server/src/tools/analyze.ts
@@ -644,11 +644,11 @@ const ANTI_PATTERNS = [
   {
     code: 'AP021',
     name: 'Event Emit Directly After publishAsync in CommandService',
-    severity: 'critical' as const,
-    // Detect eventEmitter.emit() called in the same method body after commandService.publishAsync/publishSync
-    // Pattern: publishAsync(...) followed by eventEmitter.emit(...) without an IDataSyncHandler boundary
+    severity: 'high' as const,
+    // Detect eventEmitter.emit() called close after commandService.publishAsync/publishSync.
+    // 200-char window reduces cross-method false positives while catching same-method violations.
     pattern:
-      /commandService\.publish(?:Async|Sync|PartialUpdateAsync|PartialUpdateSync)\b[\s\S]{0,500}?this\.eventEmitter\.emit\s*\(/,
+      /commandService\.publish(?:Async|Sync|PartialUpdateAsync|PartialUpdateSync)\b[\s\S]{0,200}?this\.eventEmitter\.emit\s*\(/,
     recommendation:
       'Do not call eventEmitter.emit() directly after publishAsync(). At that point only the command table has been written; the data table is populated asynchronously via DynamoDB Streams. Any @OnEvent handler that calls DataService.getItem() will find no data. Instead, implement IDataSyncHandler and emit events inside up()/down(), which are called after the data table write completes. Register the handler in CommandModule.register({ dataSyncHandlers: [...] }). If change-detection is needed (e.g. statusChanged), embed previous values as attributes._prev in publishAsync and read them in the handler; strip _prev in RDS sync handlers to prevent it leaking into the database.',
   },

--- a/packages/mcp-server/src/tools/analyze.ts
+++ b/packages/mcp-server/src/tools/analyze.ts
@@ -460,7 +460,17 @@ interface AntiPatternMatch {
 
 /**
  * Anti-patterns to check for.
- * Codes are sequential from AP001 to AP010.
+ *
+ * Codes are sequential from AP001 to AP021 in detector-implementation order.
+ *
+ * IMPORTANT: These detector codes are a SEPARATE numbering system from the AP codes
+ * used in `skills/mbc-review/SKILL.md`. Only AP016, AP017, AP018, AP019, and AP021
+ * happen to refer to the same concept in both systems. See the cross-reference
+ * table at the top of `skills/mbc-review/SKILL.md` to map a detector code to its
+ * corresponding skill-doc section.
+ *
+ * When adding a new detector, append at the end (do not renumber) and update the
+ * cross-reference table in `skills/mbc-review/SKILL.md`.
  */
 const ANTI_PATTERNS = [
   {
@@ -655,6 +665,30 @@ const ANTI_PATTERNS = [
 ]
 
 /**
+ * Maps a detector AP code (this file) to the corresponding skill-doc AP code in
+ * `skills/mbc-review/SKILL.md`. Used to annotate detector output so users can
+ * navigate from a detector hit to the human-readable explanation.
+ *
+ * Codes not present in the map are detector-only (no skill-doc counterpart).
+ * Keep this table in sync with the cross-reference table in SKILL.md.
+ */
+const DETECTOR_TO_SKILL_AP: Record<string, string> = {
+  AP001: 'AP012', // Direct DynamoDB Write → Direct DynamoDB Access Instead of DataService
+  AP002: 'AP005', // Ignored Version Mismatch → Not Handling ConditionalCheckFailedException
+  AP005: 'AP002', // Hardcoded Tenant → Missing tenantCode in Multi-Tenant Operations
+  AP006: 'AP002', // Missing Tenant Validation → Missing tenantCode in Multi-Tenant Operations
+  AP011: 'AP010', // Deprecated Method Usage → Deprecated Method Usage
+  AP013: 'AP001', // publishSync Null Return Unchecked → Using publishSync Instead of publishAsync (related)
+  AP014: 'AP010', // Deprecated genNewSequence → Deprecated Method Usage (related)
+  AP016: 'AP016', // Missing Error Logging Before Rethrow ✅
+  AP017: 'AP017', // Incorrect Attribute Merging ✅
+  AP018: 'AP018', // Missing Swagger Documentation ✅
+  AP019: 'AP019', // Missing Pagination in List Queries ✅
+  AP020: 'AP011', // Missing getCommandSource for Tracing → Missing getCommandSource for Tracing
+  AP021: 'AP021', // Event Emit After publishAsync ✅
+}
+
+/**
  * Check for anti-patterns in code.
  */
 async function checkAntiPatterns(
@@ -733,6 +767,8 @@ async function checkAntiPatterns(
   text += `| 🟠 High | ${high.length} |\n`
   text += `| 🟡 Medium | ${medium.length} |\n`
   text += `| 🟢 Low | ${low.length} |\n\n`
+  text +=
+    '> **Note:** AP codes below are *detector codes* (from `analyze.ts`). They are a separate numbering system from the AP codes in `mbc-review` skill documentation. See the cross-reference table at the top of `skills/mbc-review/SKILL.md` to map a detector code to its corresponding skill-doc section.\n\n'
 
   for (const m of matches) {
     const icon =
@@ -743,7 +779,9 @@ async function checkAntiPatterns(
           : m.severity === 'medium'
             ? '🟡'
             : '🟢'
-    text += `### ${icon} ${m.code}: ${m.name}\n\n`
+    const skillRef = DETECTOR_TO_SKILL_AP[m.code]
+    const skillRefSuffix = skillRef ? ` _(skill-doc: ${skillRef})_` : ''
+    text += `### ${icon} ${m.code}: ${m.name}${skillRefSuffix}\n\n`
     text += `**File:** \`${m.file}:${m.line}\`\n`
     text += `**Snippet:** \`${m.snippet}\`\n\n`
     text += `**Recommendation:** ${m.recommendation}\n\n`


### PR DESCRIPTION
## Summary

Release `develop` → `main` for **v1.2.6**. Bundles the following merged PRs:

- **#408** `feat(mcp-server)`: Add AP021 anti-pattern detector — flags `eventEmitter.emit()` called directly after `commandService.publishAsync()` in the same method (data table not yet written, `@OnEvent` handlers find no data).
- **#410** `feat(core)`: Repository RYW improvements — proactively purge stale RYW sessions when the data table catches up to or surpasses the session version, eliminating "stale override" reads. Adds `mergeOptions.getVersion` to short-circuit the data-table check on the `listItems` path. Parallelizes per-session merging with `Promise.all`.
- **#411** `feat(mcp-server)`: Skill documentation for v1.2.6 + cross-reference table mapping detector AP codes to skill-doc AP codes (the two systems were silently diverging). Also fixes hardcoded package version in `server.ts`.

## Highlights

**Repository RYW (transparent — no migration steps required):**

- `getItem`: when `existing.version >= session.version`, the session is purged in the background and persisted data is returned directly.
- `listItemsByPk` / `listItems`: synchronized sessions are cleaned up in-place during the merge loop.
- `listItems` (RDS path): per-session checks now run in parallel; new optional `getVersion` lets callers skip the extra DynamoDB GetItem when the RDS row already proves caught-up.

All RYW changes are backward-compatible. Projects with `RYW_SESSION_TTL_MINUTES` unset are unaffected.

**MCP server:**

- New `mbc_check_anti_patterns` detector AP021 (Severity: High).
- Detector output now annotates each hit with the corresponding skill-doc AP code, e.g. `AP005: Hardcoded Tenant (skill-doc: AP002)`. The two AP numbering systems are documented side-by-side in `skills/mbc-review/SKILL.md`.

## Test plan

- [x] `npm run build` (mcp-server) passes
- [x] `npm test` (mcp-server) passes — 265/265
- [x] CI green for #410 across Node 18/20/22/24 (Unit + E2E)
- [ ] Reviewer: confirm v1.2.6 release notes in `docs/changelog.md` reflect these changes before tagging
- [ ] Reviewer: after merge, tag `v1.2.6` on `main` to trigger publish workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
