### PR TITLE
feat(mcp-server): update skills and analyzer for v1.3.0 AppSync Events API support

### DIFF
--- a/packages/mcp-server/skills/mbc-debug/SKILL.md
+++ b/packages/mcp-server/skills/mbc-debug/SKILL.md
@@ -596,6 +596,54 @@ Error Occurred
 
 ---
 
+---
+
+## AppSync Events API Troubleshooting
+
+### Notifications not delivered via Events API
+
+**Symptom:** `appsync-event` transport is configured but clients receive no events.
+
+**Checklist:**
+
+1. **Verify `NOTIFICATION_TRANSPORTS` includes `appsync-event`**
+   ```bash
+   echo $NOTIFICATION_TRANSPORTS
+   # Expected: appsync-event  or  appsync-graphql,appsync-event
+   ```
+
+2. **Verify `APPSYNC_EVENTS_ENDPOINT` is set and correct**
+   ```bash
+   # Must end with /event, not /graphql
+   echo $APPSYNC_EVENTS_ENDPOINT
+   # Expected: https://xxxx.appsync-api.ap-northeast-1.amazonaws.com/event
+   ```
+
+3. **Check IAM permissions (most common cause)**
+   ```bash
+   # Lambda/ECS execution role must have appsync:EventPublish
+   aws iam simulate-principal-policy \
+     --policy-source-arn arn:aws:iam::ACCOUNT:role/YOUR_LAMBDA_ROLE \
+     --action-names appsync:EventPublish \
+     --resource-arns "arn:aws:appsync:REGION:ACCOUNT:apis/API_ID/channelNamespace/*"
+   ```
+   If using CDK, `appSyncEventsApi.grantPublish(lambdaRole)` handles this automatically.
+
+4. **Verify `APPSYNC_EVENTS_NAMESPACE` matches the ChannelNamespace in AppSync**
+   ```bash
+   echo $APPSYNC_EVENTS_NAMESPACE
+   # Expected: default (or whatever namespace was created by CDK)
+   ```
+   The value must match a pre-created `ChannelNamespace` in the AppSync Event API. Check the AWS Console → AppSync → your Event API → Channel Namespaces.
+
+5. **Check for 400 errors in CloudWatch**
+   A 400 response from AppSync means the channel path is invalid. Channel segments must be alphanumeric + dashes only, max 50 chars each. The framework sanitizes `tenantCode`, `action`, and `id` automatically.
+
+6. **Confirm dual-publish is intentional**
+   If `NOTIFICATION_TRANSPORTS=appsync-graphql,appsync-event`, the framework publishes to both transports. A failure in one transport causes the entire publish to fail — check CloudWatch for errors from either service.
+
+---
+
 ## Getting Help
 
 When reporting issues, include:

