### PR TITLE
feat(core): JWT group permissions via custom:groups

### DIFF
--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -1,2 +1,3 @@
 export * from './invoke'
+export * from './role-resolver'
 export * from './user'

--- a/packages/core/src/context/invoke.ts
+++ b/packages/core/src/context/invoke.ts
@@ -21,6 +21,8 @@ export interface JwtClaims {
   name: string
   'custom:tenant'?: string // tenant code
   'custom:roles'?: string
+  /** JSON array of { tenant, role } — roles granted via group membership (flattened at token issuance). */
+  'custom:groups'?: string
   exp: number
   email: string
   email_verified?: boolean

--- a/packages/core/src/context/role-resolver.spec.ts
+++ b/packages/core/src/context/role-resolver.spec.ts
@@ -1,0 +1,82 @@
+import { JwtClaims } from './invoke'
+import { parseCustomRolesJson, resolveTenantRoles } from './role-resolver'
+
+describe('parseCustomRolesJson', () => {
+  it('returns empty array when undefined', () => {
+    expect(parseCustomRolesJson(undefined)).toEqual([])
+  })
+
+  it('parses valid JSON array', () => {
+    const json = JSON.stringify([{ tenant: 'T1', role: 'admin' }])
+    expect(parseCustomRolesJson(json)).toEqual([
+      { tenant: 't1', role: 'admin' },
+    ])
+  })
+
+  it('throws on invalid JSON', () => {
+    expect(() => parseCustomRolesJson('not-json')).toThrow()
+  })
+})
+
+describe('resolveTenantRoles', () => {
+  const baseClaims = {
+    sub: 'user-1',
+  } as JwtClaims
+
+  it('unions direct and group roles for tenant', () => {
+    const claims: JwtClaims = {
+      ...baseClaims,
+      'custom:roles': JSON.stringify([{ tenant: '1801', role: 'user' }]),
+      'custom:groups': JSON.stringify([
+        { tenant: '1801', role: 'viewer' },
+        { tenant: '1801', role: 'admin' },
+      ]),
+    }
+    expect(resolveTenantRoles(claims, '1801').sort()).toEqual(
+      ['admin', 'user', 'viewer'].sort(),
+    )
+  })
+
+  it('includes global tenant empty string roles', () => {
+    const claims: JwtClaims = {
+      ...baseClaims,
+      'custom:roles': JSON.stringify([]),
+      'custom:groups': JSON.stringify([{ tenant: '', role: 'auditor' }]),
+    }
+    expect(resolveTenantRoles(claims, '1801')).toEqual(['auditor'])
+  })
+
+  it('dedupes duplicate role names', () => {
+    const claims: JwtClaims = {
+      ...baseClaims,
+      'custom:roles': JSON.stringify([{ tenant: '1801', role: 'admin' }]),
+      'custom:groups': JSON.stringify([{ tenant: '1801', role: 'admin' }]),
+    }
+    expect(resolveTenantRoles(claims, '1801')).toEqual(['admin'])
+  })
+
+  it('treats missing custom:groups as empty', () => {
+    const claims: JwtClaims = {
+      ...baseClaims,
+      'custom:roles': JSON.stringify([{ tenant: '1801', role: 'user' }]),
+    }
+    expect(resolveTenantRoles(claims, '1801')).toEqual(['user'])
+  })
+
+  it('returns only global roles when tenantCode is undefined', () => {
+    const claims: JwtClaims = {
+      ...baseClaims,
+      'custom:roles': JSON.stringify([{ tenant: '1801', role: 'user' }]),
+      'custom:groups': JSON.stringify([{ tenant: '', role: 'auditor' }]),
+    }
+    expect(resolveTenantRoles(claims, undefined)).toEqual(['auditor'])
+  })
+
+  it('normalizes tenant code case when filtering', () => {
+    const claims: JwtClaims = {
+      ...baseClaims,
+      'custom:groups': JSON.stringify([{ tenant: 'MY-TENANT', role: 'admin' }]),
+    }
+    expect(resolveTenantRoles(claims, 'my-tenant')).toEqual(['admin'])
+  })
+})

--- a/packages/core/src/context/role-resolver.spec.ts
+++ b/packages/core/src/context/role-resolver.spec.ts
@@ -13,8 +13,16 @@ describe('parseCustomRolesJson', () => {
     ])
   })
 
-  it('throws on invalid JSON', () => {
-    expect(() => parseCustomRolesJson('not-json')).toThrow()
+  it('returns empty array on invalid JSON', () => {
+    expect(parseCustomRolesJson('not-json')).toEqual([])
+  })
+
+  it('returns empty array when JSON is null literal', () => {
+    expect(parseCustomRolesJson('null')).toEqual([])
+  })
+
+  it('returns empty array when JSON is a single object (not array)', () => {
+    expect(parseCustomRolesJson(JSON.stringify({ tenant: 'a', role: 'b' }))).toEqual([])
   })
 })
 

