### PR TITLE
ci(security): add blocking production-audit and ESLint startup gates

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -48,6 +48,13 @@ jobs:
         run: npm run lint
         continue-on-error: true
 
+      # Blocking: ESLint must at least start. A broken dependency tree
+      # (e.g. an override forcing an incompatible ajv onto @eslint/eslintrc,
+      # see PR #446) crashes ESLint before any file is linted, which the
+      # non-blocking lint step above cannot surface.
+      - name: ESLint startup check
+        run: npx eslint --print-config .eslintrc.js > /dev/null
+
       - name: Type Check
         run: npx tsc --noEmit
         continue-on-error: true
@@ -55,6 +62,13 @@ jobs:
       - name: Security Audit (npm)
         run: npm audit --audit-level=high
         continue-on-error: true
+
+      # Blocking: production dependencies must stay free of high/critical
+      # advisories. npm re-resolution (npm install/update/audit fix) can
+      # silently resurrect vulnerable nested copies that root overrides do
+      # not reach through workspace packages (see PRs #445/#447).
+      - name: Security Audit (production, blocking)
+        run: npm audit --omit=dev --audit-level=high
 
       - name: Security Scan (Trivy)
         uses: aquasecurity/trivy-action@v0.36.0


### PR DESCRIPTION
## Summary

Adds the regression guards recommended across #445/#446/#447. Every quality step in `ci-cd.yml` currently has `continue-on-error: true`, and GitHub rewrites a failed step's conclusion to `success` — which let two real failures pass green checks during this security series:

1. **#445's global ajv override crashed ESLint at startup** — the lint step "passed" and the break merged to develop (fixed in #446 after local reproduction).
2. **npm re-resolution resurrected vulnerable nested `lodash`/`js-yaml` copies twice** (root overrides don't propagate to workspace-package dependencies), regressing the production audit from 5 moderate to include a high — with no CI signal either time (caught manually during #447).

## Changes (two minimal blocking steps)

| Step | Command | Fails when |
|---|---|---|
| ESLint startup check | `npx eslint --print-config .eslintrc.js` | ESLint cannot start at all (dependency-tree breakage). Independent of the 65 pre-existing lint errors, which keep the full lint step non-blocking for now. |
| Security Audit (production, blocking) | `npm audit --omit=dev --audit-level=high` | A high/critical advisory enters the production dependency tree. Currently 0 high/critical (the 5 documented moderates are below the gate). |

Existing non-blocking steps are left untouched: the full-tree audit still has known unfixable dev advisories (serverless-offline chain), and the full lint step stays non-blocking until the 65 pre-existing errors are cleaned up.

## Test plan

- [x] Both commands verified exit 0 on current develop (`PROD AUDIT GATE exit=0`, `ESLINT SMOKE exit=0`)
- [x] YAML validated
- [x] Negative case verified earlier in this series: on the broken #445 tree, `eslint --print-config` crashes with exit 2 (the exact failure this gate is for)

🤖 Generated with [Claude Code](https://claude.com/claude-code)