### PR TITLE
docs(mcp-server): add AP022-AP025 to detector cross-reference table

### DIFF
--- a/packages/mcp-server/skills/mbc-review/SKILL.md
+++ b/packages/mcp-server/skills/mbc-review/SKILL.md
@@ -55,6 +55,10 @@ This codebase currently has **two independent `AP00X` numbering systems** that a
 | AP019 Missing Pagination in List Queries | AP019 | ✅ same code |
 | AP020 Missing getCommandSource for Tracing | AP011 | Tracing/audit |
 | AP021 Event Emit After publishAsync | AP021 | ✅ same code |
+| AP022 Use of eval() or Function() Constructor | — (detector only) | RCE/XSS sink (CWE-95) |
+| AP023 Shell Command Built from String Concatenation | — (detector only) | Command injection (CWE-78) |
+| AP024 HTTP Request Without Timeout | — (detector only) | Local DoS via stalled upstream (CWE-400) |
+| AP025 Logging process.env or full request object | — (detector only) | Sensitive data exposure (CWE-312, CWE-532) |
 
 When you receive `mbc_check_anti_patterns` output, look up the detector code in this table to find the corresponding skill-doc section for full context and recommended fixes. Future versions of this framework should consolidate the two systems; until then, treat them as separate identifier spaces.
 


### PR DESCRIPTION
## Summary

Follow-up to [#423](https://github.com/mbc-net/mbc-cqrs-serverless/pull/423) which introduced four new security-focused detectors (AP022 eval/Function, AP023 shell injection, AP024 HTTP timeout, AP025 sensitive logging).

Adds them to the **detector → skill-doc cross-reference table** in `packages/mcp-server/skills/mbc-review/SKILL.md` so that users navigating from `mbc_check_anti_patterns` output can find context.

The four new detectors are marked `— (detector only)` because they don't yet have full skill-doc counterparts. Promoting them to full entries is a future PR (and a separate doc-site sync is also needed in `mbc-cqrs-serverless-doc/docs/mcp-server.md`).

## Verification

Pure documentation change (4 lines added to a Markdown table). No code or test impact.