--- a/packages/core/src/context/role-resolver.ts
+++ b/packages/core/src/context/role-resolver.ts
@@ -2,14 +2,17 @@ import { JwtClaims } from './invoke'
 import { CustomRole } from './user'
 
 export function parseCustomRolesJson(json: string | undefined): CustomRole[] {
-  if (!json) {
+  if (!json) return []
+  try {
+    const parsed = JSON.parse(json)
+    if (!Array.isArray(parsed)) return []
+    return parsed.map((entry) => ({
+      ...entry,
+      tenant: (entry.tenant || '').toLowerCase(),
+    }))
+  } catch {
     return []
   }
-  const parsed = JSON.parse(json) as CustomRole[]
-  return parsed.map((entry) => ({
-    ...entry,
-    tenant: (entry.tenant || '').toLowerCase(),
-  }))
 }
 
 export function resolveTenantRoles(

--- a/packages/core/src/context/role-resolver.ts
+++ b/packages/core/src/context/role-resolver.ts
@@ -1,0 +1,42 @@
+import { JwtClaims } from './invoke'
+import { CustomRole } from './user'
+
+export function parseCustomRolesJson(json: string | undefined): CustomRole[] {
+  if (!json) {
+    return []
+  }
+  const parsed = JSON.parse(json) as CustomRole[]
+  return parsed.map((entry) => ({
+    ...entry,
+    tenant: (entry.tenant || '').toLowerCase(),
+  }))
+}
+
+export function resolveTenantRoles(
+  claims: JwtClaims,
+  tenantCode: string | undefined,
+): string[] {
+  const normalizedTenant = tenantCode?.toLowerCase()
+  const direct = parseCustomRolesJson(claims['custom:roles'])
+  const fromGroups = parseCustomRolesJson(claims['custom:groups'])
+  const merged = [...direct, ...fromGroups]
+
+  const roles: string[] = []
+  const seen = new Set<string>()
+
+  for (const { tenant, role } of merged) {
+    if (normalizedTenant && tenant !== '' && tenant !== normalizedTenant) {
+      continue
+    }
+    if (!normalizedTenant && tenant !== '') {
+      continue
+    }
+    if (!role || seen.has(role)) {
+      continue
+    }
+    seen.add(role)
+    roles.push(role)
+  }
+
+  return roles
+}

--- a/packages/core/src/context/user.spec.ts
+++ b/packages/core/src/context/user.spec.ts
@@ -25,7 +25,9 @@ describe('getUserContext', () => {
         {
           sub: 'user-123',
           'custom:tenant': 'tenant-a',
-          'custom:roles': JSON.stringify([{ tenant: 'tenant-a', role: 'user' }]),
+          'custom:roles': JSON.stringify([
+            { tenant: 'tenant-a', role: 'user' },
+          ]),
         },
         { [HEADER_TENANT_CODE]: 'tenant-b' },
       )
@@ -40,7 +42,9 @@ describe('getUserContext', () => {
       const ctx = createMockContext(
         {
           sub: 'user-123',
-          'custom:roles': JSON.stringify([{ tenant: 'tenant-a', role: 'user' }]),
+          'custom:roles': JSON.stringify([
+            { tenant: 'tenant-a', role: 'user' },
+          ]),
         },
         { [HEADER_TENANT_CODE]: 'tenant-b' },
       )
@@ -204,9 +208,7 @@ describe('getUserContext', () => {
       const ctx = createMockContext({
         sub: 'user-123',
         'custom:tenant': 'tenant-a',
-        'custom:roles': JSON.stringify([
-          { tenant: 'TENANT-A', role: 'admin' },
-        ]),
+        'custom:roles': JSON.stringify([{ tenant: 'TENANT-A', role: 'admin' }]),
       })
 
       const result = getUserContext(ctx)
@@ -219,7 +221,9 @@ describe('getUserContext', () => {
         {
           sub: 'user-123',
           'custom:tenant': 'Tenant-A',
-          'custom:roles': JSON.stringify([{ tenant: 'tenant-a', role: 'user' }]),
+          'custom:roles': JSON.stringify([
+            { tenant: 'tenant-a', role: 'user' },
+          ]),
         },
         { [HEADER_TENANT_CODE]: 'tenant-b' },
       )
@@ -303,7 +307,9 @@ describe('getUserContext', () => {
       const ctx = createMockContext(
         {
           sub: 'user-123',
-          'custom:roles': JSON.stringify([{ tenant: 'tenant-a', role: 'admin' }]),
+          'custom:roles': JSON.stringify([
+            { tenant: 'tenant-a', role: 'admin' },
+          ]),
         },
         { [HEADER_TENANT_CODE]: 'tenant-b' },
       )
@@ -320,7 +326,9 @@ describe('getUserContext', () => {
         {
           sub: 'user-123',
           'custom:tenant': 'tenant-a',
-          'custom:roles': JSON.stringify([{ tenant: 'tenant-a', role: 'admin' }]),
+          'custom:roles': JSON.stringify([
+            { tenant: 'tenant-a', role: 'admin' },
+          ]),
         },
         { [HEADER_TENANT_CODE]: 'tenant-b' },
       )
@@ -368,7 +376,11 @@ describe('getUserContext', () => {
         {
           sub: 'attacker-123',
           'custom:roles': JSON.stringify([
-            { tenant: '', role: 'user', __proto__: { role: ROLE_SYSTEM_ADMIN } },
+            {
+              tenant: '',
+              role: 'user',
+              __proto__: { role: ROLE_SYSTEM_ADMIN },
+            },
           ]),
         },
         { [HEADER_TENANT_CODE]: 'target-tenant' },
@@ -413,6 +425,7 @@ describe('getUserContext', () => {
         userId: 'user-123',
         tenantCode: 'tenant-a',
         tenantRole: 'user',
+        tenantRoles: ['user'],
       })
       // Note: It's a plain object, not a UserContext instance
       expect(result.constructor.name).toBe('Object')
@@ -485,7 +498,9 @@ describe('getUserContext', () => {
       const ctx = createMockContext(
         {
           sub: 'user-123',
-          'custom:roles': JSON.stringify([{ tenant: 'tenant-b', role: 'admin' }]),
+          'custom:roles': JSON.stringify([
+            { tenant: 'tenant-b', role: 'admin' },
+          ]),
         },
         { [HEADER_TENANT_CODE]: 'TENANT-B' },
       )
@@ -509,7 +524,9 @@ describe('getUserContext', () => {
         const ctx = createMockContext({
           sub: 'user-123',
           'custom:tenant': tenant,
-          'custom:roles': JSON.stringify([{ tenant: roleTenant, role: 'user' }]),
+          'custom:roles': JSON.stringify([
+            { tenant: roleTenant, role: 'user' },
+          ]),
         })
 
         const result = getUserContext(ctx)
@@ -598,6 +615,70 @@ describe('getUserContext', () => {
       const result = getUserContext(ctx)
 
       expect(result.tenantRole).toBe('')
+    })
+  })
+
+  describe('tenantRoles (custom:groups union)', () => {
+    it('should include roles from custom:groups in tenantRoles', () => {
+      const ctx = createMockContext({
+        sub: 'user-123',
+        'custom:tenant': '1801',
+        'custom:roles': JSON.stringify([{ tenant: '1801', role: 'user' }]),
+        'custom:groups': JSON.stringify([
+          { tenant: '1801', role: 'admin' },
+          { tenant: '', role: 'auditor' },
+        ]),
+      })
+
+      const result = getUserContext(ctx)
+
+      expect(result.tenantRoles.sort()).toEqual(
+        ['admin', 'auditor', 'user'].sort(),
+      )
+    })
+
+    it('should keep tenantRole from custom:roles only when groups add roles', () => {
+      const ctx = createMockContext({
+        sub: 'user-123',
+        'custom:tenant': '1801',
+        'custom:roles': JSON.stringify([{ tenant: '1801', role: 'user' }]),
+        'custom:groups': JSON.stringify([{ tenant: '1801', role: 'admin' }]),
+      })
+
+      const result = getUserContext(ctx)
+
+      expect(result.tenantRole).toBe('user')
+      expect(result.tenantRoles).toContain('admin')
+    })
+
+    it('should allow group-only roles with empty tenantRole', () => {
+      const ctx = createMockContext({
+        sub: 'user-123',
+        'custom:tenant': '1801',
+        'custom:roles': '[]',
+        'custom:groups': JSON.stringify([{ tenant: '1801', role: 'admin' }]),
+      })
+
+      const result = getUserContext(ctx)
+
+      expect(result.tenantRole).toBe('')
+      expect(result.tenantRoles).toEqual(['admin'])
+    })
+
+    it('should include multiple group-derived roles for same tenant', () => {
+      const ctx = createMockContext({
+        sub: 'user-123',
+        'custom:tenant': '1801',
+        'custom:roles': '[]',
+        'custom:groups': JSON.stringify([
+          { tenant: '1801', role: 'viewer' },
+          { tenant: '1801', role: 'admin' },
+        ]),
+      })
+
+      const result = getUserContext(ctx)
+
+      expect(result.tenantRoles.sort()).toEqual(['admin', 'viewer'].sort())
     })
   })
 })

--- a/packages/core/src/context/user.ts
+++ b/packages/core/src/context/user.ts
@@ -2,6 +2,7 @@ import { ExecutionContext } from '@nestjs/common'
 
 import { HEADER_TENANT_CODE } from '../constants'
 import { extractInvokeContext, getAuthorizerClaims, IInvoke } from './invoke'
+import { parseCustomRolesJson, resolveTenantRoles } from './role-resolver'
 
 export interface CustomRole {
   tenant: string // tenant's code
@@ -10,11 +11,20 @@ export interface CustomRole {
 
 export class UserContext {
   userId: string
+  /** First matching role from custom:roles only — unchanged for backward compatibility. */
   tenantRole: string
   tenantCode: string
+  /**
+   * Union of custom:roles and custom:groups for authorization (RolesGuard).
+   * Omitted on legacy/manual contexts; guards fall back to [tenantRole] when empty.
+   */
+  tenantRoles?: string[]
 
   constructor(partial: Partial<UserContext>) {
     Object.assign(this, partial)
+    if (this.tenantRoles === undefined) {
+      this.tenantRoles = this.tenantRole ? [this.tenantRole] : []
+    }
   }
 }
 
@@ -36,10 +46,7 @@ export function getUserContext(ctx: IInvoke | ExecutionContext): UserContext {
 
   const userId = claims.sub
 
-  // Parse roles
-  const roles = (
-    JSON.parse(claims['custom:roles'] || '[]') as CustomRole[]
-  ).map((role) => ({ ...role, tenant: (role.tenant || '').toLowerCase() }))
+  const roles = parseCustomRolesJson(claims['custom:roles'])
 
   // Determine tenant code
   // 1. Cognito custom:tenant attribute takes priority
@@ -49,7 +56,9 @@ export function getUserContext(ctx: IInvoke | ExecutionContext): UserContext {
     claims['custom:tenant'] || (ctx?.event?.headers || {})[HEADER_TENANT_CODE]
   )?.toLowerCase()
 
-  // Find tenantRole (case-insensitive matching - both tenantCode and role.tenant are lowercase)
+  const tenantRoles = resolveTenantRoles(claims, tenantCode)
+
+  // Find tenantRole from direct custom:roles only (case-insensitive matching)
   let tenantRole = ''
   for (const { tenant, role } of roles) {
     if (tenant === '' || tenant === tenantCode) {
@@ -64,5 +73,6 @@ export function getUserContext(ctx: IInvoke | ExecutionContext): UserContext {
     userId,
     tenantRole,
     tenantCode,
+    tenantRoles,
   }
 }

--- a/packages/core/src/guard/roles.guard.spec.ts
+++ b/packages/core/src/guard/roles.guard.spec.ts
@@ -58,6 +58,27 @@ const userWithoutTenantClaims = {
   // No custom:tenant
 }
 
+const groupOnlyUserClaims = {
+  sub: '12345678-1234-1234-1234-123456789012',
+  'cognito:username': 'groupuser',
+  email: 'group@test.com',
+  'custom:tenant': 'test',
+  'custom:roles': '[]',
+  'custom:groups': JSON.stringify([{ tenant: 'test', role: 'admin' }]),
+}
+
+const multiGroupClaims = {
+  sub: '12345678-1234-1234-1234-123456789012',
+  'cognito:username': 'groupuser',
+  email: 'group@test.com',
+  'custom:tenant': 'test',
+  'custom:roles': JSON.stringify([{ tenant: 'test', role: 'user' }]),
+  'custom:groups': JSON.stringify([
+    { tenant: 'test', role: 'viewer' },
+    { tenant: 'test', role: 'admin' },
+  ]),
+}
+
 const createRequestStub = (tenantCode = 'test') => ({
   headers: {
     'x-tenant-code': tenantCode,
@@ -94,10 +115,12 @@ describe('RolesGuard', () => {
     it('should return false if tenant code does not exist', async () => {
       // Arrange
       mockJwtDecode.mockReturnValue(systemAdminClaims)
-      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['system_admin'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub(''),
-      )
+      jest
+        .spyOn(reflector, 'getAllAndOverride')
+        .mockReturnValue(['system_admin'])
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub(''))
       // Act & Assert
       expect(await rolesGuard.canActivate(execution_context)).toBeFalsy()
       expect(reflector.getAllAndOverride).toHaveBeenCalledTimes(0)
@@ -108,9 +131,9 @@ describe('RolesGuard', () => {
       // Arrange
       mockJwtDecode.mockReturnValue(tenantUserClaims)
       jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['user'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('test'),
-      )
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('test'))
       // Act & Assert
       expect(await rolesGuard.canActivate(execution_context)).toBeTruthy()
     })
@@ -119,10 +142,12 @@ describe('RolesGuard', () => {
     it('should allow system admin to override tenant via header', async () => {
       // Arrange
       mockJwtDecode.mockReturnValue(systemAdminClaims)
-      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['system_admin'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('any-tenant'),
-      )
+      jest
+        .spyOn(reflector, 'getAllAndOverride')
+        .mockReturnValue(['system_admin'])
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('any-tenant'))
       // Act & Assert - system admin should be able to access any tenant via header
       expect(await rolesGuard.canActivate(execution_context)).toBeTruthy()
     })
@@ -132,9 +157,9 @@ describe('RolesGuard', () => {
       // Arrange - user without custom:tenant trying to use header
       mockJwtDecode.mockReturnValue(userWithoutTenantClaims)
       jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['user'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('attempted-tenant'),
-      )
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('attempted-tenant'))
       // Act & Assert - should fail because non-admin cannot use header tenant
       expect(await rolesGuard.canActivate(execution_context)).toBeFalsy()
     })
@@ -144,9 +169,9 @@ describe('RolesGuard', () => {
       // Arrange - user without custom:tenant accessing common tenant
       mockJwtDecode.mockReturnValue(userWithoutTenantClaims)
       jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['user'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('common'),
-      )
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('common'))
       // Act & Assert - common tenant should be accessible
       expect(await rolesGuard.canActivate(execution_context)).toBeTruthy()
     })
@@ -157,14 +182,62 @@ describe('RolesGuard', () => {
       const claimsWithTenant = {
         ...userWithoutTenantClaims,
         'custom:tenant': 'my-tenant',
-        'custom:roles': JSON.stringify([{ tenant: 'my-tenant', role: 'admin' }]),
+        'custom:roles': JSON.stringify([
+          { tenant: 'my-tenant', role: 'admin' },
+        ]),
       }
       mockJwtDecode.mockReturnValue(claimsWithTenant)
       jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['admin'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('other-tenant'),
-      )
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('other-tenant'))
       // Act & Assert - should use custom:tenant, not header
+      expect(await rolesGuard.canActivate(execution_context)).toBeTruthy()
+    })
+  })
+
+  describe('custom:groups union', () => {
+    it('should allow access when required role is only in custom:groups', async () => {
+      mockJwtDecode.mockReturnValue(groupOnlyUserClaims)
+      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['admin'])
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('test'))
+
+      expect(await rolesGuard.canActivate(execution_context)).toBeTruthy()
+    })
+
+    it('should allow access when user has multiple group-derived roles', async () => {
+      mockJwtDecode.mockReturnValue(multiGroupClaims)
+      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['viewer'])
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('test'))
+
+      expect(await rolesGuard.canActivate(execution_context)).toBeTruthy()
+    })
+
+    it('should deny when neither direct nor group roles match', async () => {
+      mockJwtDecode.mockReturnValue(groupOnlyUserClaims)
+      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['manager'])
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('test'))
+
+      expect(await rolesGuard.canActivate(execution_context)).toBeFalsy()
+    })
+
+    it('should bypass with system_admin only in custom:groups', async () => {
+      const claims = {
+        ...groupOnlyUserClaims,
+        'custom:groups': JSON.stringify([{ tenant: '', role: 'system_admin' }]),
+      }
+      mockJwtDecode.mockReturnValue(claims)
+      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['manager'])
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('test'))
+
       expect(await rolesGuard.canActivate(execution_context)).toBeTruthy()
     })
   })
@@ -174,10 +247,12 @@ describe('RolesGuard', () => {
     it('should return true if the user has the system admin role', async () => {
       // Arrange
       mockJwtDecode.mockReturnValue(systemAdminClaims)
-      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['system_admin'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub(),
-      )
+      jest
+        .spyOn(reflector, 'getAllAndOverride')
+        .mockReturnValue(['system_admin'])
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub())
       // Act & Assert
       expect(await rolesGuard.canActivate(execution_context)).toBeTruthy()
       expect(reflector.getAllAndOverride).toHaveBeenCalledWith(ROLE_METADATA, [
@@ -193,9 +268,9 @@ describe('RolesGuard', () => {
       jest
         .spyOn(reflector, 'getAllAndOverride')
         .mockReturnValue(['system_admin', 'user'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub(),
-      )
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub())
       // Act & Assert
       expect(await rolesGuard.canActivate(execution_context)).toBeTruthy()
       expect(reflector.getAllAndOverride).toHaveBeenCalledWith(ROLE_METADATA, [
@@ -208,10 +283,12 @@ describe('RolesGuard', () => {
     it('should return false if the user has only the user role', async () => {
       // Arrange
       mockJwtDecode.mockReturnValue(tenantUserClaims)
-      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['system_admin'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub(),
-      )
+      jest
+        .spyOn(reflector, 'getAllAndOverride')
+        .mockReturnValue(['system_admin'])
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub())
       // Act & Assert
       expect(await rolesGuard.canActivate(execution_context)).toBeFalsy()
       expect(reflector.getAllAndOverride).toHaveBeenCalledWith(ROLE_METADATA, [
@@ -227,9 +304,9 @@ describe('RolesGuard', () => {
       jest
         .spyOn(reflector, 'getAllAndOverride')
         .mockReturnValue(['specific_role_only'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub(),
-      )
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub())
       // Act & Assert
       expect(await rolesGuard.canActivate(execution_context)).toBeTruthy()
     })
@@ -239,9 +316,9 @@ describe('RolesGuard', () => {
       // Arrange
       mockJwtDecode.mockReturnValue(tenantUserClaims)
       jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(undefined)
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub(),
-      )
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub())
       // Act & Assert
       expect(await rolesGuard.canActivate(execution_context)).toBeTruthy()
     })
@@ -250,9 +327,9 @@ describe('RolesGuard', () => {
       // Arrange
       mockJwtDecode.mockReturnValue(tenantUserClaims)
       jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue([])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub(),
-      )
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub())
       // Act & Assert
       expect(await rolesGuard.canActivate(execution_context)).toBeTruthy()
     })
@@ -272,10 +349,12 @@ describe('RolesGuard', () => {
         // No custom:tenant - trying to use header
       }
       mockJwtDecode.mockReturnValue(tenantSpecificAdminClaims)
-      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['system_admin'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('tenant-b'),
-      )
+      jest
+        .spyOn(reflector, 'getAllAndOverride')
+        .mockReturnValue(['system_admin'])
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('tenant-b'))
       // Act & Assert - tenant-specific admin should NOT access other tenants
       expect(await rolesGuard.canActivate(execution_context)).toBeFalsy()
     })
@@ -291,10 +370,12 @@ describe('RolesGuard', () => {
         // No custom:tenant - using header
       }
       mockJwtDecode.mockReturnValue(globalAdminClaims)
-      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['system_admin'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('any-tenant'),
-      )
+      jest
+        .spyOn(reflector, 'getAllAndOverride')
+        .mockReturnValue(['system_admin'])
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('any-tenant'))
       // Act & Assert - global admin should access any tenant
       expect(await rolesGuard.canActivate(execution_context)).toBeTruthy()
     })
@@ -310,9 +391,9 @@ describe('RolesGuard', () => {
       }
       mockJwtDecode.mockReturnValue(emptyRoleClaims)
       jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['user'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('any-tenant'),
-      )
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('any-tenant'))
       // Act & Assert - empty role should not grant cross-tenant access
       expect(await rolesGuard.canActivate(execution_context)).toBeFalsy()
     })
@@ -327,10 +408,12 @@ describe('RolesGuard', () => {
         'custom:roles': JSON.stringify([{ tenant: '', role: 'SYSTEM_ADMIN' }]),
       }
       mockJwtDecode.mockReturnValue(uppercaseAdminClaims)
-      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['system_admin'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('any-tenant'),
-      )
+      jest
+        .spyOn(reflector, 'getAllAndOverride')
+        .mockReturnValue(['system_admin'])
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('any-tenant'))
       // Act & Assert - SYSTEM_ADMIN != system_admin, should fail cross-tenant
       expect(await rolesGuard.canActivate(execution_context)).toBeFalsy()
     })
@@ -340,9 +423,9 @@ describe('RolesGuard', () => {
       // Arrange - 'COMMON' should match 'common' because tenantCode is normalized
       mockJwtDecode.mockReturnValue(userWithoutTenantClaims)
       jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['user'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('COMMON'),
-      )
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('COMMON'))
       // Act & Assert - 'COMMON' is normalized to 'common', should succeed
       expect(await rolesGuard.canActivate(execution_context)).toBeTruthy()
     })
@@ -359,7 +442,9 @@ describe('RolesGuard', () => {
       }
       mockJwtDecode.mockReturnValue(claimsWithTenant)
       jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['user'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(
         createRequestStub('attacker-tenant'), // malicious header should be ignored
       )
       // Act & Assert - should succeed because custom:tenant exists
@@ -380,10 +465,12 @@ describe('RolesGuard', () => {
         // No custom:tenant
       }
       mockJwtDecode.mockReturnValue(mixedRolesClaims)
-      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['system_admin'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('any-tenant'),
-      )
+      jest
+        .spyOn(reflector, 'getAllAndOverride')
+        .mockReturnValue(['system_admin'])
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('any-tenant'))
       // Act & Assert - should succeed because global system_admin role exists
       expect(await rolesGuard.canActivate(execution_context)).toBeTruthy()
     })
@@ -395,13 +482,17 @@ describe('RolesGuard', () => {
         sub: '12345678-1234-1234-1234-123456789012',
         'cognito:username': 'user',
         email: 'user@test.com',
-        'custom:roles': JSON.stringify([{ tenant: '', role: ' system_admin ' }]),
+        'custom:roles': JSON.stringify([
+          { tenant: '', role: ' system_admin ' },
+        ]),
       }
       mockJwtDecode.mockReturnValue(whitespaceRoleClaims)
-      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['system_admin'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('any-tenant'),
-      )
+      jest
+        .spyOn(reflector, 'getAllAndOverride')
+        .mockReturnValue(['system_admin'])
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('any-tenant'))
       // Act & Assert - ' system_admin ' != 'system_admin', should fail
       expect(await rolesGuard.canActivate(execution_context)).toBeFalsy()
     })
@@ -417,9 +508,9 @@ describe('RolesGuard', () => {
       }
       mockJwtDecode.mockReturnValue(noRoleClaims)
       jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue([])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('any-tenant'),
-      )
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('any-tenant'))
       // Act & Assert - no cross-tenant role, should fail header override
       expect(await rolesGuard.canActivate(execution_context)).toBeFalsy()
     })
@@ -439,9 +530,9 @@ describe('RolesGuard', () => {
       // This is the most common case - user bound to tenant via Cognito
       mockJwtDecode.mockReturnValue(tenantUserClaims)
       jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['user'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('test'),
-      )
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('test'))
       // Act & Assert - should work exactly as before
       expect(await rolesGuard.canActivate(execution_context)).toBeTruthy()
     })
@@ -450,10 +541,12 @@ describe('RolesGuard', () => {
     it('should maintain existing behavior for system admin header override', async () => {
       // System admin using header - this should work as before
       mockJwtDecode.mockReturnValue(systemAdminClaims)
-      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['system_admin'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('any-tenant'),
-      )
+      jest
+        .spyOn(reflector, 'getAllAndOverride')
+        .mockReturnValue(['system_admin'])
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('any-tenant'))
       // Act & Assert - should work exactly as before
       expect(await rolesGuard.canActivate(execution_context)).toBeTruthy()
     })
@@ -463,9 +556,9 @@ describe('RolesGuard', () => {
       // User accessing 'common' tenant without custom:tenant should work
       mockJwtDecode.mockReturnValue(userWithoutTenantClaims)
       jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['user'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('common'),
-      )
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('common'))
       // Act & Assert - 'common' is the default common tenant
       expect(await rolesGuard.canActivate(execution_context)).toBeTruthy()
     })
@@ -474,10 +567,12 @@ describe('RolesGuard', () => {
     it('should default to system_admin as cross-tenant role', async () => {
       // System admin should have cross-tenant access by default
       mockJwtDecode.mockReturnValue(systemAdminClaims)
-      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['system_admin'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('any-tenant'),
-      )
+      jest
+        .spyOn(reflector, 'getAllAndOverride')
+        .mockReturnValue(['system_admin'])
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('any-tenant'))
       // Act & Assert
       expect(await rolesGuard.canActivate(execution_context)).toBeTruthy()
 
@@ -488,9 +583,9 @@ describe('RolesGuard', () => {
       }
       mockJwtDecode.mockReturnValue(managerClaims)
       jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['manager'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('any-tenant'),
-      )
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('any-tenant'))
       expect(await rolesGuard.canActivate(execution_context)).toBeFalsy()
     })
   })
@@ -519,9 +614,9 @@ describe('RolesGuard', () => {
       // Arrange - user without custom:tenant accessing 'shared' tenant
       mockJwtDecode.mockReturnValue(userWithoutTenantClaims)
       jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['user'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('shared'),
-      )
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('shared'))
 
       // Act & Assert - 'shared' should be accessible
       expect(await customGuard.canActivate(execution_context)).toBeTruthy()
@@ -552,13 +647,17 @@ describe('RolesGuard', () => {
         sub: '12345678-1234-1234-1234-123456789012',
         'cognito:username': 'manager',
         email: 'manager@test.com',
-        'custom:roles': JSON.stringify([{ tenant: '', role: 'general_manager' }]),
+        'custom:roles': JSON.stringify([
+          { tenant: '', role: 'general_manager' },
+        ]),
       }
       mockJwtDecode.mockReturnValue(generalManagerClaims)
-      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['general_manager'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('any-tenant'),
-      )
+      jest
+        .spyOn(reflector, 'getAllAndOverride')
+        .mockReturnValue(['general_manager'])
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('any-tenant'))
 
       // Act & Assert - general_manager should have cross-tenant access
       expect(await customGuard.canActivate(execution_context)).toBeTruthy()
@@ -603,17 +702,17 @@ describe('RolesGuard', () => {
       }
       mockJwtDecode.mockReturnValue(supervisorClaims)
       jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['supervisor'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('dept-sales'),
-      )
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('dept-sales'))
 
       // Act & Assert - supervisor should access dept- tenants
       expect(await customGuard.canActivate(execution_context)).toBeTruthy()
 
       // But not other tenants
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('other-tenant'),
-      )
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('other-tenant'))
       expect(await customGuard.canActivate(execution_context)).toBeFalsy()
     })
 
@@ -656,9 +755,9 @@ describe('RolesGuard', () => {
       }
       mockJwtDecode.mockReturnValue(specialAccessClaims)
       jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['user'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('any-tenant'),
-      )
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('any-tenant'))
 
       // Act & Assert - special access bypasses header override check
       expect(await customGuard.canActivate(execution_context)).toBeTruthy()
@@ -687,9 +786,9 @@ describe('RolesGuard', () => {
       // Arrange - user trying to access 'common' tenant
       mockJwtDecode.mockReturnValue(userWithoutTenantClaims)
       jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['user'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('common'),
-      )
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('common'))
 
       // Act & Assert - 'common' should no longer be accessible
       expect(await customGuard.canActivate(execution_context)).toBeFalsy()
@@ -717,18 +816,20 @@ describe('RolesGuard', () => {
 
       // Arrange - system admin trying to access via header
       mockJwtDecode.mockReturnValue(systemAdminClaims)
-      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['system_admin'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('any-tenant'),
-      )
+      jest
+        .spyOn(reflector, 'getAllAndOverride')
+        .mockReturnValue(['system_admin'])
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('any-tenant'))
 
       // Act & Assert - even system_admin should not have cross-tenant access
       expect(await customGuard.canActivate(execution_context)).toBeFalsy()
 
       // But common tenant should still work (common tenant check comes first)
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('common'),
-      )
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('common'))
       expect(await customGuard.canActivate(execution_context)).toBeTruthy()
     })
 
