### PR TITLE
fix(infra): lower ATTRIBUTE_LIMIT_SIZE default for Step Functions payload limit

### DIFF
--- a/packages/cli/templates/.env.local
+++ b/packages/cli/templates/.env.local
@@ -48,8 +48,12 @@ LOCAL_DDB_ADMIN_PORT=8001
 # DynamoDB endpoint, useful for local development
 DYNAMODB_ENDPOINT=http://localhost:${LOCAL_DYNAMODB_PORT:-8000}
 DYNAMODB_REGION=ap-northeast-1
-# set the limit size for `attributes` of object in DDB
-ATTRIBUTE_LIMIT_SIZE=389120 # bytes, refer to https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ServiceQuotas.html#limits-attributes
+# Max size (bytes) for `attributes` before S3 offload.
+# Must account for Step Functions 256 KB payload limit: the SFN state passes
+# the DynamoDB event twice (input + context.Execution.Input), so the safe
+# limit is ~(256 KB - overhead) / 2 ≈ 110 KB. Default: 100 KB.
+# DynamoDB item limit is 400 KB — do NOT use that as the reference.
+ATTRIBUTE_LIMIT_SIZE=102400
 # S3 endpoint, useful for local development
 S3_ENDPOINT=http://localhost:${LOCAL_S3_PORT:-4566}
 S3_REGION=ap-northeast-1

--- a/packages/cli/templates/infra/libs/infra-stack.ts
+++ b/packages/cli/templates/infra/libs/infra-stack.ts
@@ -459,7 +459,12 @@ export class InfraStack extends cdk.Stack {
       APP_NAME: name,
       LOG_LEVEL: props.config.logLevel?.level || 'info',
       EVENT_SOURCE_DISABLED: 'false',
-      ATTRIBUTE_LIMIT_SIZE: '389120',
+      // Max size (bytes) for `attributes` before S3 offload.
+      // Must account for Step Functions 256 KB payload limit: the SFN state passes
+      // the DynamoDB event twice (input + context.Execution.Input), so the safe
+      // limit is ~(256 KB - overhead) / 2 ≈ 110 KB. Default: 100 KB.
+      // DynamoDB item limit is 400 KB — do NOT use that as the reference.
+      ATTRIBUTE_LIMIT_SIZE: '102400',
       S3_BUCKET_NAME: ddbBucket.bucketName,
       SFN_COMMAND_ARN: commandSfnArn,
       SFN_TASK_ARN: taskSfnArn,

--- a/packages/cli/templates/infra/test/__snapshots__/infra.test.ts.snap
+++ b/packages/cli/templates/infra/test/__snapshots__/infra.test.ts.snap
@@ -1059,7 +1059,7 @@ exports[`snapshot test for InfraStack 1`] = `
               ],
             },
             "APP_NAME": "",
-            "ATTRIBUTE_LIMIT_SIZE": "389120",
+            "ATTRIBUTE_LIMIT_SIZE": "102400",
             "COGNITO_USER_POOL_ID": {
               "Ref": "devuserpool23B1805F",
             },

--- a/packages/core/.env.example
+++ b/packages/core/.env.example
@@ -13,8 +13,12 @@ EVENT_SOURCE_DISABLED=false
 # DynamoDB endpoint, useful for local development
 DYNAMODB_ENDPOINT=http://0.0.0.0:8000 
 DYNAMODB_REGION=ap-northeast-1
-# set the limit size for `attributes` of object in DDB
-ATTRIBUTE_LIMIT_SIZE=389120 # bytes, refer to https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ServiceQuotas.html#limits-attributes
+# Max size (bytes) for `attributes` before S3 offload.
+# Must account for Step Functions 256 KB payload limit: the SFN state passes
+# the DynamoDB event twice (input + context.Execution.Input), so the safe
+# limit is ~(256 KB - overhead) / 2 ≈ 110 KB. Default: 100 KB.
+# DynamoDB item limit is 400 KB — do NOT use that as the reference.
+ATTRIBUTE_LIMIT_SIZE=102400
 # S3 endpoint, useful for local development
 S3_ENDPOINT=http://0.0.0.0:4566
 S3_REGION=ap-northeast-1


### PR DESCRIPTION
## Summary

- Lower the framework default `ATTRIBUTE_LIMIT_SIZE` from `389120` (380 KB) to `102400` (100 KB) in CDK infra templates and env examples
- The previous default was sized for DynamoDB’s 400 KB item limit, but Step Functions enforces a 256 KB payload limit per state
- Command state machines pass the DynamoDB stream event twice (`input.$` + `context.$` / `$$.Execution.Input`), so inline attributes above ~110 KB can trigger `States.DataLimitExceeded` (observed at `check_version` in production)
- Add inline comments at each definition site explaining the Step Functions constraint and why DynamoDB’s limit should not be used as the reference
- Update CDK snapshot to reflect the new Lambda env default
## Problem

Production error:

```
error: States.DataLimitExceeded
cause: The state/task 'check_version' provided parameters with a size
       exceeding the maximum number of bytes service limit.
```

**Root cause:** `ATTRIBUTE_LIMIT_SIZE` allowed attributes up to 380 KB inline in DynamoDB, but Step Functions payloads are approximately:

```
payload ≈ DynamoDB event × 2 + ~20 KB context overhead
```

Safe inline limit: `(256 KB − overhead) ÷ 2 ≈ 110 KB`. The old default was ~3.2× too high.

## Solution

When `attributes` exceed `ATTRIBUTE_LIMIT_SIZE`, the framework already offloads them to S3 via `DynamoDBService.objToDdbItem()`. This PR lowers the default so offload happens earlier, keeping Step Functions payloads under 256 KB.

**Default value rationale:**

```
SFN limit:           262,144 bytes (256 KB)
Context overhead:    ~20,480 bytes (~20 KB)
Duplication factor:  ×2
Safety margin:       ~8,192 bytes (~8 KB)
Rounded default:     102,400 bytes (100 KB)
```