### PR TITLE
chore(deps): bump flatted to ^3.4.2 (security)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16256,10 +16256,11 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fn.name": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,8 @@
     "webpack": "^5.105.0",
     "qs": "^6.14.2",
     "yaml": "^2.8.3",
-    "follow-redirects": "^1.16.0"
+    "follow-redirects": "^1.16.0",
+    "flatted": "^3.4.2"
   },
   "dependencies": {
     "jszip": "^3.10.1"


### PR DESCRIPTION
## Summary

Fifth security upgrade. First **HIGH severity** advisory addressed in this initiative. Adds a single `overrides` entry to bump the only transitive `flatted` install from `3.3.3` to `3.4.2`.

## Vulnerabilities addressed

- [GHSA-25h7-pfq9-p65f](https://github.com/advisories/GHSA-25h7-pfq9-p65f) — `flatted` unbounded recursion DoS in `parse()` revive phase (HIGH / CVSS 7.5)
- [GHSA-rf6f-7fwh-wjgh](https://github.com/advisories/GHSA-rf6f-7fwh-wjgh) — Prototype Pollution via `parse()` in NodeJS `flatted` (HIGH)

Vulnerable range: `<=3.4.1`. Fixed in `3.4.2`.

## Affected dependency path

```
mbc-cqrs-serverless
└── eslint → file-entry-cache → flat-cache → flatted
```

Single dev/lint-time-only path. `flatted` is used by ESLint's cache file format (`.eslintcache`). Not invoked at production runtime; exposure limited to malformed cache files on a developer machine.

## Verification

- `npm audit`: **98 → 97** vulnerabilities (-1 flatted, high count 64 → 63)
- `npm test` (local, macOS): identical to baseline — 156/157 suites pass, 3502/3546 tests pass. The single pre-existing failure in `csv-import.sfn.event.handler.spec.ts` is the macOS-only TS1261 casing collision in `@types/jsonstream` and is unrelated to this PR. CI runs on Linux where this is not a problem.

## Strategy progress

1. ✅ `webpack` (low) — PR #414, merged
2. ⏭️ `mailparser` / `aws-ses-v2-local` (low) — deferred (npm overrides ignored)
3. 🟡 `qs` (low) — PR #416
4. ⏭️ `brace-expansion` (moderate) — deferred (multi-version complexity)
5. 🟡 `yaml` (moderate) — PR #417
6. ⏭️ `ip-address` (moderate) — deferred (express-rate-limit pin)
7. 🟡 `follow-redirects` (moderate) — PR #418, CI green
8. ⏭️ `koa` (high) — deferred (npm overrides ignored)
9. ✅ This PR: `flatted` (HIGH) — first high-severity success

## Test plan

- [ ] CI Unit Test (Node 18/20/22/24) passes on Linux
- [ ] CI E2E Test passes on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)