@@ -757,7 +858,10 @@ describe('RolesGuard', () => {
         }
 
         protected getCrossTenantRoles(): string[] {
-          const roles = this.configService.get('CROSS_TENANT_ROLES', 'system_admin')
+          const roles = this.configService.get(
+            'CROSS_TENANT_ROLES',
+            'system_admin',
+          )
           return roles.split(',').map((r: string) => r.trim())
         }
       }
@@ -767,17 +871,17 @@ describe('RolesGuard', () => {
       // Arrange - user accessing 'shared' tenant (configured as common)
       mockJwtDecode.mockReturnValue(userWithoutTenantClaims)
       jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['user'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('shared'),
-      )
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('shared'))
 
       // Act & Assert - 'shared' should be accessible via config
       expect(await guard.canActivate(execution_context)).toBeTruthy()
 
       // Also verify 'global' works
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('global'),
-      )
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('global'))
       expect(await guard.canActivate(execution_context)).toBeTruthy()
     })
   })
@@ -788,9 +892,9 @@ describe('RolesGuard', () => {
       // Arrange - valid tenant but wrong role
       mockJwtDecode.mockReturnValue(tenantUserClaims)
       jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['admin']) // user has 'user' role
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('test'),
-      )
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('test'))
 
       // Act & Assert - should fail on role check (tenant passes)
       expect(await rolesGuard.canActivate(execution_context)).toBeFalsy()
