### PR TITLE
feat(mcp-server): add AP029/AP030 DataSyncHandler anti-pattern detectors

### DIFF
--- a/packages/mcp-server/skills/mbc-review/SKILL.md
+++ b/packages/mcp-server/skills/mbc-review/SKILL.md
@@ -32,36 +32,38 @@ This codebase currently has **two independent `AP00X` numbering systems** that a
 
 **Cross-reference table** (detector → skill doc):
 
-| Detector code (analyze.ts) | Skill doc code (this file) | Topic |
-|---|---|---|
-| AP001 Direct DynamoDB Write | AP012 | Bypassing CommandService / DataService |
-| AP002 Ignored Version Mismatch | AP005 | ConditionalCheckFailedException handling |
-| AP003 N+1 Query Pattern | — (detector only) | Query in a loop |
-| AP004 Full Table Scan | — (detector only) | `.scan()` usage |
-| AP005 Hardcoded Tenant | AP002 | Multi-tenant code/key handling |
-| AP006 Missing Tenant Validation | AP002 | Trusting client-provided `tenantCode` |
-| AP007 Throwing in Sync Handler | — (detector only) | DataSyncHandler error escape |
-| AP008 Hardcoded Secret | — (detector only) | Secrets in code |
-| AP009 Manual JWT Parsing | — (detector only) | Bypassing Cognito authorizer |
-| AP010 Heavy Module Import | — (detector only) | Cold-start optimization |
-| AP011 Deprecated Method Usage | AP010 | `publish()` / `publishPartialUpdate()` removal |
-| AP012 Uppercase COMMON Tenant Key | — (detector only) | v1.1.0 tenant key migration |
-| AP013 publishSync Null Return Unchecked | AP001 (related) | `publishSync` v1.2.0+ return |
-| AP014 Deprecated genNewSequence | AP010 (related) | v1.2.0 sequence API change |
-| AP015 Duplicate TaskModule Registration | — (detector only) | v1.2.4 global TaskModule |
-| AP016 Missing Error Logging Before Rethrow | AP016 | ✅ same code |
-| AP017 Incorrect Attribute Merging | AP017 | ✅ same code |
-| AP018 Missing Swagger Documentation | AP018 | ✅ same code |
-| AP019 Missing Pagination in List Queries | AP019 | ✅ same code |
-| AP020 Missing getCommandSource for Tracing | AP011 | Tracing/audit |
-| AP021 Event Emit After publishAsync | AP021 | ✅ same code |
-| AP022 Use of eval() or Function() Constructor | — (detector only) | RCE/XSS sink (CWE-95) |
-| AP023 Shell Command Built from String Concatenation | — (detector only) | Command injection (CWE-78) |
-| AP024 HTTP Request Without Timeout | — (detector only) | Local DoS via stalled upstream (CWE-400) |
-| AP025 Logging process.env or full request object | — (detector only) | Sensitive data exposure (CWE-312, CWE-532) |
-| AP026 @Injectable instead of @NotificationTransport | — (detector only) | INotificationTransport implementor never invoked |
-| AP027 GroupRoleResolver also annotated with @Injectable | AP022 | Incorrect group-based role resolver (v1.3.1+) |
-| AP028 Duplicate DataSyncHandler Registration | AP023 | ✅ same code |
+| Detector code (analyze.ts)                              | Skill doc code (this file) | Topic                                            |
+| ------------------------------------------------------- | -------------------------- | ------------------------------------------------ |
+| AP001 Direct DynamoDB Write                             | AP012                      | Bypassing CommandService / DataService           |
+| AP002 Ignored Version Mismatch                          | AP005                      | ConditionalCheckFailedException handling         |
+| AP003 N+1 Query Pattern                                 | — (detector only)          | Query in a loop                                  |
+| AP004 Full Table Scan                                   | — (detector only)          | `.scan()` usage                                  |
+| AP005 Hardcoded Tenant                                  | AP002                      | Multi-tenant code/key handling                   |
+| AP006 Missing Tenant Validation                         | AP002                      | Trusting client-provided `tenantCode`            |
+| AP007 Throwing in Sync Handler                          | — (detector only)          | DataSyncHandler error escape                     |
+| AP008 Hardcoded Secret                                  | — (detector only)          | Secrets in code                                  |
+| AP009 Manual JWT Parsing                                | — (detector only)          | Bypassing Cognito authorizer                     |
+| AP010 Heavy Module Import                               | — (detector only)          | Cold-start optimization                          |
+| AP011 Deprecated Method Usage                           | AP010                      | `publish()` / `publishPartialUpdate()` removal   |
+| AP012 Uppercase COMMON Tenant Key                       | — (detector only)          | v1.1.0 tenant key migration                      |
+| AP013 publishSync Null Return Unchecked                 | AP001 (related)            | `publishSync` v1.2.0+ return                     |
+| AP014 Deprecated genNewSequence                         | AP010 (related)            | v1.2.0 sequence API change                       |
+| AP015 Duplicate TaskModule Registration                 | — (detector only)          | v1.2.4 global TaskModule                         |
+| AP016 Missing Error Logging Before Rethrow              | AP016                      | ✅ same code                                     |
+| AP017 Incorrect Attribute Merging                       | AP017                      | ✅ same code                                     |
+| AP018 Missing Swagger Documentation                     | AP018                      | ✅ same code                                     |
+| AP019 Missing Pagination in List Queries                | AP019                      | ✅ same code                                     |
+| AP020 Missing getCommandSource for Tracing              | AP011                      | Tracing/audit                                    |
+| AP021 Event Emit After publishAsync                     | AP021                      | ✅ same code                                     |
+| AP022 Use of eval() or Function() Constructor           | — (detector only)          | RCE/XSS sink (CWE-95)                            |
+| AP023 Shell Command Built from String Concatenation     | — (detector only)          | Command injection (CWE-78)                       |
+| AP024 HTTP Request Without Timeout                      | — (detector only)          | Local DoS via stalled upstream (CWE-400)         |
+| AP025 Logging process.env or full request object        | — (detector only)          | Sensitive data exposure (CWE-312, CWE-532)       |
+| AP026 @Injectable instead of @NotificationTransport     | — (detector only)          | INotificationTransport implementor never invoked |
+| AP027 GroupRoleResolver also annotated with @Injectable | AP022                      | Incorrect group-based role resolver (v1.3.1+)    |
+| AP028 Duplicate DataSyncHandler Registration            | AP023                      | ✅ same code                                     |
+| AP029 Reserved DataSyncHandler Type                     | AP024                      | ✅ same code                                     |
+| AP030 Fully-Qualified Table Name in @DataSyncHandler    | AP025                      | ✅ same code                                     |
 
 When you receive `mbc_check_anti_patterns` output, look up the detector code in this table to find the corresponding skill-doc section for full context and recommended fixes. Future versions of this framework should consolidate the two systems; until then, treat them as separate identifier spaces.
 
