### PR TITLE
docs(changelog,mcp-server): document v1.3.1 and backfill all stable release entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.3.1](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.3.1) (2026-06-01)
+## [1.3.1](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.3.1) (2026-06-02)
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,226 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.1](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.3.1) (2026-06-01)
+
+### Features
+
+- **core:** Add group-based role authorization
+  - `RolesGuard` now checks direct roles from JWT `custom:roles` first, then roles derived from the user's groups in the new `custom:groups` claim (tenant-scoped)
+  - Add `@GroupRoleResolver()` decorator and `IGroupRoleResolver` interface — implement exactly one resolver per app to map group IDs to roles (loaded from DynamoDB/RDS/config); the mapping is not stored in the JWT
+  - `UserContext` gains `tenantRoles` (direct roles array) and `tenantGroupIds` (group IDs for the active tenant); `tenantRole` (singular) is kept for backward compatibility
+  - Opt-in: existing `@Roles()` checks keep working with no code changes
+
+### Bug Fixes
+
+- **core:** Tolerate a malformed `custom:groups` claim (fail-closed to no group roles) instead of throwing, so a bad token degrades to direct-role-only checks rather than crashing the request
+
+## [1.3.0](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.3.0) (2026-05-21)
+
+### Features
+
+- **core:** Add AppSync Events API support (opt-in, no breaking changes)
+  - Introduce `@NotificationTransport('transport-name')` decorator and refactor `NotificationModule` for transport flexibility
+  - Activate transports via the `NOTIFICATION_TRANSPORTS` environment variable (e.g. `appsync-graphql,appsync-event`)
+  - Add `AppSyncService` initialization, environment variable validation, and a sample AppSync event client
+- **cli:** Enhance AppSync Events API integration
+
+## [1.2.6](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.2.6) (2026-05-06)
+
+### Features
+
+- **core:** Optimize Repository read-your-writes (RYW) session handling with version checks and session deletion logic (transparent; no code changes required)
+
+## [1.2.5](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.2.5) (2026-04-10)
+
+### Features
+
+- **import:** Enhance ZIP import functionality and validation
+
+### Refactors
+
+- **import:** Remove `ZipImportQueueEventHandler` and streamline import processing
+
+## [1.2.4](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.2.4) (2026-04-09)
+
+### Breaking Changes
+
+- **master:** `TaskModule.register()` must be called exactly once in the host `AppModule`
+  - Duplicate registrations across feature modules cause `"transformTask is not a function"` at runtime
+  - **Migration:** Remove `TaskModule.register()` from feature modules and register it only in `AppModule`
+
+### Features
+
+- **core:** Implement SQS client and service for message handling; make `QueueModule` global with SQS support
+
+### Bug Fixes
+
+- **core:** Handle malformed JWT tokens gracefully in `extractInvokeContext`
+- **import:** Refine single import routing, error handling, and parent job counters in the import queue/Step Functions handlers
+
+## [1.2.3](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.2.3) (2026-04-08)
+
+### Bug Fixes
+
+- **import:** Refine SingleImportProcessor routing and error handling in ImportQueueEventHandler
+- **import:** Use `event.importEvent` instead of `event.payload` for single import processing
+- **import:** Improve error handling in CsvBatchProcessor and ImportQueueEventHandler
+
+## [1.2.2](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.2.2) (2026-04-08)
+
+### Bug Fixes
+
+- **import:** Fix Head-of-Line Blocking (Poison Pill) in `CsvBatchProcessor` by implementing Smart Retry pattern ([PR #394](https://github.com/mbc-net/mbc-cqrs-serverless/pull/394))
+  - Previously, a persistent validation error on the first row caused the entire batch to crash immediately
+  - Now, each row is processed independently; errors are collected and a single aggregated error is thrown after the full batch is processed
+  - Valid rows are saved successfully; failed rows trigger SQS retry; already-succeeded rows are skipped on retry via EQUAL comparison (idempotency maintained)
+- **import:** Fix `ImportQueueEventHandler` passing raw SQS payload instead of parsed `importEvent` to `SingleImportProcessor` ([PR #394](https://github.com/mbc-net/mbc-cqrs-serverless/pull/394))
+  - `singleImportProcessor.process()` now receives `event.importEvent` (parsed, rich object) instead of `event.payload` (raw SQS payload)
+
+## [1.2.1](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.2.1) (2026-04-06)
+
+### Features
+
+- **core:** Add `SqsService` and `SqsClientFactory` for SQS message operations ([PR #383](https://github.com/mbc-net/mbc-cqrs-serverless/pull/383))
+  - `sendMessage()` — send a single message to an SQS queue
+  - `sendMessageBatch()` — send up to 10 messages in a single API call
+  - `receiveMessages()` — receive messages with configurable `MaxNumberOfMessages` (default: 10) and `WaitTimeSeconds` (default: 0)
+  - `deleteMessage()` — acknowledge and delete a single processed message
+  - `deleteMessageBatch()` — delete up to 10 messages in a single API call
+  - `SqsService` is registered in `QueueModule` (global) and injectable across the application
+  - Supports `MessageSystemAttributeNames` for receiving system attributes (deprecated `AttributeNames` not exposed)
+- **core:** Refactor `SnsClientFactory` to use a singleton `SNSClient` instance ([PR #383](https://github.com/mbc-net/mbc-cqrs-serverless/pull/383))
+  - Previously cached a separate client per topic ARN; now a single instance is shared across all publish calls
+  - `getClient()` signature changed from `getClient(topicArn: string)` to `getClient()`
+
+## [1.2.0](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.2.0) (2026-04-02)
+
+### Breaking Changes
+
+- **core:** `CommandService.publishSync()` and `publishPartialUpdateSync()` now return `Promise<CommandModel | null>` (previously `Promise<CommandModel>`)
+  - Returns `null` when the command is not dirty (no-op), matching `publishAsync()` / `publishPartialUpdateAsync()`
+  - **Migration:** Callers must null-check the result before accessing fields such as `pk` or `version`
+- **sequence:** Remove deprecated `SequencesService.genNewSequence()` method
+  - Use `generateSequenceItem()` or `generateSequenceItemWithProvideSetting()` instead
+
+### Features
+
+- **core:** Implement read-your-writes (RYW) session management for async command publishing
+  - The same user's subsequent reads return pending command data before the DynamoDB Stream sync completes
+  - Add DynamoDB session table configuration; enable via the `RYW_SESSION_TTL_MINUTES` environment variable
+  - Introduce `CommandSyncMode` enum and `SessionService` to encapsulate the RYW session policy
+- **import:** Enhance CSV import processing with a new state-machine definition, publish-mode configuration, and improved result/error handling
+
+## [1.1.6](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.1.6) (2026-03-30)
+
+### Bug Fixes
+
+- **import:** Correct import status handling for ZIP orchestrator ([#371](https://github.com/mbc-net/mbc-cqrs-serverless/pull/371))
+
+## [1.1.5](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.1.5) (2026-03-28)
+
+### Features
+
+- **import:** Implement v2 batch processing architecture for high-throughput CSV imports ([PR #366](https://github.com/mbc-net/mbc-cqrs-serverless/pull/366))
+  - Replace per-row `import_tmp` writes with direct in-Lambda command publishing, eliminating Hot Partition bottlenecks
+  - Distributed Map now configured with `MaxItemsPerBatch: 100` and `MaxConcurrency: 50` for significantly higher throughput
+  - New `finalize_parent_job` state aggregates batch summaries and writes final job status in a single DynamoDB `UpdateItem` call
+  - Remove per-row atomic counter updates from `CommandFinishedHandler`, eliminating DynamoDB throttling at scale
+  - Add `ImportPublishMode` enum (`SYNC` / `ASYNC`) to `ImportEntityProfile` for per-entity publish mode configuration
+  - Add empty `processingResults` guard: job is marked `FAILED` if no batch results are received
+
+### Breaking Changes
+
+- **import:** CSV import no longer provides real-time row-level progress tracking
+  - `processedRows`, `succeededRows`, `failedRows` counters are now aggregated once when Step Functions execution completes
+  - Individual CSV rows are no longer written to the `import_tmp` DynamoDB table
+  - The `import-csv` state machine requires a new `finalize_parent_job` state and `resultPath: '$.processingResults'` — CDK and `serverless.yml` must be updated together with this package
+
+### Tests
+
+- Add SYNC/ASYNC routing tests for `ImportQueueEventHandler` (6 test cases covering EQUAL/NOT_EXIST/CHANGED × SYNC/ASYNC + fallback)
+- Add empty `processingResults` guard test for `CsvImportSfnEventHandler`
+- Add batch aggregation tests (1,000 + 500 rows, COMPLETED and FAILED scenarios)
+
+## [1.1.4](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.1.4) (2026-03-27)
+
+### Features
+
+- **core:** Restore audit trail and history parity for `publishSync` ([PR #363](https://github.com/mbc-net/mbc-cqrs-serverless/pull/363))
+  - `publishSync` now writes an immutable event to the Command table with `status: 'publish_sync:STARTED'` and `syncMode: 'SYNC'`
+  - History table is now populated by `publishSync`, matching the async Step Functions pipeline
+  - Command lifecycle follows `publish_sync:STARTED` → `finish:FINISHED` (or `publish_sync:FAILED` on error)
+  - Ported `isNotCommandDirty` early-return optimization from `publishAsync` — returns `null` when no changes detected
+  - DynamoDB Stream filter updated to exclude `syncMode=SYNC` records, preventing Step Functions double-execution
+  - `DefaultEventFactory` also filters `syncMode=SYNC` records for local development environments
+
+### Tests
+
+- Add comprehensive tests for `publishSync` audit trail and history parity
+
+## [1.1.3](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.1.3) (2026-03-24)
+
+### Bug Fixes
+
+- **import:** Fix CSV import Distributed Map state result exceeding 256KB limit ([PR #348](https://github.com/mbc-net/mbc-cqrs-serverless/pull/348))
+  - Set `resultPath: DISCARD` on Distributed Map to prevent child execution results from being aggregated into state data
+  - Remove `MapResult` dependency from `CsvImportSfnEventHandler`, use `countCsvRows()` from S3 instead
+  - Add error handling for cases where the S3 stream is not readable
+
+### CI/CD
+
+- Switch to npm OIDC trusted publishing, removing dependency on `NPM_TOKEN` secret ([PR #357](https://github.com/mbc-net/mbc-cqrs-serverless/pull/357))
+  - Upgrade lerna from v8 to v9 for built-in OIDC support
+  - Add `id-token: write` permission to publish job
+  - Add lockfile sync step for Node 22+ compatibility
+
+### Tests
+
+- Add comprehensive tests for `CsvImportSfnEventHandler` finalize_parent_job logic
+  - Test FAILED status when failedRows > 0
+  - Test COMPLETED status when all rows succeed
+  - Test no status update when processing is incomplete
+  - Test error handling when S3 stream is not readable
+
+## [1.1.2](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.1.2) (2026-02-25)
+
+### Features
+
+- **master:** Add built-in upsert methods for master settings and data
+  - `upsertTenantSetting()`, `upsertSetting()`, `upsertBulk()` for MasterSettingService
+  - `upsert()`, `upsertSetting()`, `upsertBulk()` for MasterDataService
+  - Automatically creates new records, updates changed records, and skips unchanged records
+  - Supports recreating soft-deleted records
+- **master:** Add unified bulk upsert API (`/api/master-bulk/`)
+  - Single endpoint that handles both settings and data items
+  - Items routed by presence of `settingCode` field
+  - Preserves original input order in response
+  - Tenant code validation enforced
+- **master:** Add `@ArrayMaxSize(100)` validation to all bulk DTOs
+- **master:** Add tenant code validation to individual bulk endpoints (`/api/master-setting/bulk`, `/api/master-data/bulk`)
+
+### Bug Fixes
+
+- **core:** Fix `checkVersion` error message using hardcoded value instead of actual `commandVersion` ([PR #331](https://github.com/mbc-net/mbc-cqrs-serverless/pull/331))
+- **master:** Fix `seq === 0` being treated as falsy in `createSetting` by changing to null check (`seq == null`)
+- **master:** Fix DTO mutation in `createSetting` by cloning attributes before modifying seq
+
+### Tests
+
+- Add comprehensive unit tests for MasterBulkController (8 test cases)
+- Add unit tests for MasterDataService upsert and upsertBulk methods
+- Add unit tests for MasterSettingService upsertTenantSetting and upsertBulk methods
+- Add integration tests for master data and setting upsert scenarios
+
+## [1.1.1](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.1.1) (2026-02-07)
+
+### Bug Fixes
+
+- **cli:** Add missing `import_tmp.json` DynamoDB table template ([PR #323](https://github.com/mbc-net/mbc-cqrs-serverless/pull/323))
+  - The `import_tmp` table definition was missing from CLI templates, causing `npm run offline:sls` to fail
+  - The `serverless.yml` references `LOCAL_DDB_IMPORT_TMP_STREAM` environment variable, which requires the table to be created during migration
+  - See [Common Issues](/docs/common-issues#missing-import-tmp-table) for workaround if using older versions
+
 ## [1.1.0](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.1.0) - TBD
 
 ### Breaking Changes
@@ -55,6 +275,97 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 - Add migration guide for v1.1.0 tenant code changes
 
+## [1.0.26](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.0.26) (2026-01-26)
+
+### Features
+
+- **cli:** Add configurable local service ports via environment variables ([PR #300](https://github.com/mbc-net/mbc-cqrs-serverless/pull/300))
+  - Support for `LOCAL_HTTP_PORT`, `LOCAL_DYNAMODB_PORT`, `LOCAL_RDS_PORT`, and other port variables
+  - Allows users to resolve port conflicts with other services
+  - Configuration is automatically applied to Docker Compose, Serverless Offline, and trigger scripts
+
+### Security
+
+- Update `diff` package from 4.0.2 to 4.0.4 for security fix ([PR #297](https://github.com/mbc-net/mbc-cqrs-serverless/pull/297), [PR #299](https://github.com/mbc-net/mbc-cqrs-serverless/pull/299))
+- Update `lodash` package from 4.17.21 to 4.17.23 for prototype pollution fix ([PR #298](https://github.com/mbc-net/mbc-cqrs-serverless/pull/298))
+
+## [1.0.25](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.0.25) (2026-01-19)
+
+### Features
+
+- **core:** Enhanced inline template email with advanced variable substitution
+  - Support for nested property access in template variables (e.g., user.profile.name in double-brace placeholders)
+  - Support for Unicode/Japanese keys in template variables
+  - Whitespace trimming inside placeholders so spaces around the variable name are ignored
+  - Improved local development fallback for template compilation
+
+## [1.0.24](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.0.24) (2026-01-17)
+
+### Features
+
+- **mcp-server:** Add Claude Code Skills for guided development assistance
+  - `/mbc-generate`: Generate boilerplate code (modules, services, controllers, DTOs, handlers)
+  - `/mbc-review`: Review code for best practices and anti-patterns (20 patterns)
+  - `/mbc-migrate`: Guide version migrations and breaking changes
+  - `/mbc-debug`: Debug and troubleshoot common issues
+  - Skills are distributed via npm package and can be installed to `~/.claude/skills/` or `.claude/skills/`
+- **cli:** Add `mbc install-skills` command for easy skills installation
+  - Install skills to personal directory (`~/.claude/skills/`) or project directory (`.claude/skills/`)
+  - Options: `--project`, `--force`, `--list`
+
+### Bug Fixes
+
+- **core:** Fix typo in parameter name `skExpession` to `skExpression`
+  - Affected packages: core, directory, master, task, ui-setting
+  - This was a breaking change for TypeScript users who referenced the old parameter name
+
+## [1.0.23](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.0.23) (2026-01-16)
+
+### Features
+
+- **core:** Add inline template email support with `sendInlineTemplateEmail()` method
+  - New `sendInlineTemplateEmail(msg: TemplatedEmailNotification)` method in EmailService
+  - Support for inline HTML/text templates with dynamic data substitution
+  - Local development fallback with manual template compilation when SES is unavailable
+  - New interfaces: `InlineTemplateContent`, `TemplatedEmailNotification`
+
+## [1.0.22](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.0.22) (2026-01-16)
+
+### Features
+
+- **mcp-server:** Add code analysis tools for AI-assisted development
+  - `mbc_check_anti_patterns`: Detect common anti-patterns in code with severity levels
+  - `mbc_health_check`: Project health check (dependencies, structure, configuration)
+  - `mbc_explain_code`: Analyze and explain code in MBC CQRS context
+
+### Bug Fixes
+
+- **mcp-server:** Improve code analysis tools robustness
+  - Renumber anti-patterns sequentially (AP001-AP010)
+  - Limit regex match range to prevent false positives
+  - Add error handling for file reading and JSON parsing
+  - Add 18 unit tests for analyze tools
+
+### Security
+
+- Fix security vulnerabilities in dependencies: qs, express, body-parser
+
+### Dependencies
+
+- Bump qs from 6.13.0 to 6.14.1
+- Bump @nestjs/platform-express from 10.4.20 to 10.4.22
+- Bump express from 4.21.2 to 4.22.1
+- Bump body-parser from 1.20.3 to 1.20.4
+
+## [1.0.21](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.0.21) (2026-01-15)
+
+### Features
+
+- **import:** Add ZIP finalization hooks support to ImportModule
+  - New `IZipFinalizationHook` interface for custom post-import processing
+  - Register hooks via `zipFinalizationHooks` option in `ImportModule.register()`
+  - Hooks receive `ZipFinalizationContext` with results, status, and execution input
+
 ## [1.0.20](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.0.20)
 
 ### Bug Fixes
@@ -67,6 +378,18 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
   - This bug caused Step Functions to report SUCCESS even when child import jobs failed with errors like `ConditionalCheckFailedException`
   - Added comprehensive unit tests for CsvImportSfnEventHandler (5 tests)
 
+## [1.0.19](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.0.19) (2026-01-11)
+
+### Bug Fixes
+
+- **import:** Fix master job status not updating to FAILED when child import jobs fail
+  - Previously, when a child import job failed with errors like `ConditionalCheckFailedException`, the master job status remained `PROCESSING` indefinitely
+  - Fixed `incrementParentJobCounters` to correctly set master job status to `FAILED` when any child job fails (was always setting to `COMPLETED`)
+  - Fixed `ImportQueueEventHandler.handleImport` to call `incrementParentJobCounters` on error, ensuring parent counters are updated
+  - Removed `throw error` in error handler to prevent Lambda crashes and allow proper status propagation
+  - This fix completes the Step Functions error handling started in v1.0.18, ensuring `SendTaskFailure` is properly triggered
+  - See [ImportQueueEventHandler Error Handling](/docs/import-export-patterns#import-error-handling) for details
+
 ## [1.0.18](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.0.18)
 
 ### Bug Fixes
@@ -77,6 +400,164 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
   - Added `sendTaskFailure()` method to send `SendTaskFailureCommand`
   - Handler now processes both `COMPLETED` and `FAILED` statuses for CSV import jobs
   - Added comprehensive unit tests for the ImportStatusHandler (16 tests)
+
+## [1.0.17](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.0.17) (2026-01-08)
+
+### Bug Fixes
+
+- **master:** Fix `masterTypeCode` comparison in `MasterDataService.search()` - Changed from partial match (`contains`) to exact match for `settingCode` search parameter
+- **cli:** Stabilize AbstractRunner tests by removing setTimeout to fix flaky CI failures
+
+### Security
+
+- Fix security vulnerabilities in dependencies: jws (HMAC signature verification issue), nodemailer (DoS vulnerability)
+
+### Dependencies
+
+- Bump validator from 13.15.20 to 13.15.26
+- Bump @modelcontextprotocol/sdk from 1.25.1 to 1.25.2
+
+### Documentation
+
+- Update README files for all packages with comprehensive API references and usage examples
+- Fix `createTenantGroup` parameter name in tenant package README
+- Update Japanese guide links to official documentation
+
+## [1.0.16](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.0.16) (2025-12-31)
+
+### Bug Fixes
+
+- **cli:** Add cleanup for test-generated files and update .gitignore
+- **master, directory, task, cli:** Improve error messages for better clarity
+
+### Features
+
+- Include __s3Key in attributes for import creation
+- Zip mode provide table name
+- Add optional s3Key to CreateImportDto
+
+## [1.0.15](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.0.15) (2025-12-31)
+
+### Bug Fixes
+
+- **ui-setting:** Improve error messages for better clarity
+- **mcp-server:** Use MBC_PROJECT_PATH for ERROR_CATALOG.md lookup
+
+## [1.0.14](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.0.14) (2025-12-29)
+
+### Features
+
+- **mcp-server:** Add MCP server package for AI tool integration
+
+### Documentation
+
+- Add comprehensive error message catalog
+- Add JSDoc comments to core interfaces
+- Add operational documentation (FAQ, troubleshooting, security)
+- Add AI-friendly documentation files
+
+## [1.0.13](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.0.13) (2025-12-26)
+
+### Features
+
+- Enhance CreateZipImportDto and ZipImportQueueEventHandler
+
+## [1.0.12](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.0.12) (2025-12-23)
+
+### Bug Fixes
+
+- Merge tenant attributes in TenantService
+
+## [1.0.11](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.0.11) (2025-12-22)
+
+### Bug Fixes
+
+- Handle unknown source IP in SequencesService
+
+## [1.0.10](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.0.10) (2025-11-28)
+
+### Bug Fixes
+
+- Fix createTenantGroup method in TenantService
+
+## [1.0.9](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.0.9) (2025-11-26)
+
+### Bug Fixes
+
+- Remove callback parameter from Lambda handler for Node.js 24 compatibility
+
+## [1.0.8](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.0.8) (2025-11-17)
+
+### Security
+
+- Bump jws dependency for security fix
+
+## [1.0.7](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.0.7) (2025-11-07)
+
+### Security
+
+- Bump validator dependency in examples
+- Bump js-yaml dependency for security fix
+
+## [1.0.6](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.0.6) (2025-11-05)
+
+### Features
+
+- **master:** Add tenantCode support to MasterDataCreateDto and update service logic
+
+## [1.0.5](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.0.5) (2025-11-04)
+
+### Features
+
+- **master:** Enhance master settings with tenantCode support in DTOs and service logic
+
+## [1.0.4](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.0.4) (2025-10-29)
+
+### Features
+
+- **core:** Add configurable request body size limit to bootstrap and environment validation
+- **master:** Add bulk creation endpoints for master data and settings
+
+### Dependencies
+
+- Bump validator from 13.11.0/13.12.0 to 13.15.20
+- Bump multer from 1.4.4-lts.1 to 2.0.2 and @nestjs/platform-express from 10.4.4 to 10.4.20
+- Bump axios from 1.7.7 to 1.13.1 in CLI templates
+
+## [1.0.3](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.0.3) (2025-10-23)
+
+### Features
+
+- **master:** Add bulk creation endpoints for master data and settings, enabling batch operations for improved efficiency
+
+## [1.0.2](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.0.2) (2025-10-16)
+
+### Features
+
+- **survey:** Add survey template API for managing survey templates
+
+### Dependencies
+
+- Bump @nestjs/common from 10.3.0 to 10.4.16 in /examples/master
+- Bump multer from 1.4.4-lts.1 to 2.0.2 and @nestjs/platform-express from 10.4.15 to 10.4.20 in /examples/seq
+- Bump @nestjs/cli from 10.4.5 to 11.0.10 and inquirer from 8.2.6 to 8.2.7
+
+## [1.0.1](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.0.1) (2025-09-19)
+
+### Features
+
+- **import:** Add zip mode support for import module, enabling compressed file imports
+
+## [1.0.0](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.0.0) (2025-09-18)
+
+### Highlights
+
+- First stable production release
+- Based on beta version 0.1.74
+
+---
+
+## Beta Releases (0.1.x)
 
 ## [0.1.75-beta.0](https://github.com/mbc-net/mbc-cqrs-serverless/compare/v0.1.74-beta.0...v0.1.75-beta.0)
 
@@ -116,18 +597,18 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - github workflow ([2cd9d44](https://github.com/mbc-net/mbc-cqrs-serverless/commit/2cd9d44178f19c2c5d7b3f53e512723e99ffca8c))
 - handle step function name limit ([762ab9a](https://github.com/mbc-net/mbc-cqrs-serverless/commit/762ab9aa27baba62c1e8f5e3da8e19d2b32e8f46))
 - StepFunctionService execution name length validation ([86291ea](https://github.com/mbc-net/mbc-cqrs-serverless/commit/86291ea9defc1edad7b0439d4e34fbf378ea630e))
-- StepFunctionServiceテストの80文字制限バグ対応 ([cf188ae](https://github.com/mbc-net/mbc-cqrs-serverless/commit/cf188ae8aa07824134d0e6e8c17400e64f9cede3))
+- Fix 80-character limit bug in StepFunctionService tests ([cf188ae](https://github.com/mbc-net/mbc-cqrs-serverless/commit/cf188ae8aa07824134d0e6e8c17400e64f9cede3))
 
 ### Features
 
 - CLI package comprehensive test enhancement ([edd8426](https://github.com/mbc-net/mbc-cqrs-serverless/commit/edd842662d90f5c1609cde332456489cd6f80062))
-- Coreパッケージサービスのユニットテスト強化 ([a4d318e](https://github.com/mbc-net/mbc-cqrs-serverless/commit/a4d318ebd1aa5d01861c21ec2acfa0e8fa8cf8c9))
+- Enhance unit tests for Core package services ([a4d318e](https://github.com/mbc-net/mbc-cqrs-serverless/commit/a4d318ebd1aa5d01861c21ec2acfa0e8fa8cf8c9))
 - implement comprehensive unit tests for controllers ([9bef4b0](https://github.com/mbc-net/mbc-cqrs-serverless/commit/9bef4b02a93aae016655f6393836a0b519f33c8e))
-- Masterパッケージサービスのユニットテスト強化 ([90ca8a9](https://github.com/mbc-net/mbc-cqrs-serverless/commit/90ca8a9365a75b869118585c4cd6f84373b907bb))
-- Sequenceサービスのテスト強化 ([8eefb34](https://github.com/mbc-net/mbc-cqrs-serverless/commit/8eefb34ce829b15ecef04607b90faba7bd133571))
-- Taskサービスのユニットテスト強化 ([3a71b92](https://github.com/mbc-net/mbc-cqrs-serverless/commit/3a71b92c4d46746a5e1a084042184f0d99c98814))
-- 不足していたサービスのユニットテスト実装 ([2f762ff](https://github.com/mbc-net/mbc-cqrs-serverless/commit/2f762ff93968c678ceec7f7eeaf78db7e74db797))
-- 高優先度パッケージのユニットテスト実装 ([1dc8494](https://github.com/mbc-net/mbc-cqrs-serverless/commit/1dc849452dafb4a628fa72fda32fe20af17316d5))
+- Enhance unit tests for Master package services ([90ca8a9](https://github.com/mbc-net/mbc-cqrs-serverless/commit/90ca8a9365a75b869118585c4cd6f84373b907bb))
+- Enhance tests for Sequence service ([8eefb34](https://github.com/mbc-net/mbc-cqrs-serverless/commit/8eefb34ce829b15ecef04607b90faba7bd133571))
+- Enhance unit tests for Task service ([3a71b92](https://github.com/mbc-net/mbc-cqrs-serverless/commit/3a71b92c4d46746a5e1a084042184f0d99c98814))
+- Implement unit tests for missing services ([2f762ff](https://github.com/mbc-net/mbc-cqrs-serverless/commit/2f762ff93968c678ceec7f7eeaf78db7e74db797))
+- Implement unit tests for high-priority packages ([1dc8494](https://github.com/mbc-net/mbc-cqrs-serverless/commit/1dc849452dafb4a628fa72fda32fe20af17316d5))
 
 ## [0.1.70-beta.0](https://github.com/mbc-net/mbc-cqrs-serverless/compare/v0.1.69-beta.0...v0.1.70-beta.0) (2025-07-14)
 
@@ -260,8 +741,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-- シリアライズヘルパーのエンティティフィールド処理を修正 ([89f2499](https://github.com/mbc-net/mbc-cqrs-serverless/commit/89f249917d515d646e23e796e4b58d87fb22b901))
+- Fix entity field handling in serialization helper ([89f2499](https://github.com/mbc-net/mbc-cqrs-serverless/commit/89f249917d515d646e23e796e4b58d87fb22b901))
 
 ### Features
 
-- シリアライズヘルパー関数の追加\n\n- 内部/外部構造の変換ヘルパーを実装\n- テストケースの追加\n- ドキュメントの追加（日本語・英語） ([56e7c1d](https://github.com/mbc-net/mbc-cqrs-serverless/commit/56e7c1d7b0ab8c808398e1895e0988d26de350d0))
+- Add serialization helper functions — implement internal/external structure conversion helpers, add test cases, and add documentation ([56e7c1d](https://github.com/mbc-net/mbc-cqrs-serverless/commit/56e7c1d7b0ab8c808398e1895e0988d26de350d0))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,7 +117,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-- **import:** Correct import status handling for ZIP orchestrator ([#371](https://github.com/mbc-net/mbc-cqrs-serverless/pull/371))
+- **import:** Correct import status handling for ZIP orchestrator ([#370](https://github.com/mbc-net/mbc-cqrs-serverless/pull/370), [#371](https://github.com/mbc-net/mbc-cqrs-serverless/pull/371))
 
 ## [1.1.5](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.1.5) (2026-03-28)
 
@@ -223,7 +223,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
   - The `serverless.yml` references `LOCAL_DDB_IMPORT_TMP_STREAM` environment variable, which requires the table to be created during migration
   - See [Common Issues](/docs/common-issues#missing-import-tmp-table) for workaround if using older versions
 
-## [1.1.0](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.1.0) - TBD
+## [1.1.0](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.1.0) (2026-02-03)
 
 ### Breaking Changes
 
@@ -366,7 +366,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
   - Register hooks via `zipFinalizationHooks` option in `ImportModule.register()`
   - Hooks receive `ZipFinalizationContext` with results, status, and execution input
 
-## [1.0.20](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.0.20)
+## [1.0.20](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.0.20) (2026-01-11)
 
 ### Bug Fixes
 
@@ -390,7 +390,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
   - This fix completes the Step Functions error handling started in v1.0.18, ensuring `SendTaskFailure` is properly triggered
   - See [ImportQueueEventHandler Error Handling](/docs/import-export-patterns#import-error-handling) for details
 
-## [1.0.18](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.0.18)
+## [1.0.18](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.0.18) (2026-01-10)
 
 ### Bug Fixes
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -35,13 +35,13 @@ Generate code and analyze projects:
 | `mbc_validate_cqrs` | Validate CQRS pattern implementation |
 | `mbc_analyze_project` | Analyze project structure and detect framework usage |
 | `mbc_lookup_error` | Look up error solutions from the error catalog |
-| `mbc_check_anti_patterns` | Detect anti-patterns (AP001–AP020) in project source files |
+| `mbc_check_anti_patterns` | Detect anti-patterns (AP001–AP027) in project source files |
 | `mbc_health_check` | Health check for dependencies, structure, and configuration |
 | `mbc_explain_code` | Explain a file or code section in the MBC CQRS context |
 
 #### Anti-Pattern Detection (`mbc_check_anti_patterns`)
 
-Detects 20 anti-patterns including v1.1.x and v1.2.x breaking changes:
+Detects 27 anti-patterns including v1.1.x, v1.2.x, and v1.3.x breaking changes and security issues:
 
 | Code | Name | Severity |
 |------|------|----------|
@@ -65,6 +65,13 @@ Detects 20 anti-patterns including v1.1.x and v1.2.x breaking changes:
 | AP018 | Missing Swagger Documentation | Low |
 | AP019 | Missing Pagination in List Queries | High |
 | AP020 | Missing getCommandSource for Tracing | Low |
+| AP021 | Event Emit Directly After publishAsync in CommandService | High |
+| AP022 | Use of eval() or Function() Constructor | Critical |
+| AP023 | Shell Command Built from String Concatenation | Critical |
+| AP024 | HTTP Request Without Timeout | Medium |
+| AP025 | Logging process.env or full request object | High |
+| AP026 | Notification service class using @Injectable instead of @NotificationTransport | High |
+| AP027 | GroupRoleResolver class also annotated with @Injectable (v1.3.1+) | High |
 
 ### Prompts
 

--- a/packages/mcp-server/skills/mbc-generate/SKILL.md
+++ b/packages/mcp-server/skills/mbc-generate/SKILL.md
@@ -661,6 +661,40 @@ export class [Entity]Resolver {
 }
 ```
 
+### Group Role Resolver (`auth/app-group-role.resolver.ts`) — since v1.3.1
+
+Generate this only when the app uses **group-based roles**. `RolesGuard` checks direct roles from the JWT `custom:roles` first, then roles derived from the user's groups in `custom:groups`. The group → role mapping is **not** in the JWT — you implement it here. Exactly **one** resolver is allowed per application.
+
+```typescript
+import {
+  GroupRoleResolver,
+  IGroupRoleResolver,
+  ResolveGroupRolesInput,
+} from '@mbc-cqrs-serverless/core';
+
+// Do NOT add @Injectable() — @GroupRoleResolver() already registers this as a
+// singleton provider. A second @Injectable() can override the scope and break bootstrap.
+@GroupRoleResolver()
+export class AppGroupRoleResolver implements IGroupRoleResolver {
+  async resolveRoles({
+    tenantCode,
+    groupIds,
+    claims,
+  }: ResolveGroupRolesInput): Promise<string[]> {
+    // Map the user's group IDs to roles for this tenant.
+    // Load from DynamoDB, RDS, config, etc. Return an array of role strings.
+    // Keep this resolver stateless and resilient — failures propagate as 5xx.
+    return [];
+  }
+}
+```
+
+**Rules:**
+- Register the class in your NestJS module `providers`. `AuthModule` is imported automatically via `AppModule.forRoot()`.
+- The resolver must be a **singleton** (resolved once at bootstrap). Do not use `REQUEST`/`TRANSIENT` scope.
+- A resolver throw propagates as a **5xx** (not a silent 403), so a backend outage is distinguishable from a real access denial.
+- Role-name matching is case-sensitive — keep the casing consistent with `@Roles(...)`.
+
 ## Customization Questions
 
 Before generating, ask the user these questions to customize the output:

--- a/packages/mcp-server/skills/mbc-migrate/SKILL.md
+++ b/packages/mcp-server/skills/mbc-migrate/SKILL.md
@@ -42,6 +42,7 @@ This skill helps migrate MBC CQRS Serverless projects between versions.
 | v1.2.4 | v1.2.5 | Low | ZIP import refactor (transparent); MCP AP016–AP020 added |
 | v1.2.5 | v1.2.6 | Low | Repository RYW improvements (transparent); `getVersion` API |
 | v1.2.7 | v1.3.0 | Low | AppSync Events API support (opt-in, no breaking changes) |
+| v1.3.0 | v1.3.1 | Low | Group-based roles (`@GroupRoleResolver`, `custom:groups`); `UserContext.tenantRoles`/`tenantGroupIds` added (opt-in, no breaking changes) |
 
 ## Migration Guides
 
@@ -619,6 +620,58 @@ Non-alphanumeric characters in `id` (e.g. `#`, `@` from DynamoDB pk/sk) are sani
 2. Verify events arrive via both transports (dual-publish phase)
 3. Migrate frontend clients to subscribe via AppSync Events API channels
 4. Once all clients migrated, set `notificationTransports: 'appsync-event'` and redeploy
+
+---
+
+### v1.3.0 → v1.3.1
+
+**Change:** Group-based roles added (opt-in, no breaking changes).
+
+`RolesGuard` now checks direct roles from `custom:roles` first, then roles derived from the user's groups in `custom:groups`. `UserContext` gains two fields — `tenantRoles` (direct roles array) and `tenantGroupIds` (group IDs for the active tenant) — while `tenantRole` (singular) is kept for backward compatibility. No code changes are required to upgrade; existing role checks keep working.
+
+**To adopt group-based roles:**
+
+**Step 1 — Add `custom:groups` to the JWT** (tenant-scoped; group → role mappings are NOT in the token):
+
+```json
+{
+  "custom:roles": "[{\"tenant\":\"tenant-a\",\"role\":\"admin\"}]",
+  "custom:groups": "[{\"tenant\":\"tenant-a\",\"groups\":[\"sales-team\"]}]"
+}
+```
+
+**Step 2 — Implement exactly one resolver** that maps group IDs to roles (loaded from DynamoDB/RDS/config):
+
+```typescript
+import {
+  GroupRoleResolver,
+  IGroupRoleResolver,
+} from '@mbc-cqrs-serverless/core';
+
+// Do NOT add @Injectable() — @GroupRoleResolver() already registers the provider
+// as a singleton. A second @Injectable() can override the scope and break bootstrap.
+@GroupRoleResolver()
+export class AppGroupRoleResolver implements IGroupRoleResolver {
+  async resolveRoles({ tenantCode, groupIds, claims }) {
+    // Map the user's group IDs to roles for this tenant
+    return ['viewer', 'reporter'];
+  }
+}
+```
+
+Register the class in your module `providers`. `AuthModule` is imported automatically via `AppModule.forRoot()`.
+
+**Notes / gotchas:**
+- The resolver must be a **singleton** — it is resolved once at bootstrap. Avoid `REQUEST`/`TRANSIENT` scope.
+- A resolver failure (e.g. DB outage) **propagates as a 5xx**, not a silent 403, so a backend outage is distinguishable from a genuine access denial. Make the resolver resilient (timeouts/retries) if its backing store can be unavailable.
+- Malformed `custom:groups` is tolerated (fail-closed → no group roles), so a bad token degrades to direct-role-only checks rather than crashing.
+- `getUserRole()` on `RolesGuard` is **deprecated** and no longer called by the default guard. For custom authorization, override `verifyRole`, `resolveGroupRoles`, or `canOverrideTenant` instead.
+- Role-name matching is case-sensitive; keep the casing in `custom:roles` consistent with your `@Roles(...)` values.
+
+**Migration Steps:**
+1. Upgrade to v1.3.1 — no code changes required; existing `@Roles()` checks keep working.
+2. (Optional) Populate `custom:groups` in the JWT and implement one `@GroupRoleResolver()`.
+3. Register the resolver in your NestJS module `providers`.
 
 ---
 

--- a/packages/mcp-server/skills/mbc-review/SKILL.md
+++ b/packages/mcp-server/skills/mbc-review/SKILL.md
@@ -60,6 +60,7 @@ This codebase currently has **two independent `AP00X` numbering systems** that a
 | AP024 HTTP Request Without Timeout | — (detector only) | Local DoS via stalled upstream (CWE-400) |
 | AP025 Logging process.env or full request object | — (detector only) | Sensitive data exposure (CWE-312, CWE-532) |
 | AP026 @Injectable instead of @NotificationTransport | — (detector only) | INotificationTransport implementor never invoked |
+| AP027 GroupRoleResolver also annotated with @Injectable | AP022 | Incorrect group-based role resolver (v1.3.1+) |
 
 When you receive `mbc_check_anti_patterns` output, look up the detector code in this table to find the corresponding skill-doc section for full context and recommended fixes. Future versions of this framework should consolidate the two systems; until then, treat them as separate identifier spaces.
 
@@ -604,6 +605,53 @@ The `IDataSyncHandler.up()` pattern above is still required when other users, ba
 
 ---
 
+### AP022: Incorrect Group-Based Role Resolver Implementation (v1.3.1+)
+
+> Detector counterpart: **AP027** (`mbc_check_anti_patterns`). Note this skill-doc `AP022` is unrelated to the detector's `AP022` (eval/Function) — see the cross-reference table above.
+
+**Problem:** Group-based roles (`@GroupRoleResolver`, `custom:groups`) are implemented in ways that break bootstrap or leak across requests.
+
+**❌ Incorrect — adding `@Injectable()` alongside `@GroupRoleResolver()`:**
+```typescript
+@GroupRoleResolver()
+@Injectable({ scope: Scope.REQUEST }) // ❌ overrides the singleton scope; breaks bootstrap
+export class AppGroupRoleResolver implements IGroupRoleResolver { /* ... */ }
+```
+
+**❌ Incorrect — swallowing resolver errors to "fail open":**
+```typescript
+async resolveRoles(input) {
+  try {
+    return await this.lookup(input); // ❌ catching and returning roles on error
+  } catch {
+    return ['admin']; // ❌ grants access on backend failure
+  }
+}
+```
+
+**❌ Incorrect — more than one resolver, or stateful instance shared across requests:**
+```typescript
+@GroupRoleResolver() class ResolverA ... // ❌ only one @GroupRoleResolver() per app
+@GroupRoleResolver() class ResolverB ... //    (bootstrap throws)
+```
+
+**✅ Correct:**
+```typescript
+import { GroupRoleResolver, IGroupRoleResolver, ResolveGroupRolesInput } from '@mbc-cqrs-serverless/core';
+
+// No @Injectable() — @GroupRoleResolver() already registers a singleton provider.
+@GroupRoleResolver()
+export class AppGroupRoleResolver implements IGroupRoleResolver {
+  async resolveRoles({ tenantCode, groupIds, claims }: ResolveGroupRolesInput): Promise<string[]> {
+    return this.mapGroupsToRoles(tenantCode, groupIds); // stateless; let failures throw
+  }
+}
+```
+
+**Explanation:** `@GroupRoleResolver()` already applies `@Injectable()` with the default (singleton) scope. Adding another `@Injectable()` — especially with `REQUEST`/`TRANSIENT` scope — overrides it and breaks bootstrap, which resolves a single instance once at startup. Exactly one resolver is allowed per app. The default `RolesGuard` deliberately **rethrows** resolver failures so a backend outage surfaces as a 5xx instead of a silent 403; do not catch-and-grant inside the resolver. Use `tenantRoles` / `tenantGroupIds` from `getUserContext()` for direct/group context; do not rely on the deprecated `RolesGuard.getUserRole()`.
+
+---
+
 ## Review Checklist
 
 When reviewing MBC CQRS Serverless code, check:
@@ -649,6 +697,14 @@ When reviewing MBC CQRS Serverless code, check:
 ### Notification Transport (when implementing INotificationTransport)
 - [ ] Uses `@NotificationTransport('transport-name')` decorator instead of `@Injectable()` (AP026)
 - [ ] Transport name is registered in `NOTIFICATION_TRANSPORTS` env var to be active
+
+### Group Role Resolver (when implementing IGroupRoleResolver, v1.3.1+) (AP022)
+- [ ] Uses `@GroupRoleResolver()` only — no extra `@Injectable()` on the same class
+- [ ] Resolver is singleton-scoped (no `REQUEST`/`TRANSIENT` scope)
+- [ ] Exactly one `@GroupRoleResolver()` per application
+- [ ] Resolver is stateless and does NOT catch-and-grant on failure (let errors propagate as 5xx)
+- [ ] Registered in the module `providers`
+- [ ] Uses `tenantRoles` / `tenantGroupIds` from `getUserContext()`, not the deprecated `RolesGuard.getUserRole()`
 
 ## Output Format
 

--- a/packages/mcp-server/src/prompts/cqrs-guide.ts
+++ b/packages/mcp-server/src/prompts/cqrs-guide.ts
@@ -463,177 +463,29 @@ function getMigrationGuideMessages(
    npm update @mbc-cqrs-serverless/core @mbc-cqrs-serverless/cli
    \`\`\`
 
-2. **Check for breaking changes** in the CHANGELOG.md
+2. **Review breaking changes** for every version between ${fromVersion} and ${toVersion} (see the version-specific notes below).
 
-3. **Update imports** if API has changed
+3. **Update imports / call sites** if any API changed.
 
-4. **Run tests** to verify everything works
+4. **Run \`npm run build\` and \`npm test\`** to verify everything still compiles and passes.
 
-## v1.1.x Migration Notes
+## Where to find version-specific breaking changes
 
-### v1.1.0 — Breaking Changes (data migration required)
+Detailed, per-version migration notes (v1.0.x → v1.3.1, including data migrations,
+removed APIs, and step-by-step upgrade instructions) live in the **\`mbc-migrate\` skill**
+(\`skills/mbc-migrate/SKILL.md\`) and in the framework **CHANGELOG.md**. These are the
+single source of truth and are kept current with each release — consult them for the
+exact changes between ${fromVersion} and ${toVersion}.
 
-**1. TENANT_COMMON renamed to lowercase**
-\`\`\`typescript
-// Before (v1.0.x)
-const pk = \`MASTER_SETTING#COMMON#\${settingCode}\`
+**High-impact versions to check when crossing them:**
+- **v1.1.0** — *Breaking*: \`TENANT_COMMON\` keys lowercased (DynamoDB data migration); \`publish()\` / \`publishPartialUpdate()\` removed (use the \`*Async\` variants).
+- **v1.1.5** — CSV Import v2 batch architecture (Step Functions \`finalize_parent_job\` now required).
+- **v1.2.0** — *Breaking*: \`publishSync\` / \`publishPartialUpdateSync\` now return \`null\` on a no-op (add null checks); \`SequenceService.genNewSequence()\` removed.
+- **v1.2.4** — *Breaking for \`@mbc-cqrs-serverless/master\` users*: \`TaskModule.register()\` must be called exactly once in the host \`AppModule\`.
+- **v1.3.0** — AppSync Events API support (opt-in, no breaking changes).
+- **v1.3.1** — Group-based roles (\`@GroupRoleResolver\`, \`custom:groups\`); \`UserContext\` gains \`tenantRoles\` / \`tenantGroupIds\` (opt-in, no breaking changes).
 
-// After (v1.1.0+)
-const pk = \`MASTER_SETTING#common#\${settingCode}\`
-\`\`\`
-- All DynamoDB keys using \`#COMMON\` must be migrated to \`#common\`
-- New utilities: \`normalizeTenantCode()\`, \`isCommonTenant()\`
-
-**2. Deprecated methods removed**
-\`\`\`typescript
-// Removed — compilation error in v1.1.0+
-this.commandService.publish(...)
-this.commandService.publishPartialUpdate(...)
-
-// Use instead
-this.commandService.publishAsync(...)
-this.commandService.publishPartialUpdateAsync(...)
-\`\`\`
-
-### v1.1.4 — publishSync audit trail
-
-\`publishSync\` now writes a full audit trail to Command and History tables (parity with async pipeline):
-- Command table entry: \`syncMode: 'SYNC'\`, status \`publish_sync:STARTED\` → \`finish:FINISHED\`
-- History table is auto-populated
-- No code changes required; behavior is transparent
-
-### v1.1.5 — CSV Import v2 batch architecture
-
-Step Functions state machine changes required:
-\`\`\`json
-{
-  "finalize_parent_job": {
-    "Type": "Task",
-    "Parameters": {
-      "resultPath": "$.processingResults"
-    }
-  }
-}
-\`\`\`
-- \`finalize_parent_job\` state is now **required**
-- Row-level progress tracking via \`import_tmp\` table is removed
-- Counters (\`processedRows\`, \`succeededRows\`, \`failedRows\`) are aggregated at completion
-- Update both CDK and \`serverless.yml\` Step Functions definitions
-
-## v1.2.x Migration Notes
-
-### v1.2.0 — Breaking Changes
-
-**1. publishSync / publishPartialUpdateSync return type change**
-\`\`\`typescript
-// Before (v1.1.x) — always returned CommandModel
-const result = await commandService.publishSync(entity, options)
-console.log(result.pk) // safe
-
-// After (v1.2.0+) — returns null when command is not dirty (no-op)
-const result = await commandService.publishSync(entity, options)
-if (!result) return // no-op: command was not dirty, nothing was written
-console.log(result.pk) // safe after null check
-\`\`\`
-- Same semantics as \`publishAsync()\` / \`publishPartialUpdateAsync()\`
-- **Migration:** Add null check before accessing any property on the result
-
-**2. SequenceService.genNewSequence() removed**
-\`\`\`typescript
-// Removed — compilation error in v1.2.0+
-await sequenceService.genNewSequence(...)
-
-// Use instead
-await sequenceService.generateSequenceItem(...)
-// or
-await sequenceService.generateSequenceItemWithProvideSetting(...)
-\`\`\`
-
-**3. Read-Your-Writes (RYW) consistency (new feature)**
-
-After \`publishAsync\`, the same user's subsequent reads now return the pending command data before the DynamoDB Stream sync completes:
-\`\`\`typescript
-// Repository and DetailKey are exported from CommandModule / core
-import { DetailKey, Repository } from '@mbc-cqrs-serverless/core'
-
-@Injectable()
-export class OrderService {
-  constructor(private readonly repository: Repository) {}
-
-  async getOrder(key: DetailKey, options: IInvoke) {
-    // Returns pending command data if session exists
-    return this.repository.getItem(key, options)
-  }
-}
-\`\`\`
-- Enable by setting \`RYW_SESSION_TTL_MINUTES\` env var (e.g. \`5\`)
-- No effect if unset — zero impact on existing projects
-- Session table \`{NODE_ENV}-{APP_NAME}-session\` must be created (see \`dynamodbs/session.json\`)
-
-### v1.2.4 — TaskModule global registration (breaking for @mbc-cqrs-serverless/master users)
-
-**\`TaskModule.register()\` now returns a global dynamic module (\`global: true\`)**
-
-\`MasterModule\` no longer calls \`TaskModule.register()\` internally. Any app that uses \`MasterModule\` must now register \`TaskModule\` exactly once in the host \`AppModule\`.
-
-**Before (v1.2.3 and earlier — worked automatically):**
-\`\`\`typescript
-// No TaskModule.register() needed; MasterModule registered it internally
-@Module({
-  imports: [
-    MasterModule.register({ enableController: true, prismaService: PrismaService }),
-  ],
-})
-export class AppModule {}
-\`\`\`
-
-**After (v1.2.4+ — must register explicitly):**
-\`\`\`typescript
-import { TaskModule, TaskQueueEventFactory } from '@mbc-cqrs-serverless/master'
-
-@Module({
-  imports: [
-    TaskModule.register({
-      taskQueueEventFactory: MyTaskQueueEventFactory, // extend TaskQueueEventFactory from master
-    }),
-    MasterModule.register({ enableController: true, prismaService: PrismaService }),
-  ],
-})
-export class AppModule {}
-\`\`\`
-
-**Migration steps:**
-1. Create a factory class that extends \`TaskQueueEventFactory\` from \`@mbc-cqrs-serverless/master\`:
-\`\`\`typescript
-import { TaskQueueEventFactory } from '@mbc-cqrs-serverless/master'
-import { IEvent, TaskQueueEvent } from '@mbc-cqrs-serverless/task'
-
-export class MyTaskQueueEventFactory extends TaskQueueEventFactory {
-  async transformTask(event: TaskQueueEvent): Promise<IEvent[]> {
-    // add your own task handling here
-    return []
-  }
-  // transformStepFunctionTask for MASTER_COPY tasks is inherited from TaskQueueEventFactory
-}
-\`\`\`
-2. Call \`TaskModule.register({ taskQueueEventFactory: MyTaskQueueEventFactory })\` once in the host \`AppModule\`.
-3. Remove any \`TaskModule.register()\` calls from feature modules — multiple registrations cause \`"transformTask is not a function"\` at runtime (detected by AP015).
-
-**Symptom if migration is skipped:** App crashes at startup with \`Nest can't resolve dependencies of MyTaskService (?)\`.
-
-## Common Migration Issues
-
-### Interface Changes
-- Check if CommandEntity/DataEntity interfaces have new required fields
-- Update your entities accordingly
-
-### Configuration Changes
-- Review CommandModuleOptions for new options
-- Check environment variables
-
-### Deprecated Features
-- Look for deprecation warnings in build output
-- Replace deprecated APIs with recommended alternatives
+For the full instructions on any of the above, open the \`mbc-migrate\` skill and read the matching \`### <version>\` section.
 
 ## Verification
 
@@ -652,7 +504,7 @@ export class MyTaskQueueEventFactory extends TaskQueueEventFactory {
    npm run offline
    \`\`\`
 
-For specific version migration details, check the CHANGELOG.md in the framework repository.`,
+For specific version migration details, check the \`mbc-migrate\` skill and CHANGELOG.md in the framework repository.`,
         },
       },
     ],

--- a/packages/mcp-server/src/tools/analyze.spec.ts
+++ b/packages/mcp-server/src/tools/analyze.spec.ts
@@ -198,6 +198,61 @@ describe('analyze tools', () => {
       )
     })
 
+    it('should detect @GroupRoleResolver also annotated with @Injectable (AP027)', async () => {
+      const testFile = path.join(testDir, 'src', 'test.ts')
+      fs.writeFileSync(
+        testFile,
+        `
+        import { Injectable } from '@nestjs/common';
+        import { GroupRoleResolver, IGroupRoleResolver } from '@mbc-cqrs-serverless/core';
+
+        @GroupRoleResolver()
+        @Injectable()
+        export class AppGroupRoleResolver implements IGroupRoleResolver {
+          async resolveRoles() {
+            return [];
+          }
+        }
+      `,
+      )
+
+      const result = await handleAnalyzeTool(
+        'mbc_check_anti_patterns',
+        { path: 'src' },
+        testDir,
+      )
+
+      expect(result.content[0].text).toContain('AP027')
+      expect(result.content[0].text).toContain(
+        'GroupRoleResolver class also annotated with @Injectable',
+      )
+    })
+
+    it('should NOT flag a correctly-decorated GroupRoleResolver (AP027 negative)', async () => {
+      const testFile = path.join(testDir, 'src', 'test.ts')
+      fs.writeFileSync(
+        testFile,
+        `
+        import { GroupRoleResolver, IGroupRoleResolver } from '@mbc-cqrs-serverless/core';
+
+        @GroupRoleResolver()
+        export class AppGroupRoleResolver implements IGroupRoleResolver {
+          async resolveRoles() {
+            return [];
+          }
+        }
+      `,
+      )
+
+      const result = await handleAnalyzeTool(
+        'mbc_check_anti_patterns',
+        { path: 'src' },
+        testDir,
+      )
+
+      expect(result.content[0].text).not.toContain('AP027')
+    })
+
     it('should return error for non-existent path', async () => {
       const result = await handleAnalyzeTool(
         'mbc_check_anti_patterns',

--- a/packages/mcp-server/src/tools/analyze.spec.ts
+++ b/packages/mcp-server/src/tools/analyze.spec.ts
@@ -253,6 +253,35 @@ describe('analyze tools', () => {
       expect(result.content[0].text).not.toContain('AP027')
     })
 
+    it('should NOT flag a GroupRoleResolver class followed by a separate @Injectable class (AP027 negative)', async () => {
+      const testFile = path.join(testDir, 'src', 'test.ts')
+      fs.writeFileSync(
+        testFile,
+        `
+        import { Injectable } from '@nestjs/common';
+        import { GroupRoleResolver, IGroupRoleResolver } from '@mbc-cqrs-serverless/core';
+
+        @GroupRoleResolver()
+        export class AppGroupRoleResolver implements IGroupRoleResolver {
+          async resolveRoles() {
+            return [];
+          }
+        }
+
+        @Injectable()
+        export class SomeOtherService {}
+      `,
+      )
+
+      const result = await handleAnalyzeTool(
+        'mbc_check_anti_patterns',
+        { path: 'src' },
+        testDir,
+      )
+
+      expect(result.content[0].text).not.toContain('AP027')
+    })
+
     it('should return error for non-existent path', async () => {
       const result = await handleAnalyzeTool(
         'mbc_check_anti_patterns',

--- a/packages/mcp-server/src/tools/analyze.ts
+++ b/packages/mcp-server/src/tools/analyze.ts
@@ -461,7 +461,7 @@ interface AntiPatternMatch {
 /**
  * Anti-patterns to check for.
  *
- * Codes are sequential from AP001 to AP025 in detector-implementation order.
+ * Codes are sequential from AP001 to AP027 in detector-implementation order.
  *
  * IMPORTANT: These detector codes are a SEPARATE numbering system from the AP codes
  * used in `skills/mbc-review/SKILL.md`. Only AP016, AP017, AP018, AP019, and AP021
@@ -719,6 +719,20 @@ const ANTI_PATTERNS = [
     recommendation:
       "Classes that implement INotificationTransport must use @NotificationTransport('transport-name') instead of @Injectable(). The decorator registers the transport name as metadata so NotificationEventHandler can discover and activate it via NOTIFICATION_TRANSPORTS env var. With @Injectable() alone, the transport will never be invoked.",
   },
+  {
+    code: 'AP027',
+    name: 'GroupRoleResolver class also annotated with @Injectable (v1.3.1+)',
+    severity: 'high' as const,
+    // Detect classes decorated with @GroupRoleResolver() that ALSO carry @Injectable().
+    // @GroupRoleResolver() already applies @Injectable() with the default (singleton)
+    // scope; a second @Injectable() — especially @Injectable({ scope: ... }) — overrides
+    // that scope and breaks bootstrap, which resolves a single instance once at startup.
+    // Matches in either decorator order.
+    pattern:
+      /@GroupRoleResolver\(\)[\s\S]{0,120}@Injectable\(|@Injectable\([\s\S]{0,120}@GroupRoleResolver\(\)/,
+    recommendation:
+      'Do not annotate a @GroupRoleResolver() class with @Injectable(). @GroupRoleResolver() already registers the class as a singleton provider; adding @Injectable() (particularly with REQUEST/TRANSIENT scope) overrides the scope and breaks bootstrap, which resolves the resolver exactly once at application startup. Remove the extra @Injectable().',
+  },
 ]
 
 /**
@@ -744,6 +758,7 @@ const DETECTOR_TO_SKILL_AP: Record<string, string> = {
   AP020: 'AP011', // Missing getCommandSource for Tracing → Missing getCommandSource for Tracing
   AP021: 'AP021', // Event Emit After publishAsync ✅
   // AP026: detector-only (no skill-doc AP counterpart)
+  AP027: 'AP022', // GroupRoleResolver + @Injectable → Incorrect Group-Based Role Resolver Implementation
 }
 
 /**
@@ -1174,7 +1189,7 @@ async function explainCode(
   }
   if (content.includes('getUserContext(')) {
     explanations.push(
-      'Extracts user context (tenantCode, userId, role) from the invocation context.',
+      'Extracts user context (userId, tenantCode, tenantRole, tenantRoles, tenantGroupIds) from the invocation context. Since v1.3.1, tenantRoles is the array of direct roles from custom:roles and tenantGroupIds holds the group IDs from custom:groups; tenantRole (singular) is kept for backward compatibility. A malformed custom:groups claim is tolerated (fail-closed to no group roles), but a malformed custom:roles claim still throws — guard accordingly when the claim source is untrusted.',
     )
   }
 

--- a/packages/mcp-server/src/tools/analyze.ts
+++ b/packages/mcp-server/src/tools/analyze.ts
@@ -725,11 +725,13 @@ const ANTI_PATTERNS = [
     severity: 'high' as const,
     // Detect classes decorated with @GroupRoleResolver() that ALSO carry @Injectable().
     // @GroupRoleResolver() already applies @Injectable() with the default (singleton)
-    // scope; a second @Injectable() — especially @Injectable({ scope: ... }) — overrides
-    // that scope and breaks bootstrap, which resolves a single instance once at startup.
-    // Matches in either decorator order.
+    // scope; a second @Injectable() overrides that scope and breaks bootstrap, which
+    // resolves a single instance once at startup. The two decorators must be ADJACENT
+    // (only whitespace or other decorators between them) so we don't match
+    // @GroupRoleResolver on one class and @Injectable on a different class below it.
+    // Decorator arguments are allowed. Matches either order.
     pattern:
-      /@GroupRoleResolver\(\)[\s\S]{0,120}@Injectable\(|@Injectable\([\s\S]{0,120}@GroupRoleResolver\(\)/,
+      /@GroupRoleResolver\([^)]*\)(?:\s|@[A-Za-z]+\([^)]*\))*@Injectable\(|@Injectable\([^)]*\)(?:\s|@[A-Za-z]+\([^)]*\))*@GroupRoleResolver\(/,
     recommendation:
       'Do not annotate a @GroupRoleResolver() class with @Injectable(). @GroupRoleResolver() already registers the class as a singleton provider; adding @Injectable() (particularly with REQUEST/TRANSIENT scope) overrides the scope and breaks bootstrap, which resolves the resolver exactly once at application startup. Remove the extra @Injectable().',
   },


### PR DESCRIPTION
## Summary

Documents the upcoming **v1.3.1** (group-based role authorization) release and brings the project's documentation/tooling in sync with it.

### CHANGELOG.md
- Add the **v1.3.1** entry (group-based role authorization: `@GroupRoleResolver`, `custom:groups`, `UserContext.tenantRoles` / `tenantGroupIds`, plus malformed-`custom:groups` fail-closed handling).
- **Backfill every missing stable `1.x` release entry** (v1.0.0–v1.2.6). The changelog previously listed only a handful of stable versions; it now covers all 42 released `v1.x` tags, in descending order.
- Translate previously Japanese auto-generated entries to English and fix a stray `\n` escape in the `0.1.50-beta.0` entry. The file is now fully English.

### mcp-server
- **`analyze.ts`**: update the `getUserContext` explanation for `tenantRoles` / `tenantGroupIds`; add the **AP027** detector — a `@GroupRoleResolver()` class must not also be annotated with `@Injectable()` (would override the singleton scope and break bootstrap). Includes a positive and negative test.
- **skills**: `mbc-migrate` v1.3.1 migration guide; `mbc-generate` group role resolver template; `mbc-review` AP022 (group role resolver) anti-pattern + checklist + cross-reference table entry.
- **prompts**: the `migration_guide` prompt now defers version-specific notes to the `mbc-migrate` skill instead of duplicating (and drifting out of date with) them.

## Verification
- `tsc --noEmit`: pass
- mcp-server unit tests: pass (incl. new AP027 cases)
- CHANGELOG: all 42 stable `v1.x` tags covered, no remaining Japanese, no broken `\n` escapes

## Notes
- Sources: stable entries backfilled from the documentation site changelog (the most complete source, with PR links); v1.1.6 and v1.2.3 were reconstructed from git history as they were absent from the doc site.
- The related documentation-site changes (changelog + authentication page + translations for v1.3.1) live in the separate `mbc-cqrs-serverless-doc` repository and are not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)