@@ -803,9 +907,9 @@ describe('RolesGuard', () => {
       // Arrange - invalid tenant access
       mockJwtDecode.mockReturnValue(userWithoutTenantClaims)
       jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['user'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('unauthorized-tenant'),
-      )
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('unauthorized-tenant'))
 
       // Act & Assert
       expect(await rolesGuard.canActivate(execution_context)).toBeFalsy()
@@ -824,9 +928,9 @@ describe('RolesGuard', () => {
       }
       mockJwtDecode.mockReturnValue(noRolesClaims)
       jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue([])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('any-tenant'),
-      )
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('any-tenant'))
 
       // Act & Assert - should not throw, should return false
       expect(await rolesGuard.canActivate(execution_context)).toBeFalsy()
@@ -837,17 +941,17 @@ describe('RolesGuard', () => {
       // 'Common' (capital C) should match 'common' because tenantCode is normalized
       mockJwtDecode.mockReturnValue(userWithoutTenantClaims)
       jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['user'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('Common'),
-      )
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('Common'))
 
       // Both 'Common' and 'common' should work (normalized to lowercase)
       expect(await rolesGuard.canActivate(execution_context)).toBeTruthy()
 
       // 'common' should also work
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('common'),
-      )
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('common'))
       expect(await rolesGuard.canActivate(execution_context)).toBeTruthy()
     })
 
