### PR TITLE
fix(cli): upgrade multer to 2.2.0 to resolve CVE-2026-5079 (DoS)

### DIFF
--- a/packages/cli/templates/package-lock.json
+++ b/packages/cli/templates/package-lock.json
@@ -23583,9 +23583,9 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/multer": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
-      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",

--- a/packages/cli/templates/package.json
+++ b/packages/cli/templates/package.json
@@ -129,7 +129,7 @@
     "yaml": "^2.8.3",
     "follow-redirects": "^1.16.0",
     "flatted": "^3.4.2",
-    "multer": "^2.1.1",
+    "multer": "^2.2.0",
     "@angular-devkit/core": {
       "ajv": "^8.18.0",
       "picomatch": "^4.0.4"


### PR DESCRIPTION
## Summary

Upgrades `multer` from `2.1.1` to `2.2.0` in the CLI project template to resolve a HIGH severity vulnerability.

## Vulnerability

| Field | Detail |
|-------|--------|
| CVE | CVE-2026-5079 |
| Severity | **HIGH** |
| Package | `multer` |
| Affected | `< 2.2.0` |
| Fixed in | `2.2.0` |
| Description | Denial of Service via deeply nested field names |

Detected by Trivy in the CI check for PR #462.

## Changes

- `packages/cli/templates/package.json`: `"multer": "^2.1.1"` → `"^2.2.0"`
- `packages/cli/templates/package-lock.json`: regenerated

## Breaking Changes

None. `2.2.0` is a minor release within the `2.x` line with no API changes. The template code does not call multer APIs directly — multer is used internally by `@nestjs/platform-express`.

## Verification

```bash
npm audit --audit-level=high
# multer no longer appears in the report
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)