--- a/packages/mcp-server/skills/mbc-generate/SKILL.md
+++ b/packages/mcp-server/skills/mbc-generate/SKILL.md
@@ -440,6 +440,55 @@ export class [Entity]EventHandler {
 }
 ```
 
+### Custom Notification Transport (`notifications/[name].transport.ts`)
+
+For adding a custom pub/sub transport alongside or instead of the built-in AppSync transports:
+
+```typescript
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { NotificationTransport } from '@mbc-cqrs-serverless/core';
+import { INotification, INotificationTransport } from '@mbc-cqrs-serverless/core';
+
+@NotificationTransport('[name]')  // must match NOTIFICATION_TRANSPORTS value
+export class [Name]NotificationTransport implements INotificationTransport {
+  private readonly logger = new Logger([Name]NotificationTransport.name);
+
+  constructor(private readonly config: ConfigService) {}
+
+  async sendMessage(notification: INotification): Promise<void> {
+    this.logger.debug(`sendMessage:: ${notification.action} for ${notification.tenantCode}`);
+    // Add your transport logic here (e.g., WebSocket push, Pusher, SNS, etc.)
+  }
+}
+```
+
+Register in `NotificationModule` (or your app module):
+
+```typescript
+import { NotificationModule } from '@mbc-cqrs-serverless/core';
+
+@Module({
+  imports: [NotificationModule],
+  providers: [[Name]NotificationTransport],
+})
+export class AppModule {}
+```
+
+Activate via environment variable (comma-separated, order does not matter):
+
+```bash
+# Use only the custom transport
+NOTIFICATION_TRANSPORTS=[name]
+
+# Use alongside the built-in AppSync GraphQL transport
+NOTIFICATION_TRANSPORTS=appsync-graphql,[name]
+```
+
+> **Note:** The decorator name `'[name]'` must exactly match the value in `NOTIFICATION_TRANSPORTS`. If it does not match, the transport is silently ignored (AP026).
+
+---
+
 ### Query Handler for Complex Searches (`[entity].query.ts`)
 
 For advanced query operations:

--- a/packages/mcp-server/skills/mbc-migrate/SKILL.md
+++ b/packages/mcp-server/skills/mbc-migrate/SKILL.md
@@ -41,6 +41,7 @@ This skill helps migrate MBC CQRS Serverless projects between versions.
 | v1.2.x | v1.2.4 | Medium | TaskModule.register() must be in AppModule |
 | v1.2.4 | v1.2.5 | Low | ZIP import refactor (transparent); MCP AP016–AP020 added |
 | v1.2.5 | v1.2.6 | Low | Repository RYW improvements (transparent); `getVersion` API |
+| v1.2.7 | v1.3.0 | Low | AppSync Events API support (opt-in, no breaking changes) |
 
 ## Migration Guides
 
@@ -549,10 +550,83 @@ export class OrderDataSyncRdsHandler implements IDataSyncHandler {}
 
 ---
 
+---
+
+### v1.2.7 → v1.3.0
+
+**Change:** AppSync Events API support added (opt-in, no breaking changes)
+
+No code changes are required. `AppSyncEventsService` is registered in `NotificationModule` automatically but does nothing unless `NOTIFICATION_TRANSPORTS` includes `appsync-event`.
+
+**To adopt the new Events API transport:**
+
+**Step 1 — Provision infrastructure (CDK)**
+
+Add `appsyncEvents` and `notificationTransports` to your `Config`:
+
+```typescript
+// infra/config/config.ts
+export const config: Config = {
+  appsyncEvents: {
+    enabled: true,
+    namespace: 'default',       // must match the ChannelNamespace created in AppSync
+    apiKeyExpireDays: 365,
+  },
+  notificationTransports: 'appsync-graphql,appsync-event', // dual-publish during migration
+}
+```
+
+Run `cdk deploy` to create the `EventApi` and `ChannelNamespace`. The stack outputs `AppSyncEventsHttpEndpoint` and `AppSyncEventsNamespace`.
+
+**Step 2 — Enable dual-publish (migration phase)**
+
+When `appsyncEvents.enabled: true`, the CDK stack automatically injects these env vars into Lambda/ECS:
+
+```bash
+NOTIFICATION_TRANSPORTS=appsync-graphql,appsync-event   # dual-publish
+APPSYNC_EVENTS_ENDPOINT=https://xxxx.appsync-api.ap-northeast-1.amazonaws.com/event
+APPSYNC_EVENTS_NAMESPACE=default
+APPSYNC_ENDPOINT=https://xxxx.appsync-api.ap-northeast-1.amazonaws.com/graphql  # keep existing
+```
+
+**Step 3 — Switch to Events API only**
+
+Once all clients have migrated to the Events API, update `notificationTransports` in CDK Config:
+
+```typescript
+notificationTransports: 'appsync-event',  // Events API only
+```
+
+Then redeploy. `APPSYNC_ENDPOINT` can be removed from the environment.
+
+**Channel subscription patterns (for client-side code):**
+
+```javascript
+// All events for a tenant
+appsyncClient.subscribe(`/${namespace}/${tenantCode}/*`)
+
+// Filtered by action
+appsyncClient.subscribe(`/${namespace}/${tenantCode}/${action}/*`)
+
+// Track one specific command result
+appsyncClient.subscribe(`/${namespace}/${tenantCode}/${action}/${sanitizedId}`)
+```
+
+Non-alphanumeric characters in `id` (e.g. `#`, `@` from DynamoDB pk/sk) are sanitized to `-` automatically on the server side. Client-side code using `EventsSubscriptionClientImpl` from the example app applies the same sanitization.
+
+**Migration Steps:**
+1. Add `appsyncEvents` and `notificationTransports` to CDK `Config` and deploy
+2. Verify events arrive via both transports (dual-publish phase)
+3. Migrate frontend clients to subscribe via AppSync Events API channels
+4. Once all clients migrated, set `notificationTransports: 'appsync-event'` and redeploy
+
+---
+
 ## Version Compatibility Matrix
 
 | Core Version | CLI Version | NestJS | Node.js | TypeScript |
 |--------------|-------------|--------|---------|------------|
+| v1.3.0 | v1.3.0 | 10.x | 18+ | 5.x |
 | v1.0.23 | v1.0.23 | 10.x | 18+ | 5.x |
 | v1.0.22 | v1.0.22 | 10.x | 18+ | 5.x |
 | v1.0.21 | v1.0.21 | 10.x | 18+ | 5.x |

--- a/packages/mcp-server/skills/mbc-review/SKILL.md
+++ b/packages/mcp-server/skills/mbc-review/SKILL.md
@@ -59,6 +59,7 @@ This codebase currently has **two independent `AP00X` numbering systems** that a
 | AP023 Shell Command Built from String Concatenation | — (detector only) | Command injection (CWE-78) |
 | AP024 HTTP Request Without Timeout | — (detector only) | Local DoS via stalled upstream (CWE-400) |
 | AP025 Logging process.env or full request object | — (detector only) | Sensitive data exposure (CWE-312, CWE-532) |