@@ -857,7 +961,9 @@ describe('RolesGuard', () => {
       // Should use custom:tenant and succeed
       mockJwtDecode.mockReturnValue(tenantUserClaims) // custom:tenant = 'test'
       jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['user'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(
         createRequestStub('other-tenant'), // header says different tenant
       )
 
@@ -876,10 +982,12 @@ describe('RolesGuard', () => {
         'custom:roles': JSON.stringify([{ tenant: '', role: 'system_admin' }]),
       }
       mockJwtDecode.mockReturnValue(systemAdminWithTenant)
-      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['system_admin'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('other-tenant'),
-      )
+      jest
+        .spyOn(reflector, 'getAllAndOverride')
+        .mockReturnValue(['system_admin'])
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('other-tenant'))
 
       // Act & Assert - should succeed, using custom:tenant (not header)
       expect(await rolesGuard.canActivate(execution_context)).toBeTruthy()
@@ -903,12 +1011,13 @@ describe('RolesGuard', () => {
           },
         ],
       }).compile()
-      const testableGuard = moduleRef.get<TestableRolesGuard>(TestableRolesGuard)
+      const testableGuard =
+        moduleRef.get<TestableRolesGuard>(TestableRolesGuard)
 
       mockJwtDecode.mockReturnValue(tenantUserClaims)
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('test'),
-      )
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('test'))
 
       const claims = testableGuard.testGetClaims(execution_context)
       expect(claims['custom:tenant']).toBe('test')
