### PR TITLE
chore(deps): bump serverless-dynamodb to ^0.2.58 (security)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11100,12 +11100,63 @@
       }
     },
     "node_modules/aws-dynamodb-local": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/aws-dynamodb-local/-/aws-dynamodb-local-0.0.11.tgz",
-      "integrity": "sha512-Vz7UAgNY3bEb7nWAQvEg5VGP0nF8nJ3QEExf/fiv4jdLdfEfobv0w/iaSjxFVK9V5emamhmqNSvnUF9EVQQa+w==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/aws-dynamodb-local/-/aws-dynamodb-local-0.0.14.tgz",
+      "integrity": "sha512-LrpP9L4kFT+uOviDsDoRVouvTwHLoIbUkJCJ3xT0VIZkowJC5t/zHLds0gLxHVUn35BrbgKHhDK2H4+ylCihbQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "tar": "^6.2.0"
+        "tar": "^7.5.6"
+      }
+    },
+    "node_modules/aws-dynamodb-local/node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/aws-dynamodb-local/node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/aws-dynamodb-local/node_modules/tar": {
+      "version": "7.5.15",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/aws-dynamodb-local/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/aws-sdk": {
@@ -26137,14 +26188,15 @@
       }
     },
     "node_modules/serverless-dynamodb": {
-      "version": "0.2.56",
-      "resolved": "https://registry.npmjs.org/serverless-dynamodb/-/serverless-dynamodb-0.2.56.tgz",
-      "integrity": "sha512-b378F7yUMrT+atFZteHquSg2TlnnGug7jTsOdGQ+6eApAP/CpW+5HsO+CYXGDgVBl2UqTqt6/HeQqr7vN8g9tg==",
+      "version": "0.2.58",
+      "resolved": "https://registry.npmjs.org/serverless-dynamodb/-/serverless-dynamodb-0.2.58.tgz",
+      "integrity": "sha512-HGNmaHu2RnjAjyDHh3v9q9aFs2Ypu6A67mlJdAcROHaRXkfIpRwir8dnOu6mwRKMHzPpHQZ5pRWa++mFkOAsZg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@aws-sdk/client-dynamodb": "^3.428.0",
-        "@aws-sdk/lib-dynamodb": "^3.428.0",
-        "aws-dynamodb-local": "^0.0.11"
+        "@aws-sdk/client-dynamodb": "^3.474.0",
+        "@aws-sdk/lib-dynamodb": "^3.474.0",
+        "aws-dynamodb-local": "^0.0.14"
       }
     },
     "node_modules/serverless-localstack": {
@@ -30839,7 +30891,7 @@
       "devDependencies": {
         "@types/nodemailer": "^6.4.17",
         "serverless": "^3.40.0",
-        "serverless-dynamodb": "^0.2.47",
+        "serverless-dynamodb": "^0.2.58",
         "serverless-localstack": "^1.1.2",
         "serverless-offline": "^13.3.2",
         "serverless-offline-aws-eventbridge": "^2.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -69,7 +69,7 @@
   "devDependencies": {
     "@types/nodemailer": "^6.4.17",
     "serverless": "^3.40.0",
-    "serverless-dynamodb": "^0.2.47",
+    "serverless-dynamodb": "^0.2.58",
     "serverless-localstack": "^1.1.2",
     "serverless-offline": "^13.3.2",
     "serverless-offline-aws-eventbridge": "^2.1.0",


### PR DESCRIPTION
## Summary

Sixth security upgrade. **Direct devDependency upgrade** (rather than `overrides`) — `serverless-dynamodb` is bumped from `^0.2.47` to `^0.2.58` in `@mbc-cqrs-serverless/core`. This chains an upgrade of the transitive `aws-dynamodb-local` from `0.0.11` to `0.0.14`, addressing a HIGH-severity advisory.

## Vulnerability addressed

- `aws-dynamodb-local <=0.0.13` (HIGH severity advisory)

The transitive `aws-dynamodb-local` was effectively pinned because the older `serverless-dynamodb@0.2.56` declares `"aws-dynamodb-local": "^0.0.11"` — and `^0.0.11` resolves to `0.0.11` only (in 0.0.x semver). `npm overrides` could not break this constraint. Bumping the parent direct dep is the clean solution: `serverless-dynamodb@0.2.58` declares `"aws-dynamodb-local": "^0.0.14"`, naturally upgrading the transitive.

## Affected dependency path

```
@mbc-cqrs-serverless/core (devDep)
└── serverless-dynamodb → aws-dynamodb-local
```

`serverless-dynamodb` is used only by `npm run migrate:ddb` and the local DynamoDB development setup. **No production runtime impact**.

## Verification

- `npm audit`: **98 → 96** vulnerabilities (-2: aws-dynamodb-local + chained)
  - HIGH count: 64 → 62
- `npm test` (local, macOS): identical to baseline — 156/157 suites pass, 3502/3546 tests pass. The single pre-existing failure in `csv-import.sfn.event.handler.spec.ts` is the macOS-only TS1261 casing collision in `@types/jsonstream` and is unrelated to this PR.

## Strategy progress

1. ✅ `webpack` (low) — PR #414 merged
2. 🟡 `qs` (low) — PR #416
3. 🟡 `yaml` (moderate) — PR #417
4. 🟡 `follow-redirects` (moderate) — PR #418
5. 🟡 `flatted` (HIGH) — PR #419, CI green
6. ✅ This PR: `serverless-dynamodb` → `aws-dynamodb-local` (HIGH, devDep)

**Deferred (npm overrides cannot reach exact-pin parents)**: `mailparser`, `koa`, `underscore`, `ip-address`, `brace-expansion` — these will need direct dep upgrades or upstream patches.

## Test plan

- [ ] CI Unit Test (Node 18/20/22/24) passes on Linux
- [ ] CI E2E Test passes on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)