@@ -72,12 +74,13 @@ When you receive `mbc_check_anti_patterns` output, look up the detector code in 
 **Severity:** Warning
 
 **Pattern:**
+
 ```typescript
 // Bad
-await this.commandService.publishSync(command, options);
+await this.commandService.publishSync(command, options)
 
 // Good
-await this.commandService.publishAsync(command, options);
+await this.commandService.publishAsync(command, options)
 ```
 
 **Explanation:** `publishAsync` is the recommended default. Only use `publishSync` when immediate consistency is absolutely required, as it blocks until processing completes.
@@ -89,13 +92,14 @@ await this.commandService.publishAsync(command, options);
 **Severity:** Error
 
 **Pattern:**
+
 ```typescript
 // Bad
-const pk = `ORDER#${code}`;
+const pk = `ORDER#${code}`
 
 // Good
-const { tenantCode } = getUserContext(invokeContext);
-const pk = `ORDER#${tenantCode}`;
+const { tenantCode } = getUserContext(invokeContext)
+const pk = `ORDER#${tenantCode}`
 ```
 
 **Explanation:** All operations must include `tenantCode` for proper tenant isolation.
@@ -107,6 +111,7 @@ const pk = `ORDER#${tenantCode}`;
 **Severity:** Error
 
 **Pattern:**
