### PR TITLE
ci(security): pin trivy-action + enable Dependabot for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,3 +36,12 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "class-validator"
         update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(actions)"
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -57,7 +57,7 @@ jobs:
         continue-on-error: true
 
       - name: Security Scan (Trivy)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0
         if: matrix.node-version == '20.x'
         with:
           scan-type: 'fs'


### PR DESCRIPTION
## Summary

Two related supply-chain hardening changes for GitHub Actions:

1. **Pin `aquasecurity/trivy-action`** from `@master` to `@0.36.0`
2. **Enable Dependabot** for the `github-actions` ecosystem so pinned versions stay current

## Why pin?

Floating refs like `@master` execute whatever HEAD happens to be at the moment of CI run. If the upstream maintainer's account or branch protection slips, a malicious commit on `master` would silently propagate into our CI workers — and our CI workers have repository write permissions for tag pushes (publishing). Pinning to a specific version makes the action immutable and changes visible in PR diffs.

This was the **only** action in our workflows using a floating ref. All others already pin to a semver tag (`@v4`, `@v3`, etc.).

## Why enable Dependabot for actions?

Without Dependabot tracking, the new pin would silently rot — we wouldn't get notified about Trivy updates (security or otherwise). The new ecosystem entry mirrors the existing npm config: weekly schedule, sensible PR limit, dedicated commit prefix.

## References

- OpenSSF Scorecard "Pinned-Dependencies" check: https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies
- Trivy releases: https://github.com/aquasecurity/trivy-action/releases

## Verification

- ✅ Workflow YAML is otherwise unchanged — Trivy scans run identically
- [ ] CI passes (Trivy job in particular)
- After merge: Dependabot will start opening PRs for action updates on Mondays

## Notes

A future hardening step could be to pin all actions by SHA instead of tag (e.g. `@a1b2c3d4...`), per the strictest OpenSSF Scorecard rule. That's a larger change touching every workflow line; this PR addresses the immediate `@master` risk first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)