### PR TITLE
docs(mcp-server): add v1.3.3 ATTRIBUTE_LIMIT_SIZE guidance to skills

### DIFF
--- a/packages/mcp-server/skills/mbc-debug/SKILL.md
+++ b/packages/mcp-server/skills/mbc-debug/SKILL.md
@@ -419,6 +419,23 @@ functions:
 
 ---
 
+### 11. States.DataLimitExceeded in Command State Machine (fixed in v1.3.3)
+
+**Symptom:** The command state machine execution fails with:
+```
+error: States.DataLimitExceeded
+cause: The state/task 'check_version' provided parameters with a size
+       exceeding the maximum number of bytes service limit.
+```
+
+**Cause:** `ATTRIBUTE_LIMIT_SIZE` was set too high. AWS Step Functions enforces a 256 KB payload limit per state, but the command state machine passes the DynamoDB stream event twice per state (`input.$` and `context.$`), so inline `attributes` above roughly 110 KB can exceed that limit even though DynamoDB itself allows items up to 400 KB. Prior to v1.3.3, the framework's default `ATTRIBUTE_LIMIT_SIZE` in generated CDK templates and env examples was `389120` (380 KB) — sized for DynamoDB's item limit rather than the Step Functions payload limit.
+
+**Fix:** As of v1.3.3, the default is lowered to `102400` (100 KB). If your `.env` or CDK stack (`infra/libs/infra-stack.ts`) still sets `ATTRIBUTE_LIMIT_SIZE=389120` (or another value above ~110 KB), lower it to `102400` or less. Attributes larger than this threshold are automatically offloaded to S3 by `DynamoDbService.objToDdbItem()`, so lowering the limit does not lose data — it just offloads to S3 earlier.
+
+**Related:** See migration guide v1.3.3.
+
+---
+
 ## CloudWatch Log Queries
 
 ### Find Errors by Request ID

--- a/packages/mcp-server/skills/mbc-migrate/SKILL.md
+++ b/packages/mcp-server/skills/mbc-migrate/SKILL.md
@@ -43,6 +43,7 @@ This skill helps migrate MBC CQRS Serverless projects between versions.
 | v1.2.5 | v1.2.6 | Low | Repository RYW improvements (transparent); `getVersion` API |
 | v1.2.7 | v1.3.0 | Low | AppSync Events API support (opt-in, no breaking changes) |
 | v1.3.0 | v1.3.1 | Low | Group-based roles (`@GroupRoleResolver`, `custom:groups`); `UserContext.tenantRoles`/`tenantGroupIds` added (opt-in, no breaking changes) |
+| v1.3.2 | v1.3.3 | Low | `ATTRIBUTE_LIMIT_SIZE` default lowered 389120 → 102400 for Step Functions payload limit (transparent unless overridden) |
 
 ## Migration Guides
 
@@ -672,6 +673,18 @@ Register the class in your module `providers`. `AuthModule` is imported automati
 1. Upgrade to v1.3.1 — no code changes required; existing `@Roles()` checks keep working.
 2. (Optional) Populate `custom:groups` in the JWT and implement one `@GroupRoleResolver()`.
 3. Register the resolver in your NestJS module `providers`.
+
+---
+
+### v1.3.2 → v1.3.3 (no code changes required, unless you hardcoded the old default)
+
+**Change:** The framework's default `ATTRIBUTE_LIMIT_SIZE` in generated CDK templates (`infra/libs/infra-stack.ts`) and env examples (`.env.local`, `.env.example`) is lowered from `389120` (380 KB) to `102400` (100 KB).
+
+**Why:** The old default was sized for DynamoDB's 400 KB item limit, but AWS Step Functions enforces a 256 KB payload limit per state. The command state machine passes the DynamoDB stream event twice per state (`input.$` + `context.$`), so inline attributes above ~110 KB could trigger `States.DataLimitExceeded` in production. See [Debug Guide — States.DataLimitExceeded](../mbc-debug/SKILL.md) for the full symptom/cause/fix.
+
+**Action required:**
+- If you never customized `ATTRIBUTE_LIMIT_SIZE` and redeploy your CDK stack, the new lower default takes effect automatically — no code changes needed.
+- If you explicitly set `ATTRIBUTE_LIMIT_SIZE=389120` (or another value above ~110 KB) in your own `.env` or CDK stack, lower it to `102400` or less to avoid `States.DataLimitExceeded`. Attributes above the limit are automatically offloaded to S3, so lowering the value does not lose data.
 
 ---
 

--- a/packages/mcp-server/src/__tests__/skills.spec.ts
+++ b/packages/mcp-server/src/__tests__/skills.spec.ts
@@ -280,6 +280,11 @@ describe('Claude Code Skills', () => {
       expect(content).toContain('NestJS')
       expect(content).toContain('Node.js')
     })
+
+    it('should contain v1.3.3 migration guide (ATTRIBUTE_LIMIT_SIZE)', () => {
+      expect(content).toContain('v1.3.3')
+      expect(content).toContain('ATTRIBUTE_LIMIT_SIZE')
+    })
   })
 
   describe('mbc-debug skill', () => {
@@ -337,6 +342,11 @@ describe('Claude Code Skills', () => {
     it('should contain troubleshooting decision tree', () => {
       expect(content).toContain('Decision Tree')
       expect(content).toContain('Error Occurred')
+    })
+
+    it('should contain States.DataLimitExceeded troubleshooting (v1.3.3+)', () => {
+      expect(content).toContain('States.DataLimitExceeded')
+      expect(content).toContain('ATTRIBUTE_LIMIT_SIZE')
     })
   })
 


### PR DESCRIPTION
## Summary

Documents the `ATTRIBUTE_LIMIT_SIZE` default change from #466 (389120 → 102400, Step Functions 256 KB payload limit) in the `mcp-server` package's Claude Code skills, following the established pattern used for prior version updates (e.g. v1.2.5, v1.2.6, v1.3.1).

- **`skills/mbc-debug/SKILL.md`**: Add debugging workflow entry "11. States.DataLimitExceeded in Command State Machine (fixed in v1.3.3)" — symptom (the exact production error from #466), cause (Step Functions payload duplication via `input.$`/`context.$`), and fix.
- **`skills/mbc-migrate/SKILL.md`**: Add a `v1.3.2 → v1.3.3` row to the Version Migration Matrix and a corresponding migration guide section (transparent change; explains what to do if `ATTRIBUTE_LIMIT_SIZE` was hardcoded to the old default).
- **`src/__tests__/skills.spec.ts`**: Add two assertions verifying the new content is present in each skill file.

## Test plan

- [x] TDD: added the two test assertions first, confirmed they failed (red) before adding the doc content
- [x] `npm test` (packages/mcp-server) — 277/277 passed, no regressions (was 275 before this change)
- [x] `npm run build` (tsc) — succeeds with no errors
- [x] Reviewed via `mbc:code-reviewer` subagent; cross-checked the new prose against the actual PR #466 diff (`infra-stack.ts`, `.env.local`, `.env.example`, `dynamodb.service.ts`) for numeric/technical accuracy — one LOW finding (class name casing `DynamoDBService` → `DynamoDbService`) was fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)