### PR TITLE
fix(deps): scope ajv override to @angular-devkit/core to unbreak ESLint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3628,6 +3628,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -3637,6 +3654,13 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.2",
@@ -15285,6 +15309,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/eslint/node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -15306,6 +15347,13 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.2",
@@ -25876,6 +25924,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/schema-utils/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/schema-utils/node_modules/ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
@@ -25885,6 +25950,13 @@
       "peerDependencies": {
         "ajv": "^6.9.1"
       }
+    },
+    "node_modules/schema-utils/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/seek-bzip": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -150,8 +150,8 @@
     "follow-redirects": "^1.16.0",
     "flatted": "^3.4.2",
     "multer": "^2.1.1",
-    "ajv": "^8.18.0",
     "@angular-devkit/core": {
+      "ajv": "^8.18.0",
       "picomatch": "^4.0.4"
     }
   },


### PR DESCRIPTION
## Summary

Follow-up to #445. The global `"ajv": "^8.18.0"` override added there breaks ESLint on a clean `npm ci`: npm overrides apply to **every** dependency edge with that name regardless of the requested range, so `@eslint/eslintrc` / `eslint` / `schema-utils` (all requesting `ajv ^6.12.4`) were forced onto ajv 8.20.0. `@eslint/eslintrc` uses the ajv 6 API at module load, so every `npm run lint` crashed:

```
TypeError: Cannot set properties of undefined (setting 'defaultMeta')
    at ajvOrig (node_modules/@eslint/eslintrc/dist/eslintrc.cjs:1626:27)
```

**Why CI showed green:** the `Run ESLint` step in `ci-cd.yml` has `continue-on-error: true`. GitHub rewrites a failed step's conclusion to `success`, so the crash was invisible in the checks UI. Reproduced locally with the exact CI sequence (`npm install --package-lock-only` → `npm ci` → `npm run lint`) on merged develop: exit code 2.

## Fix

The advisory behind the override (GHSA-2g4f-4pwh-qvx6) covers ajv **7.0.0-alpha.0 – 8.17.1** only; ajv 6.x is not affected, so forcing the eslint family off ajv 6 had no security benefit. The only dependent pinning a vulnerable ajv is `@angular-devkit/core` (pins `8.12.0` exactly). The override is now scoped to it, merged with the existing scoped picomatch override:

```json
"@angular-devkit/core": {
  "ajv": "^8.18.0",
  "picomatch": "^4.0.4"
}
```

`@modelcontextprotocol/sdk` requests `^8.17.1` and resolves to 8.20.0 with no override needed. The lockfile restores nested `ajv@6.15.0` (latest 6.x, not in the vulnerable range) under `@eslint/eslintrc`, `eslint`, and `schema-utils`; root ajv stays 8.20.0.

## Test plan

- [x] `npm run lint` no longer crashes — ESLint runs normally. (65 pre-existing lint errors in source files remain; this diff touches no TS files. They accumulated unseen because the lint step is non-blocking.)
- [x] `npm audit --omit=dev` — unchanged: 0 critical / 0 high / 5 moderate (same documented NestJS-11 / Node-20 blocked items as #445).
- [x] `npm test` — 3568 tests passed; the single failing suite is the pre-existing macOS-only `@types/jsonstream` casing issue, identical on develop.
- [x] `npm run build` — same result as develop (macOS-only `import` package casing issue; CI/Linux unaffected).

## Recommendations (out of scope here)

1. Consider making `Run ESLint` and `Security Audit (npm)` blocking (drop `continue-on-error`) once the 65 pre-existing lint errors are fixed — both failures are currently invisible.
2. The hand-pinned lockfile state from #445 has no regression guard; a blocking `npm audit --omit=dev --audit-level=high` step would catch vulnerable nested copies resurfacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)