### PR TITLE
fix(core): bump @nestjs/config to ^4.0.4 to drop vulnerable lodash pin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6108,23 +6108,25 @@
       }
     },
     "node_modules/@nestjs/config": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-3.3.0.tgz",
-      "integrity": "sha512-pdGTp8m9d0ZCrjTpjkUbZx6gyf2IKf+7zlkrPNMsJzYZ4bFRRTpXrnj+556/5uiI6AfL5mMrJc2u7dB6bvM+VA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-4.0.4.tgz",
+      "integrity": "sha512-CJPjNitr0bAufSEnRe2N+JbnVmMmDoo6hvKCPzXgZoGwJSmp/dZPk9f/RMbuD/+Q1ZJPjwsRpq0vxna++Knwow==",
+      "license": "MIT",
       "dependencies": {
-        "dotenv": "16.4.5",
-        "dotenv-expand": "10.0.0",
-        "lodash": "4.17.21"
+        "dotenv": "17.4.1",
+        "dotenv-expand": "12.0.3",
+        "lodash": "4.18.1"
       },
       "peerDependencies": {
-        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
         "rxjs": "^7.1.0"
       }
     },
     "node_modules/@nestjs/config/node_modules/dotenv": {
-      "version": "16.4.5",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
+      "integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },
@@ -6133,11 +6135,30 @@
       }
     },
     "node_modules/@nestjs/config/node_modules/dotenv-expand": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
-      "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-12.0.3.tgz",
+      "integrity": "sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/@nestjs/config/node_modules/dotenv-expand/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/@nestjs/core": {
@@ -30855,7 +30876,7 @@
         "@aws-crypto/sha256-js": "^5.2.0",
         "@codegenie/serverless-express": "^4.13.0",
         "@nestjs/common": "^10.3.0",
-        "@nestjs/config": "^3.1.1",
+        "@nestjs/config": "^4.0.4",
         "@nestjs/core": "^10.3.0",
         "@nestjs/mapped-types": "^2.0.4",
         "@nestjs/platform-express": "^10.3.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,7 +53,7 @@
     "@aws-crypto/sha256-js": "^5.2.0",
     "@codegenie/serverless-express": "^4.13.0",
     "@nestjs/common": "^10.3.0",
-    "@nestjs/config": "^3.1.1",
+    "@nestjs/config": "^4.0.4",
     "@nestjs/core": "^10.3.0",
     "@nestjs/mapped-types": "^2.0.4",
     "@nestjs/platform-express": "^10.3.0",


### PR DESCRIPTION
## Summary

Structural fix for the recurring vulnerable-nested-copy problem documented in #445/#447: `@nestjs/config` 3.x pins `lodash@4.17.21` exactly (GHSA-r5fr-rjxr-66jc + prototype-pollution advisories). Because root `overrides` don't propagate to workspace-package dependencies, every npm re-resolution restored a vulnerable nested copy under `@nestjs/config`, requiring hand-repair of the lockfile (needed 3 times in 2 days).

`@nestjs/config@4.0.4` ships `lodash@4.18.1` (safe) and declares `peerDependencies: "@nestjs/common": "^10.0.0 || ^11.0.0"` — **compatible with the current NestJS 10 line**. After this bump, no override or lockfile surgery is needed for the config side; `npm ls` no longer reports the config edge at all.

The only remaining exact-pin source is `@nestjs/swagger` 7.x (lodash + js-yaml). No NestJS-10-compatible fixed version exists (fixed only in 11.2.6+), so that one stays documented until the NestJS 11 migration.

## Changes

- `packages/core/package.json`: `"@nestjs/config": "^3.1.1"` → `"^4.0.4"` (also moves dotenv 16 → 17 and dotenv-expand 10 → 12 inside config)
- `package-lock.json`: re-resolution (36 insertions)

## Test plan

- [x] `npm ls` — no nested vulnerable lodash/js-yaml entries anywhere; `@nestjs/config@4.0.4` resolves lodash 4.18.1
- [x] `npm audit --omit=dev` — 0 critical / 0 high / 5 moderate (same documented set)
- [x] `npm test` — 3568 passed; single failing suite is the known macOS-only `@types/jsonstream` casing issue, identical on develop
- [x] `npm run build` / `npm run lint` — identical to develop baseline
- [x] Lockfile stable under CI's `Sync lockfile` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)