@@ -926,7 +1035,9 @@ describe('RolesGuard', () => {
       for (const { header, description } of falsyTenantTests) {
         mockJwtDecode.mockReturnValue(userWithoutTenantClaims)
         jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['user'])
-        ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue({
+        ;(
+          execution_context.switchToHttp().getRequest as jest.Mock
+        ).mockReturnValue({
           headers: { 'x-tenant-code': header },
           get: () => dummyToken,
         })
@@ -952,36 +1063,42 @@ describe('RolesGuard', () => {
           },
         ],
       }).compile()
-      const multiGuard = moduleRef.get<MultiCommonRolesGuard>(MultiCommonRolesGuard)
+      const multiGuard = moduleRef.get<MultiCommonRolesGuard>(
+        MultiCommonRolesGuard,
+      )
 
       mockJwtDecode.mockReturnValue(userWithoutTenantClaims)
       jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['user'])
 
       // All three should work
       for (const tenant of ['common', 'public', 'shared']) {
-        ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-          createRequestStub(tenant),
-        )
+        ;(
+          execution_context.switchToHttp().getRequest as jest.Mock
+        ).mockReturnValue(createRequestStub(tenant))
         expect(await multiGuard.canActivate(execution_context)).toBeTruthy()
       }
 
       // But others should not
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('private'),
-      )
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('private'))
       expect(await multiGuard.canActivate(execution_context)).toBeFalsy()
     })
 
     /** Verify verifyTenant and verifyRole are async (for subclass override) */
     it('should support async overrides of verifyTenant and verifyRole', async () => {
       class AsyncRolesGuard extends RolesGuard {
-        protected async verifyTenant(context: ExecutionContext): Promise<boolean> {
+        protected async verifyTenant(
+          context: ExecutionContext,
+        ): Promise<boolean> {
           // Simulate async operation
           await new Promise((resolve) => setTimeout(resolve, 1))
           return super.verifyTenant(context)
         }
 
-        protected async verifyRole(context: ExecutionContext): Promise<boolean> {
+        protected async verifyRole(
+          context: ExecutionContext,
+        ): Promise<boolean> {
           // Simulate async operation
           await new Promise((resolve) => setTimeout(resolve, 1))
           return super.verifyRole(context)
@@ -1001,9 +1118,9 @@ describe('RolesGuard', () => {
 
       mockJwtDecode.mockReturnValue(tenantUserClaims)
       jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['user'])
-      ;(execution_context.switchToHttp().getRequest as jest.Mock).mockReturnValue(
-        createRequestStub('test'),
-      )
+      ;(
+        execution_context.switchToHttp().getRequest as jest.Mock
+      ).mockReturnValue(createRequestStub('test'))
 
       // Should work with async overrides
       expect(await asyncGuard.canActivate(execution_context)).toBeTruthy()

--- a/packages/core/src/guard/roles.guard.ts
+++ b/packages/core/src/guard/roles.guard.ts
@@ -88,8 +88,9 @@ export class RolesGuard implements CanActivate {
       return true
     }
 
-    // Allow users with cross-tenant roles
-    return this.getCrossTenantRoles().includes(userContext.tenantRole)
+    const tenantRoles = this.getUserTenantRoles(context)
+    const crossTenantRoles = this.getCrossTenantRoles()
+    return tenantRoles.some((role) => crossTenantRoles.includes(role))
   }
 
   /**
@@ -135,6 +136,14 @@ export class RolesGuard implements CanActivate {
     return getAuthorizerClaims(invokeContext)
   }
 
+  protected getUserTenantRoles(context: ExecutionContext): string[] {
+    const { tenantRoles, tenantRole } = getUserContext(context)
+    if (tenantRoles?.length) {
+      return tenantRoles
+    }
+    return tenantRole ? [tenantRole] : []
+  }
+
   protected async verifyRole(context: ExecutionContext): Promise<boolean> {
     const requiredRoles = this.reflector.getAllAndOverride<string[]>(
       ROLE_METADATA,
@@ -145,15 +154,15 @@ export class RolesGuard implements CanActivate {
       return true
     }
 
-    const userRole = await this.getUserRole(context)
-    if (!userRole) {
+    const tenantRoles = this.getUserTenantRoles(context)
+    if (!tenantRoles.length) {
       return false
     }
-    if (userRole === ROLE_SYSTEM_ADMIN) {
+    if (tenantRoles.includes(ROLE_SYSTEM_ADMIN)) {
       return true
     }
 
-    return requiredRoles.includes(userRole)
+    return requiredRoles.some((role) => tenantRoles.includes(role))
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/core/src/guard/roles.guard.ts
+++ b/packages/core/src/guard/roles.guard.ts
@@ -165,10 +165,13 @@ export class RolesGuard implements CanActivate {
     return requiredRoles.some((role) => tenantRoles.includes(role))
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  /**
+   * @deprecated Override `getUserTenantRoles` instead. This method is no longer
+   * called by `verifyRole` as of [this release] and will be removed in a future
+   * major version.
+   */
   protected async getUserRole(context: ExecutionContext): Promise<string> {
     const userContext = getUserContext(context)
-
     return userContext.tenantRole
   }
 }

--- a/packages/core/src/helpers/serializer.ts
+++ b/packages/core/src/helpers/serializer.ts
@@ -1,43 +1,36 @@
-import { CommandEntity, DataEntity } from '../interfaces';
-
-export interface SerializerOptions {
-  keepAttributes?: boolean;
-  flattenDepth?: number;
-}
+import { CommandEntity, DataEntity } from '../interfaces'
 
 /**
  * Converts internal DynamoDB structure to external flat structure
  * @param item Internal item (CommandEntity or DataEntity)
- * @param options Serialization options
  * @returns Flattened external structure
  */
 export function serializeToExternal<T extends CommandEntity | DataEntity>(
   item: T | null | undefined,
-  options: SerializerOptions = {}
 ): Record<string, any> | null {
-  if (!item) return null;
+  if (!item) return null
 
   const result: Record<string, any> = {
     id: `${item.pk}#${item.sk}`,
     code: item.sk,
     name: item.name,
-  };
+  }
 
   // Copy first level properties
-  Object.keys(item).forEach(key => {
+  Object.keys(item).forEach((key) => {
     if (key !== 'attributes' && typeof item[key] !== 'undefined') {
-      result[key] = item[key];
+      result[key] = item[key]
     }
-  });
+  })
 
   // Handle attributes
   if (item.attributes) {
     Object.entries(item.attributes).forEach(([key, value]) => {
-      result[key] = value;
-    });
+      result[key] = value
+    })
   }
 
-  return result;
+  return result
 }
 
 /**
@@ -48,37 +41,68 @@ export function serializeToExternal<T extends CommandEntity | DataEntity>(
  */
 export function deserializeToInternal<T extends CommandEntity | DataEntity>(
   data: Record<string, any> | null | undefined,
-  EntityClass: new () => T
+  EntityClass: new () => T,
 ): T | null {
-  if (!data) return null;
+  if (!data) return null
 
-  const [pk, sk] = (data.id || '').split('#');
-  const entity = new EntityClass();
-  const attributes: Record<string, any> = {};
-  
+  const [pk, sk] = (data.id || '').split('#')
+  const entity = new EntityClass()
+  const attributes: Record<string, any> = {}
+
   // Set basic properties
-  entity.pk = pk;
-  entity.sk = sk || data.code;
-  entity.name = data.name;
+  entity.pk = pk
+  entity.sk = sk || data.code
+  entity.name = data.name
 
   // Copy entity-specific fields first
-  ['version', 'tenantCode', 'type', 'isDeleted', 'status', 'createdAt', 'updatedAt', 'createdBy', 'updatedBy', 'createdIp', 'updatedIp'].forEach(key => {
+  ;[
+    'version',
+    'tenantCode',
+    'type',
+    'isDeleted',
+    'status',
+    'createdAt',
+    'updatedAt',
+    'createdBy',
+    'updatedBy',
+    'createdIp',
+    'updatedIp',
+  ].forEach((key) => {
     if (key in data) {
-      entity[key] = data[key];
+      entity[key] = data[key]
     }
-  });
+  })
 
   // Separate remaining fields into attributes
-  Object.keys(data).forEach(key => {
-    if (!['id', 'code', 'pk', 'sk', 'name', 'version', 'tenantCode', 'type', 'isDeleted', 'status', 'createdAt', 'updatedAt', 'createdBy', 'updatedBy', 'createdIp', 'updatedIp'].includes(key)) {
+  Object.keys(data).forEach((key) => {
+    if (
+      ![
+        'id',
+        'code',
+        'pk',
+        'sk',
+        'name',
+        'version',
+        'tenantCode',
+        'type',
+        'isDeleted',
+        'status',
+        'createdAt',
+        'updatedAt',
+        'createdBy',
+        'updatedBy',
+        'createdIp',
+        'updatedIp',
+      ].includes(key)
+    ) {
       if (key in entity) {
-        entity[key] = data[key];
+        entity[key] = data[key]
       } else {
-        attributes[key] = data[key];
+        attributes[key] = data[key]
       }
     }
-  });
+  })
 
-  entity.attributes = attributes;
-  return entity;
+  entity.attributes = attributes
+  return entity
 }

--- a/packages/core/test/infra-local/cognito-local/db/local_2G7noHgW.json
+++ b/packages/core/test/infra-local/cognito-local/db/local_2G7noHgW.json
@@ -13,6 +13,10 @@
         {
           "Name": "custom:roles",
           "Value": "[{\"role\":\"system_admin\"}]"
+        },
+        {
+          "Name": "custom:groups",
+          "Value": "[]"
         }
       ],
       "Enabled": true,
@@ -257,6 +261,17 @@
         "StringAttributeConstraints": {
           "MinLength": "1",
           "MaxLength": "10"
+        }
+      },
+      {
+        "Name": "custom:groups",
+        "AttributeDataType": "String",
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "Required": false,
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
         }
       }
     ],


### PR DESCRIPTION
## Summary
- Adds **group-derived roles** to core authorization using a new optional JWT claim **`custom:groups`** (same `{ tenant, role }` JSON shape as `custom:roles`).
- **`RolesGuard`** and cross-tenant header checks use **`tenantRoles`** — the union of direct and group roles for the active tenant (deduplicated).
- **`tenantRole`** is unchanged: still the **first** matching entry from **`custom:roles` only**

## Token contract

| Claim | Meaning |
|-------|---------|
| `custom:roles` | Roles assigned **directly** to the user |
| `custom:groups` | **Flattened** roles from group membership |

- Missing or empty `custom:groups` → same behavior as before
- **`system_admin`** in either claim → full `@Roles` bypass.
- Cross-tenant header override succeeds if **any** `tenantRoles` entry is in `CROSS_TENANT_ROLES`.

## Backward compatibility

- Tokens **without** `custom:groups`: no change for guards.
- **`UserContext.tenantRole`**: same semantics (direct roles only).
- Routes protected by **`@Roles()`** automatically honor group roles.