+
 ```typescript
 // Bad
 version: 1,
@@ -126,6 +131,7 @@ version: existingItem.version,  // For updates
 **Severity:** Error
 
 **Pattern:**
+
 ```typescript
 // Bad
 CommandModule.register({
@@ -149,19 +155,20 @@ CommandModule.register({
 **Severity:** Warning
 
 **Pattern:**
+
 ```typescript
 // Bad
-await this.commandService.publishAsync(command, options);
+await this.commandService.publishAsync(command, options)
 
 // Good
 try {
-  await this.commandService.publishAsync(command, options);
+  await this.commandService.publishAsync(command, options)
 } catch (error) {
   if (error.name === 'ConditionalCheckFailedException') {
     // Handle version conflict - retry or inform user
-    throw new ConflictException('Data was modified by another user');
+    throw new ConflictException('Data was modified by another user')
   }
-  throw error;
+  throw error
 }
 ```
 
@@ -174,14 +181,15 @@ try {
 **Severity:** Error
 
 **Pattern:**
+
 ```typescript
 // Bad - inconsistent format
-const pk = `order-${tenantCode}`;
-const sk = `order_${code}`;
+const pk = `order-${tenantCode}`
+const sk = `order_${code}`
 
 // Good - consistent ENTITY#value format
-const pk = `ORDER#${tenantCode}`;
-const sk = `ORDER#${code}`;
+const pk = `ORDER#${tenantCode}`
+const sk = `ORDER#${code}`
 ```
 
 **Explanation:** Follow the `ENTITY#value` convention for partition and sort keys.
@@ -193,6 +201,7 @@ const sk = `ORDER#${code}`;
 **Severity:** Error
 
 **Pattern:**
+
 ```typescript
 // Bad
 async create(dto: CreateOrderDto) {
@@ -214,6 +223,7 @@ async create(dto: CreateOrderDto, invokeContext: IInvoke) {
 **Severity:** Warning
 
 **Pattern:**
+
 ```typescript
 // Bad
 id: uuid(),
@@ -232,22 +242,23 @@ id: generateId(pk, sk),
 **Severity:** Warning
 
 **Pattern:**
+
 ```typescript
 // Bad
 export class CreateOrderDto {
-  code: string;
-  name: string;
+  code: string
+  name: string
 }
 
 // Good
 export class CreateOrderDto {
   @IsString()
   @IsNotEmpty()
-  code: string;
+  code: string
 
   @IsString()
   @IsNotEmpty()
-  name: string;
+  name: string
 }
 ```
 
@@ -260,14 +271,15 @@ export class CreateOrderDto {
 **Severity:** Warning
 
 **Pattern:**
+
 ```typescript
 // Bad - deprecated
-await this.commandService.publish(command, options);
-await this.commandService.publishPartialUpdate(command, options);
+await this.commandService.publish(command, options)
+await this.commandService.publishPartialUpdate(command, options)
 
 // Good - use Async variants
-await this.commandService.publishAsync(command, options);
-await this.commandService.publishPartialUpdateAsync(command, options);
+await this.commandService.publishAsync(command, options)
+await this.commandService.publishPartialUpdateAsync(command, options)
 ```
 
 **Explanation:** The non-Async methods are deprecated. Use `publishAsync` and `publishPartialUpdateAsync`.
@@ -279,23 +291,24 @@ await this.commandService.publishPartialUpdateAsync(command, options);
 **Severity:** Warning
 
 **Pattern:**
+
 ```typescript
 // Bad - no source tracking
 await this.commandService.publishAsync(command, {
   invokeContext,
-});
+})
 
 // Good - with source tracking
 const commandSource = getCommandSource(
   basename(__dirname),
   this.constructor.name,
   'create',
-);
+)
 
 await this.commandService.publishAsync(command, {
   source: commandSource,
   invokeContext,
-});
+})
 ```
 
 **Explanation:** Always include `source` in publish options for debugging and audit trails.
@@ -307,18 +320,21 @@ await this.commandService.publishAsync(command, {
 **Severity:** Warning
 
 **Pattern:**
+
 ```typescript
 // Bad - direct DynamoDB access
-import { DynamoDBClient, GetItemCommand } from '@aws-sdk/client-dynamodb';
+import { DynamoDBClient, GetItemCommand } from '@aws-sdk/client-dynamodb'
 
-const client = new DynamoDBClient({});
-const result = await client.send(new GetItemCommand({
-  TableName: 'my-table',
-  Key: { pk: { S: 'ORDER#tenant' }, sk: { S: 'ORDER#123' } },
-}));
+const client = new DynamoDBClient({})
+const result = await client.send(
+  new GetItemCommand({
+    TableName: 'my-table',
+    Key: { pk: { S: 'ORDER#tenant' }, sk: { S: 'ORDER#123' } },
+  }),
+)
 
 // Good - use DataService
-const result = await this.dataService.getItem({ pk, sk });
+const result = await this.dataService.getItem({ pk, sk })
 ```
 
 **Explanation:** Use `DataService` for read operations. It provides caching, consistent interfaces, and proper error handling.
@@ -330,6 +346,7 @@ const result = await this.dataService.getItem({ pk, sk });
 **Severity:** Error
 
 **Pattern:**
+
 ```typescript
 // Bad - missing type
 @DataSyncHandler({})
@@ -353,6 +370,7 @@ export class OrderDataSyncRdsHandler implements IDataSyncHandler {
 **Severity:** Info
 
 **Pattern:**
+
 ```typescript
 // Bad - inline key definition
 async findOne(pk: string, sk: string) {
@@ -376,6 +394,7 @@ async findOne(key: DetailKey) {
 **Severity:** Warning
 
 **Pattern:**
+
 ```typescript
 // Bad - hardcoded table name
 CommandModule.register({
@@ -399,6 +418,7 @@ CommandModule.register({
 **Severity:** Warning
 
 **Pattern:**
+
 ```typescript
 // Bad - silently catching errors
 try {
@@ -430,22 +450,29 @@ try {
 **Severity:** Error
 
 **Pattern:**
+
 ```typescript
 // Bad - overwrites all attributes
-await this.commandService.publishPartialUpdateAsync({
-  pk: key.pk,
-  sk: key.sk,
-  version: existingItem.version,
-  attributes: dto.attributes, // Overwrites existing attributes!
-}, options);
+await this.commandService.publishPartialUpdateAsync(
+  {
+    pk: key.pk,
+    sk: key.sk,
+    version: existingItem.version,
+    attributes: dto.attributes, // Overwrites existing attributes!
+  },
+  options,
+)
 
 // Good - merge attributes properly
-await this.commandService.publishPartialUpdateAsync({
-  pk: key.pk,
-  sk: key.sk,
-  version: existingItem.version,
-  attributes: { ...existingItem.attributes, ...dto.attributes },
-}, options);
+await this.commandService.publishPartialUpdateAsync(
+  {
+    pk: key.pk,
+    sk: key.sk,
+    version: existingItem.version,
+    attributes: { ...existingItem.attributes, ...dto.attributes },
+  },
+  options,
+)
 ```
 
 **Explanation:** When updating, merge new attributes with existing ones to avoid data loss.
@@ -457,6 +484,7 @@ await this.commandService.publishPartialUpdateAsync({
 **Severity:** Info
 
 **Pattern:**
+
 ```typescript
 // Bad - no documentation
 @Controller('orders')
@@ -486,6 +514,7 @@ export class OrderController {
 **Severity:** Warning
 
 **Pattern:**
+
 ```typescript
 // Bad - no pagination support
 async search(dto: SearchOrderDto, invokeContext: IInvoke) {
@@ -515,6 +544,7 @@ async search(dto: SearchOrderDto, invokeContext: IInvoke) {
 **Severity:** Error
 
 **Pattern:**
+
 ```typescript
 // Bad - circular dependency
 // order.module.ts
@@ -552,6 +582,7 @@ export class OrderModule {}
 **Severity:** Error
 
 **Pattern:**
+
 ```typescript
 // Bad - emit immediately after publishAsync (data table not yet written)
 async createOrder(params: CreateOrderParams, context: UserContext): Promise<string> {
@@ -613,13 +644,17 @@ The `IDataSyncHandler.up()` pattern above is still required when other users, ba
 **Problem:** Group-based roles (`@GroupRoleResolver`, `custom:groups`) are implemented in ways that break bootstrap or leak across requests.
 
 **❌ Incorrect — adding `@Injectable()` alongside `@GroupRoleResolver()`:**
+
 ```typescript
 @GroupRoleResolver()
 @Injectable({ scope: Scope.REQUEST }) // ❌ overrides the singleton scope; breaks bootstrap
-export class AppGroupRoleResolver implements IGroupRoleResolver { /* ... */ }
+export class AppGroupRoleResolver implements IGroupRoleResolver {
+  /* ... */
+}
 ```
 
 **❌ Incorrect — swallowing resolver errors to "fail open":**
+
 ```typescript
 async resolveRoles(input) {
   try {
@@ -631,20 +666,30 @@ async resolveRoles(input) {
 ```
 
 **❌ Incorrect — more than one resolver, or stateful instance shared across requests:**
+
 ```typescript
 @GroupRoleResolver() class ResolverA ... // ❌ only one @GroupRoleResolver() per app
 @GroupRoleResolver() class ResolverB ... //    (bootstrap throws)
 ```
 
 **✅ Correct:**
+
 ```typescript
-import { GroupRoleResolver, IGroupRoleResolver, ResolveGroupRolesInput } from '@mbc-cqrs-serverless/core';
+import {
+  GroupRoleResolver,
+  IGroupRoleResolver,
+  ResolveGroupRolesInput,
+} from '@mbc-cqrs-serverless/core'
 
 // No @Injectable() — @GroupRoleResolver() already registers a singleton provider.
 @GroupRoleResolver()
 export class AppGroupRoleResolver implements IGroupRoleResolver {
-  async resolveRoles({ tenantCode, groupIds, claims }: ResolveGroupRolesInput): Promise<string[]> {
-    return this.mapGroupsToRoles(tenantCode, groupIds); // stateless; let failures throw
+  async resolveRoles({
+    tenantCode,
+    groupIds,
+    claims,
+  }: ResolveGroupRolesInput): Promise<string[]> {
+    return this.mapGroupsToRoles(tenantCode, groupIds) // stateless; let failures throw
   }
 }
 ```
@@ -660,6 +705,7 @@ export class AppGroupRoleResolver implements IGroupRoleResolver {
 **Severity:** High
 
 **Pattern:**
+
 ```typescript
 // Bad — same handler class listed as a provider in multiple modules
 
@@ -689,6 +735,7 @@ export class TenantModule {}
 This is a copy-paste mistake driven by the misconception that "each module must register the handler to pick it up." In reality, `ExplorerService` scans globally, so a single registration in any one module is sufficient.
 
 **Common symptoms:**
+
 - RDS records created in duplicate after a single command
 - P2002 / unique constraint violations in Step Functions logs
 - Alert/notification handlers firing multiple times per event
@@ -697,16 +744,89 @@ This is a copy-paste mistake driven by the misconception that "each module must 
 
 ---
 
+### AP024: Reserved DataSyncHandler Type (`'dynamodb'`)
+
+> Detector counterpart: **AP029** (`mbc_check_anti_patterns`).
+
+**Severity:** High
+
+**Pattern:**
+
+```typescript
+// Bad — 'dynamodb' is reserved for the internal DataSyncDdsHandler
+@DataSyncHandler('my-table')
+export class TenantConfigRdsHandler implements IDataSyncHandler {
+  readonly type = 'dynamodb'  // ← silently excluded from publishSync pipeline
+  async up(cmd: CommandModel) { ... }
+  async down(cmd: CommandModel) { ... }
+}
+
+// Good — use any other string, or omit the type property entirely
+@DataSyncHandler('my-table')
+export class TenantConfigRdsHandler implements IDataSyncHandler {
+  readonly type = 'rds'  // ← included in publishSync pipeline
+  async up(cmd: CommandModel) { ... }
+  async down(cmd: CommandModel) { ... }
+}
+```
+
+**Explanation:** `CommandService.publishSync()` filters out handlers whose `type` is `'dynamodb'` before executing the sync pipeline (`this.dataSyncHandlers?.filter(h => h.type !== 'dynamodb')`). The string `'dynamodb'` is the type used exclusively by the internal `DataSyncDdsHandler` (the handler that writes the Data table). If a custom handler accidentally sets `readonly type = 'dynamodb'`, it is silently excluded — `handler.up()` is never called, data is never written, and no error or warning is produced.
+
+**Common symptoms:**
+
+- Custom RDS / OpenSearch sync appears to work (no errors) but data is never written
+- Integration tests pass (mock handlers are not filtered) but production sync is missing
+- The symptom first appears in `publishSync` paths; async Step Functions path is unaffected (the async path calls all handlers by name, not by `type`)
+
+**Fix:** Remove `readonly type = 'dynamodb'` from custom handlers and use a different value (e.g., `'rds'`, `'opensearch'`, `'custom'`). If no `type` is needed, omit the property — a missing `type` evaluates to `undefined`, which satisfies `!== 'dynamodb'` and is included in the pipeline.
+
+---
+
+### AP025: Fully-Qualified Table Name in `@DataSyncHandler`
+
+> Detector counterpart: **AP030** (`mbc_check_anti_patterns`).
+
+**Severity:** High
+
+**Pattern:**
+
+```typescript
+// Bad — fully-qualified DynamoDB table name (with env prefix + -command suffix)
+@DataSyncHandler('dev-my-table-command')  // ← wrong: this is the DynamoDB table name
+export class MyRdsHandler implements IDataSyncHandler { ... }
+
+// Good — raw table name as passed to CommandModule.register()
+@DataSyncHandler('my-table')  // ← correct: matches tableName in CommandModule.register
+export class MyRdsHandler implements IDataSyncHandler { ... }
+
+// In the module:
+CommandModule.register({ tableName: 'my-table', dataSyncHandlers: [] })
+```
+
+**Explanation:** `@DataSyncHandler(commandTableName)` stores `commandTableName` as Reflect metadata on the class. `ExplorerService` matches handlers to `CommandService` instances by comparing this metadata value to the `tableName` option passed to `CommandModule.register()`. `tableName` is the raw logical name (e.g., `'my-table'`), not the DynamoDB table name (e.g., `'dev-my-table-command'` which the framework builds internally with environment prefix and `-command` suffix). A mismatch causes `ExplorerService` to find no match and silently skip the handler — no error, no warning, no data sync.
+
+**Common symptoms:**
+
+- Custom DataSyncHandler is correctly defined and registered as a provider, but `handler.up()` is never called
+- Data appears to sync correctly for the DynamoDB (Data table) path but the RDS / secondary sync is missing
+- No errors in CloudWatch; Step Functions shows `SYNC_DATA` state with an empty handler list
+
+**Fix:** Pass the same raw `tableName` string to `@DataSyncHandler` that you pass to `CommandModule.register({ tableName: '...' })`. Do not include environment prefixes (`dev-`, `stg-`, `prod-`) or the `-command` suffix — those are added internally by the framework when constructing the actual DynamoDB table name.
+
+---
+
 ## Review Checklist
 
 When reviewing MBC CQRS Serverless code, check:
 
 ### Module Structure
+
 - [ ] Module properly imports `CommandModule.register()`
 - [ ] DataSyncHandlers are registered
 - [ ] Services and controllers are properly provided
 
 ### Service Layer
+
 - [ ] All methods receive `invokeContext: IInvoke`
 - [ ] `getUserContext()` is used to extract tenant info
 - [ ] `publishAsync` is used (not `publishSync`)
@@ -717,21 +837,25 @@ When reviewing MBC CQRS Serverless code, check:
 - [ ] `eventEmitter.emit()` is NOT called directly after `publishAsync` (use IDataSyncHandler instead)
 
 ### DTOs
+
 - [ ] class-validator decorators are present
 - [ ] Swagger decorators for API documentation
 - [ ] CommandDto extends the base class
 
 ### Controller
+
 - [ ] `@INVOKE_CONTEXT()` decorator is used
 - [ ] Proper HTTP methods (POST for create, PUT for update, etc.)
 - [ ] API tags and documentation
 
 ### Error Handling
+
 - [ ] ConditionalCheckFailedException is handled
 - [ ] Proper HTTP exceptions are thrown
 - [ ] Errors are logged appropriately
 
 ### Data Sync Handler
+
 - [ ] `@DataSyncHandler({ type: 'ENTITY' })` decorator is present (for RDS sync handlers)
 - [ ] Implements `IDataSyncHandler`
 - [ ] Handles both create/update and delete cases
@@ -740,10 +864,12 @@ When reviewing MBC CQRS Serverless code, check:
 - [ ] `_prev` metadata is stripped before RDS upsert if used for change-detection
 
 ### Notification Transport (when implementing INotificationTransport)
+
 - [ ] Uses `@NotificationTransport('transport-name')` decorator instead of `@Injectable()` (AP026)
 - [ ] Transport name is registered in `NOTIFICATION_TRANSPORTS` env var to be active
 
 ### Group Role Resolver (when implementing IGroupRoleResolver, v1.3.1+) (AP022)
+
 - [ ] Uses `@GroupRoleResolver()` only — no extra `@Injectable()` on the same class
 - [ ] Resolver is singleton-scoped (no `REQUEST`/`TRANSIENT` scope)
 - [ ] Exactly one `@GroupRoleResolver()` per application
@@ -755,7 +881,7 @@ When reviewing MBC CQRS Serverless code, check:
 
 When reviewing, provide output in this format:
 
-```
+````
 ## Code Review: [File Name]
 
 ### Issues Found
@@ -766,7 +892,8 @@ When reviewing, provide output in this format:
 - **Current Code:**
   ```typescript
   // problematic code
-  ```
+````
+
 - **Suggested Fix:**
   ```typescript
   // corrected code
@@ -776,12 +903,16 @@ When reviewing, provide output in this format:
 ### Summary
 
 | Severity | Count |
-|----------|-------|
+| -------- | ----- |
 | Error    | X     |
 | Warning  | X     |
 | Info     | X     |
 
 ### Recommendations
+
 1. Priority fixes...
 2. Suggested improvements...
+
+```
+
 ```

--- a/packages/mcp-server/src/tools/analyze.spec.ts
+++ b/packages/mcp-server/src/tools/analyze.spec.ts
@@ -375,6 +375,106 @@ describe('analyze tools', () => {
       expect(result.isError).toBe(true)
       expect(result.content[0].text).toContain('Path not found')
     })
+
+    /** AP029: custom DataSyncHandler using reserved type = 'dynamodb' */
+    it('should detect reserved type dynamodb in custom DataSyncHandler (AP029)', async () => {
+      fs.writeFileSync(
+        path.join(testDir, 'src', 'bad-handler.ts'),
+        `
+        import { DataSyncHandler, IDataSyncHandler } from '@mbc-cqrs-serverless/core';
+
+        @DataSyncHandler('my-table')
+        export class BadHandler implements IDataSyncHandler {
+          readonly type = 'dynamodb'
+          async up(cmd) {}
+          async down(cmd) {}
+        }
+      `,
+      )
+
+      const result = await handleAnalyzeTool(
+        'mbc_check_anti_patterns',
+        { path: 'src' },
+        testDir,
+      )
+
+      expect(result.content[0].text).toContain('AP029')
+      expect(result.content[0].text).toContain('Reserved DataSyncHandler Type')
+    })
+
+    it('should NOT flag DataSyncHandler with a non-reserved type (AP029 negative)', async () => {
+      fs.writeFileSync(
+        path.join(testDir, 'src', 'ok-handler.ts'),
+        `
+        import { DataSyncHandler, IDataSyncHandler } from '@mbc-cqrs-serverless/core';
+
+        @DataSyncHandler('my-table')
+        export class OkHandler implements IDataSyncHandler {
+          readonly type = 'rds'
+          async up(cmd) {}
+          async down(cmd) {}
+        }
+      `,
+      )
+
+      const result = await handleAnalyzeTool(
+        'mbc_check_anti_patterns',
+        { path: 'src' },
+        testDir,
+      )
+
+      expect(result.content[0].text).not.toContain('AP029')
+    })
+
+    /** AP030: @DataSyncHandler with fully-qualified table name ending in -command */
+    it('should detect fully-qualified table name with -command suffix (AP030)', async () => {
+      fs.writeFileSync(
+        path.join(testDir, 'src', 'bad-table-name.ts'),
+        `
+        import { DataSyncHandler, IDataSyncHandler } from '@mbc-cqrs-serverless/core';
+
+        @DataSyncHandler('dev-my-table-command')
+        export class MyHandler implements IDataSyncHandler {
+          async up(cmd) {}
+          async down(cmd) {}
+        }
+      `,
+      )
+
+      const result = await handleAnalyzeTool(
+        'mbc_check_anti_patterns',
+        { path: 'src' },
+        testDir,
+      )
+
+      expect(result.content[0].text).toContain('AP030')
+      expect(result.content[0].text).toContain(
+        'Fully-Qualified Table Name in @DataSyncHandler',
+      )
+    })
+
+    it('should NOT flag DataSyncHandler with raw table name (AP030 negative)', async () => {
+      fs.writeFileSync(
+        path.join(testDir, 'src', 'ok-table-name.ts'),
+        `
+        import { DataSyncHandler, IDataSyncHandler } from '@mbc-cqrs-serverless/core';
+
+        @DataSyncHandler('my-table')
+        export class MyHandler implements IDataSyncHandler {
+          async up(cmd) {}
+          async down(cmd) {}
+        }
+      `,
+      )
+
+      const result = await handleAnalyzeTool(
+        'mbc_check_anti_patterns',
+        { path: 'src' },
+        testDir,
+      )
+
+      expect(result.content[0].text).not.toContain('AP030')
+    })
   })
 
   describe('mbc_health_check', () => {

--- a/packages/mcp-server/src/tools/analyze.ts
+++ b/packages/mcp-server/src/tools/analyze.ts
@@ -739,6 +739,31 @@ const ANTI_PATTERNS = [
     recommendation:
       'Do not annotate a @GroupRoleResolver() class with @Injectable(). @GroupRoleResolver() already registers the class as a singleton provider; adding @Injectable() (particularly with REQUEST/TRANSIENT scope) overrides the scope and breaks bootstrap, which resolves the resolver exactly once at application startup. Remove the extra @Injectable().',
   },
+  {
+    code: 'AP029',
+    name: 'Reserved DataSyncHandler Type',
+    severity: 'high' as const,
+    // Detect a @DataSyncHandler-decorated class that sets readonly type = 'dynamodb'.
+    // 'dynamodb' is reserved for the internal DataSyncDdsHandler. Any user-defined
+    // handler with this type is silently excluded from publishSync's handler pipeline
+    // (which filters out type === 'dynamodb'), causing data loss with no error or warning.
+    pattern:
+      /@DataSyncHandler[\s\S]{0,500}readonly\s+type\s*=\s*['"`]dynamodb['"`]/,
+    recommendation:
+      "Remove or rename the 'dynamodb' type value. This string is reserved for the internal DataSyncDdsHandler. Setting readonly type = 'dynamodb' on a custom handler causes publishSync to silently exclude it from the synchronous pipeline (CommandService filters handler.type !== 'dynamodb'), resulting in data loss with no error or warning. Use any other string (e.g. 'rds', 'opensearch') or omit the type property entirely.",
+  },
+  {
+    code: 'AP030',
+    name: 'Fully-Qualified Table Name in @DataSyncHandler',
+    severity: 'high' as const,
+    // Detect @DataSyncHandler called with a table name ending in '-command'.
+    // The decorator expects the RAW table name as passed to CommandModule.register({ tableName }).
+    // Passing the DynamoDB-level name (e.g. 'dev-my-table-command') causes silent handler
+    // discovery failure: ExplorerService matches by this metadata key and finds nothing.
+    pattern: /@DataSyncHandler\s*\(\s*['"`][^'"`]+-command['"`]/,
+    recommendation:
+      "Pass the raw table name to @DataSyncHandler(), not the fully-qualified DynamoDB table name. Example: if CommandModule.register({ tableName: 'my-table' }), then use @DataSyncHandler('my-table'). Passing 'dev-my-table-command' (with environment prefix and -command suffix) causes the ExplorerService to find no matching metadata, so the handler is silently never called — no error is raised. Remove the environment prefix and the '-command' suffix.",
+  },
 ]
 
 /**
@@ -766,6 +791,8 @@ const DETECTOR_TO_SKILL_AP: Record<string, string> = {
   // AP026: detector-only (no skill-doc AP counterpart)
   AP027: 'AP022', // GroupRoleResolver + @Injectable → Incorrect Group-Based Role Resolver Implementation
   AP028: 'AP023', // Duplicate DataSyncHandler Registration → Duplicate DataSyncHandler Registration Across Modules
+  AP029: 'AP024', // Reserved DataSyncHandler Type → Reserved DataSyncHandler Type
+  AP030: 'AP025', // Fully-Qualified Table Name in @DataSyncHandler → Fully-Qualified Table Name
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds two new anti-pattern detectors extending the DataSyncHandler family introduced by AP028.

- **AP029 — Reserved DataSyncHandler Type**: Detects `@DataSyncHandler` classes that set `readonly type = 'dynamodb'`. This string is reserved for the internal `DataSyncDdsHandler`. Custom handlers with this type are silently excluded from the `publishSync` pipeline (`CommandService` filters `handler.type !== 'dynamodb'`), causing data loss with no error or warning.
- **AP030 — Fully-Qualified Table Name in `@DataSyncHandler`**: Detects `@DataSyncHandler` calls with a table name ending in `-command`. The decorator expects the raw logical name (e.g., `'my-table'`) that matches `CommandModule.register({ tableName })`, not the DynamoDB-level name (e.g., `'dev-my-table-command'`). A mismatch causes `ExplorerService` to find no match and silently skip the handler.

Both patterns include detector entries in `analyze.ts`, `DETECTOR_TO_SKILL_AP` map updates, 4 new tests (TDD red→green), and full SKILL.md documentation as AP024 and AP025.

## Test plan

- [ ] AP029 positive test: `readonly type = 'dynamodb'` → AP029 detected
- [ ] AP029 negative test: `readonly type = 'rds'` → AP029 not flagged
- [ ] AP030 positive test: `@DataSyncHandler('dev-my-table-command')` → AP030 detected
- [ ] AP030 negative test: `@DataSyncHandler('my-table')` → AP030 not flagged
- [ ] Full test suite: 163 suites passed, 3591 tests passed (+4 new)
- [ ] ESLint and Prettier clean confirmed

> **Note:** This branch is based on `fix/command-service-bugs-and-mcp-ap028` (PR #460). Will rebase onto `develop` once PR #460 is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)