+| AP026 @Injectable instead of @NotificationTransport | — (detector only) | INotificationTransport implementor never invoked |
 
 When you receive `mbc_check_anti_patterns` output, look up the detector code in this table to find the corresponding skill-doc section for full context and recommended fixes. Future versions of this framework should consolidate the two systems; until then, treat them as separate identifier spaces.
 
@@ -644,6 +645,10 @@ When reviewing MBC CQRS Serverless code, check:
 - [ ] Registered in module
 - [ ] Event-emitting handlers implement `IDataSyncHandler` and emit in `up()` / `down()`
 - [ ] `_prev` metadata is stripped before RDS upsert if used for change-detection
+
+### Notification Transport (when implementing INotificationTransport)
+- [ ] Uses `@NotificationTransport('transport-name')` decorator instead of `@Injectable()` (AP026)
+- [ ] Transport name is registered in `NOTIFICATION_TRANSPORTS` env var to be active
 
 ## Output Format
 

--- a/packages/mcp-server/src/tools/analyze.spec.ts
+++ b/packages/mcp-server/src/tools/analyze.spec.ts
@@ -169,6 +169,35 @@ describe('analyze tools', () => {
       )
     })
 
+    it('should detect @Injectable instead of @NotificationTransport (AP026)', async () => {
+      const testFile = path.join(testDir, 'src', 'test.ts')
+      fs.writeFileSync(
+        testFile,
+        `
+        import { Injectable } from '@nestjs/common';
+        import { INotificationTransport } from '@mbc-cqrs-serverless/core';
+
+        @Injectable()
+        export class MyCustomTransport implements INotificationTransport {
+          async sendMessage(notification: INotification): Promise<void> {
+            // custom logic
+          }
+        }
+      `,
+      )
+
+      const result = await handleAnalyzeTool(
+        'mbc_check_anti_patterns',
+        { path: 'src' },
+        testDir,
+      )
+
+      expect(result.content[0].text).toContain('AP026')
+      expect(result.content[0].text).toContain(
+        'Notification service class using @Injectable instead of @NotificationTransport',
+      )
+    })
+
     it('should return error for non-existent path', async () => {
       const result = await handleAnalyzeTool(
         'mbc_check_anti_patterns',

--- a/packages/mcp-server/src/tools/analyze.ts
+++ b/packages/mcp-server/src/tools/analyze.ts
@@ -710,6 +710,15 @@ const ANTI_PATTERNS = [
     recommendation:
       'Logging process.env (without picking specific keys), the full headers object, or fields like authorization/cookie leaks credentials, JWT tokens, and API keys into log aggregation systems where they may be retained or replicated to less-trusted observers (CWE-312, CWE-532). Log only the specific non-secret fields you actually need (e.g. process.env.NODE_ENV, request id, user id from JWT claims).',
   },
+  {
+    code: 'AP026',
+    name: 'Notification service class using @Injectable instead of @NotificationTransport',
+    severity: 'high' as const,
+    // Detect classes that implement INotificationTransport but use @Injectable() instead of @NotificationTransport()
+    pattern: /@Injectable\(\)[\s\S]{0,200}implements\s+INotificationTransport/,
+    recommendation:
+      "Classes that implement INotificationTransport must use @NotificationTransport('transport-name') instead of @Injectable(). The decorator registers the transport name as metadata so NotificationEventHandler can discover and activate it via NOTIFICATION_TRANSPORTS env var. With @Injectable() alone, the transport will never be invoked.",
+  },
 ]
 
 /**
@@ -734,6 +743,7 @@ const DETECTOR_TO_SKILL_AP: Record<string, string> = {
   AP019: 'AP019', // Missing Pagination in List Queries ✅
   AP020: 'AP011', // Missing getCommandSource for Tracing → Missing getCommandSource for Tracing
   AP021: 'AP021', // Event Emit After publishAsync ✅
+  // AP026: detector-only (no skill-doc AP counterpart)
 }
 
 /**


### PR DESCRIPTION
## Summary

Updates MCP server skills and anti-pattern analyzer to reflect the AppSync Events API changes introduced in v1.3.0 (PR #433).

- **mbc-migrate**: Version table and migration guide updated to v1.3.0; `APPSYNC_EVENTS_ENABLED` replaced with `NOTIFICATION_TRANSPORTS`; channel path corrected (`/{namespace}/{tenantCode}/{action}/{sanitizedId}`)
- **mbc-debug**: `APPSYNC_EVENTS_ENABLED` replaced with `NOTIFICATION_TRANSPORTS`; stale CDK API key bug workaround removed (code was never merged); `APPSYNC_EVENTS_NAMESPACE` verification step added
- **mbc-review**: AP026 added to cross-reference table and review checklist
- **mbc-generate**: Custom notification transport code generation template added
- **analyze.ts**: AP026 detector added (`@Injectable` instead of `@NotificationTransport` on `INotificationTransport` implementors)
- **analyze.spec.ts**: Unit test added for AP026 detector

## Test plan

- [x] `npm run test --workspace=packages/mcp-server` — 266 tests passed
- [x] `npm run build --workspace=packages/mcp-server` — build succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)