### PR TITLE
chore(deps): bump follow-redirects to ^1.16.0 (security)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16217,9 +16217,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {
@@ -16227,6 +16227,7 @@
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },

--- a/package.json
+++ b/package.json
@@ -146,7 +146,8 @@
     "tmp": "0.2.4",
     "webpack": "^5.105.0",
     "qs": "^6.14.2",
-    "yaml": "^2.8.3"
+    "yaml": "^2.8.3",
+    "follow-redirects": "^1.16.0"
   },
   "dependencies": {
     "jszip": "^3.10.1"


### PR DESCRIPTION
## Summary

Fourth security upgrade. Adds a single `overrides` entry to bump the only transitive `follow-redirects` install from `1.15.11` to `1.16.0`.

## Vulnerability addressed

- [GHSA-r4q5-vmmm-2653](https://github.com/advisories/GHSA-r4q5-vmmm-2653) — `follow-redirects` leaks Custom Authentication Headers to Cross-Domain Redirect Targets (moderate)

Vulnerable range: `<=1.15.11`. Fixed in `1.16.0`.

## Affected dependency path

```
mbc-cqrs-serverless
└── lerna → nx → axios → follow-redirects
```

Single dev/build-time-only path — not used at production runtime. axios in this path is only invoked by the nx CLI for local tooling, so practical exposure is nil.

## Verification

- `npm audit`: **98 → 97** vulnerabilities (-1 follow-redirects)
- `npm test` (local, macOS): identical to baseline — 156/157 suites pass, 3502/3546 tests pass. The single pre-existing failure in `csv-import.sfn.event.handler.spec.ts` is the macOS-only TS1261 casing collision in `@types/jsonstream` and is unrelated to this PR. CI runs on Linux where this is not a problem.

## Strategy progress

1. ✅ `webpack` (low, build-time) — PR #414, merged
2. ⏭️ `mailparser` / `aws-ses-v2-local` (low, dev/test) — deferred (npm overrides bug)
3. 🟡 `qs` (low, runtime) — PR #416, awaiting merge
4. ⏭️ `brace-expansion` (moderate, build-time) — deferred (multi-version transitive complexity)
5. 🟡 `yaml` (moderate, build/dev-time) — PR #417, awaiting merge
6. ⏭️ `ip-address` (moderate, deps of MCP server) — deferred (express-rate-limit pin)
7. ✅ This PR: `follow-redirects` (moderate, dev/build-time)

## Test plan

- [ ] CI Unit Test (Node 18/20/22/24) passes on Linux
- [ ] CI E2E Test passes on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)