### PR TITLE
release: v1.3.3 — lower ATTRIBUTE_LIMIT_SIZE default for Step Functions payload limit

### DIFF
--- a/packages/cli/templates/.env.local
+++ b/packages/cli/templates/.env.local
@@ -48,8 +48,12 @@ LOCAL_DDB_ADMIN_PORT=8001
 # DynamoDB endpoint, useful for local development
 DYNAMODB_ENDPOINT=http://localhost:${LOCAL_DYNAMODB_PORT:-8000}
 DYNAMODB_REGION=ap-northeast-1
-# set the limit size for `attributes` of object in DDB
-ATTRIBUTE_LIMIT_SIZE=389120 # bytes, refer to https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ServiceQuotas.html#limits-attributes
+# Max size (bytes) for `attributes` before S3 offload.
+# Must account for Step Functions 256 KB payload limit: the SFN state passes
+# the DynamoDB event twice (input + context.Execution.Input), so the safe
+# limit is ~(256 KB - overhead) / 2 ≈ 110 KB. Default: 100 KB.
+# DynamoDB item limit is 400 KB — do NOT use that as the reference.
+ATTRIBUTE_LIMIT_SIZE=102400
 # S3 endpoint, useful for local development
 S3_ENDPOINT=http://localhost:${LOCAL_S3_PORT:-4566}
 S3_REGION=ap-northeast-1

--- a/packages/cli/templates/infra/libs/infra-stack.ts
+++ b/packages/cli/templates/infra/libs/infra-stack.ts
@@ -459,7 +459,12 @@ export class InfraStack extends cdk.Stack {
       APP_NAME: name,
       LOG_LEVEL: props.config.logLevel?.level || 'info',
       EVENT_SOURCE_DISABLED: 'false',
-      ATTRIBUTE_LIMIT_SIZE: '389120',
+      // Max size (bytes) for `attributes` before S3 offload.
+      // Must account for Step Functions 256 KB payload limit: the SFN state passes
+      // the DynamoDB event twice (input + context.Execution.Input), so the safe
+      // limit is ~(256 KB - overhead) / 2 ≈ 110 KB. Default: 100 KB.
+      // DynamoDB item limit is 400 KB — do NOT use that as the reference.
+      ATTRIBUTE_LIMIT_SIZE: '102400',
       S3_BUCKET_NAME: ddbBucket.bucketName,
       SFN_COMMAND_ARN: commandSfnArn,
       SFN_TASK_ARN: taskSfnArn,

--- a/packages/cli/templates/infra/test/__snapshots__/infra.test.ts.snap
+++ b/packages/cli/templates/infra/test/__snapshots__/infra.test.ts.snap
@@ -1059,7 +1059,7 @@ exports[`snapshot test for InfraStack 1`] = `
               ],
             },
             "APP_NAME": "",
-            "ATTRIBUTE_LIMIT_SIZE": "389120",
+            "ATTRIBUTE_LIMIT_SIZE": "102400",
             "COGNITO_USER_POOL_ID": {
               "Ref": "devuserpool23B1805F",
             },

--- a/packages/core/.env.example
+++ b/packages/core/.env.example
@@ -13,8 +13,12 @@ EVENT_SOURCE_DISABLED=false
 # DynamoDB endpoint, useful for local development
 DYNAMODB_ENDPOINT=http://0.0.0.0:8000 
 DYNAMODB_REGION=ap-northeast-1
-# set the limit size for `attributes` of object in DDB
-ATTRIBUTE_LIMIT_SIZE=389120 # bytes, refer to https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ServiceQuotas.html#limits-attributes
+# Max size (bytes) for `attributes` before S3 offload.
+# Must account for Step Functions 256 KB payload limit: the SFN state passes
+# the DynamoDB event twice (input + context.Execution.Input), so the safe
+# limit is ~(256 KB - overhead) / 2 ≈ 110 KB. Default: 100 KB.
+# DynamoDB item limit is 400 KB — do NOT use that as the reference.
+ATTRIBUTE_LIMIT_SIZE=102400
 # S3 endpoint, useful for local development
 S3_ENDPOINT=http://0.0.0.0:4566
 S3_REGION=ap-northeast-1

--- a/packages/mcp-server/skills/mbc-debug/SKILL.md
+++ b/packages/mcp-server/skills/mbc-debug/SKILL.md
@@ -419,6 +419,23 @@ functions:
 
 ---
 
+### 11. States.DataLimitExceeded in Command State Machine (fixed in v1.3.3)
+
+**Symptom:** The command state machine execution fails with:
+```
+error: States.DataLimitExceeded
+cause: The state/task 'check_version' provided parameters with a size
+       exceeding the maximum number of bytes service limit.
+```
+
+**Cause:** `ATTRIBUTE_LIMIT_SIZE` was set too high. AWS Step Functions enforces a 256 KB payload limit per state, but the command state machine passes the DynamoDB stream event twice per state (`input.$` and `context.$`), so inline `attributes` above roughly 110 KB can exceed that limit even though DynamoDB itself allows items up to 400 KB. Prior to v1.3.3, the framework's default `ATTRIBUTE_LIMIT_SIZE` in generated CDK templates and env examples was `389120` (380 KB) — sized for DynamoDB's item limit rather than the Step Functions payload limit.
+
+**Fix:** As of v1.3.3, the default is lowered to `102400` (100 KB). If your `.env` or CDK stack (`infra/libs/infra-stack.ts`) still sets `ATTRIBUTE_LIMIT_SIZE=389120` (or another value above ~110 KB), lower it to `102400` or less. Attributes larger than this threshold are automatically offloaded to S3 by `DynamoDbService.objToDdbItem()`, so lowering the limit does not lose data — it just offloads to S3 earlier.
+
+**Related:** See migration guide v1.3.3.
+
+---
+
 ## CloudWatch Log Queries
 
 ### Find Errors by Request ID

--- a/packages/mcp-server/skills/mbc-migrate/SKILL.md
+++ b/packages/mcp-server/skills/mbc-migrate/SKILL.md
@@ -43,6 +43,7 @@ This skill helps migrate MBC CQRS Serverless projects between versions.
 | v1.2.5 | v1.2.6 | Low | Repository RYW improvements (transparent); `getVersion` API |
 | v1.2.7 | v1.3.0 | Low | AppSync Events API support (opt-in, no breaking changes) |
 | v1.3.0 | v1.3.1 | Low | Group-based roles (`@GroupRoleResolver`, `custom:groups`); `UserContext.tenantRoles`/`tenantGroupIds` added (opt-in, no breaking changes) |
+| v1.3.2 | v1.3.3 | Low | `ATTRIBUTE_LIMIT_SIZE` default lowered 389120 → 102400 for Step Functions payload limit (transparent unless overridden) |
 
 ## Migration Guides
 
@@ -672,6 +673,18 @@ Register the class in your module `providers`. `AuthModule` is imported automati
 1. Upgrade to v1.3.1 — no code changes required; existing `@Roles()` checks keep working.
 2. (Optional) Populate `custom:groups` in the JWT and implement one `@GroupRoleResolver()`.
 3. Register the resolver in your NestJS module `providers`.
+
+---
+
+### v1.3.2 → v1.3.3 (no code changes required, unless you hardcoded the old default)
+
+**Change:** The framework's default `ATTRIBUTE_LIMIT_SIZE` in generated CDK templates (`infra/libs/infra-stack.ts`) and env examples (`.env.local`, `.env.example`) is lowered from `389120` (380 KB) to `102400` (100 KB).
+
+**Why:** The old default was sized for DynamoDB's 400 KB item limit, but AWS Step Functions enforces a 256 KB payload limit per state. The command state machine passes the DynamoDB stream event twice per state (`input.$` + `context.$`), so inline attributes above ~110 KB could trigger `States.DataLimitExceeded` in production. See [Debug Guide — States.DataLimitExceeded](../mbc-debug/SKILL.md) for the full symptom/cause/fix.
+
+**Action required:**
+- If you never customized `ATTRIBUTE_LIMIT_SIZE` and redeploy your CDK stack, the new lower default takes effect automatically — no code changes needed.
+- If you explicitly set `ATTRIBUTE_LIMIT_SIZE=389120` (or another value above ~110 KB) in your own `.env` or CDK stack, lower it to `102400` or less to avoid `States.DataLimitExceeded`. Attributes above the limit are automatically offloaded to S3, so lowering the value does not lose data.
 
 ---
 

--- a/packages/mcp-server/src/__tests__/skills.spec.ts
+++ b/packages/mcp-server/src/__tests__/skills.spec.ts
@@ -280,6 +280,11 @@ describe('Claude Code Skills', () => {
       expect(content).toContain('NestJS')
       expect(content).toContain('Node.js')
     })
+
+    it('should contain v1.3.3 migration guide (ATTRIBUTE_LIMIT_SIZE)', () => {
+      expect(content).toContain('v1.3.3')
+      expect(content).toContain('ATTRIBUTE_LIMIT_SIZE')
+    })
   })
 
   describe('mbc-debug skill', () => {
@@ -337,6 +342,11 @@ describe('Claude Code Skills', () => {
     it('should contain troubleshooting decision tree', () => {
       expect(content).toContain('Decision Tree')
       expect(content).toContain('Error Occurred')
+    })
+
+    it('should contain States.DataLimitExceeded troubleshooting (v1.3.3+)', () => {
+      expect(content).toContain('States.DataLimitExceeded')
+      expect(content).toContain('ATTRIBUTE_LIMIT_SIZE')
     })
   })
 


### PR DESCRIPTION
## Summary

Release `develop` → `main` for **v1.3.3**. Bundles the following merged PRs:

- **#466** `fix(infra)`: Lower the framework default `ATTRIBUTE_LIMIT_SIZE` from `389120` (380 KB) to `102400` (100 KB) in CDK infra templates and env examples.
- **#470** `docs(mcp-server)`: Document the change in the `mbc-debug` and `mbc-migrate` Claude Code skills.

## Problem

Production error:

```
error: States.DataLimitExceeded
cause: The state/task 'check_version' provided parameters with a size
       exceeding the maximum number of bytes service limit.
```

**Root cause:** `ATTRIBUTE_LIMIT_SIZE` allowed attributes up to 380 KB inline in DynamoDB, but Step Functions payloads are approximately `DynamoDB event × 2 + ~20 KB context overhead` — the command state machine passes the DynamoDB stream event twice per state (`input.$` + `context.$`). The old default was ~3.2× too high for the 256 KB Step Functions payload limit.

## Changes

### Bug Fix (`packages/cli`, `packages/core`)

- Lower `ATTRIBUTE_LIMIT_SIZE` default `389120` → `102400` in:
  - `packages/cli/templates/.env.local`
  - `packages/cli/templates/infra/libs/infra-stack.ts`
  - `packages/core/.env.example`
- Update CDK infra snapshot to reflect the new Lambda env default.
- Add inline comments at each definition site explaining the Step Functions payload constraint (attributes above `ATTRIBUTE_LIMIT_SIZE` are already offloaded to S3 via `DynamoDBService.objToDdbItem()`, so lowering the default just makes that offload happen earlier).

### MCP Server (`packages/mcp-server`)

- `mbc-debug` skill: new debugging entry "States.DataLimitExceeded in Command State Machine (fixed in v1.3.3)" — symptom, cause, and fix.
- `mbc-migrate` skill: new `v1.3.2 → v1.3.3` migration guide entry (transparent change; explains what to do if `ATTRIBUTE_LIMIT_SIZE` was hardcoded to the old default).
- New Jest assertions in `skills.spec.ts` covering the added content.

## Migration

No breaking changes. If you never customized `ATTRIBUTE_LIMIT_SIZE`, redeploying picks up the new default automatically. If you explicitly set `ATTRIBUTE_LIMIT_SIZE=389120` (or another value above ~110 KB), lower it to `102400` or less. See the `mbc-migrate` skill (`v1.3.2 → v1.3.3`) for details.

## Notes

- Documentation-site changelog and environment-variables reference updates are tracked separately in `mbc-cqrs-serverless-doc` ([PR #148](https://github.com/mbc-net/mbc-cqrs-serverless-doc/pull/148)).

## Test plan

- [x] `npm test` (mcp-server) — 277/277 passed
- [x] `npm run build` (mcp-server) — passes
- [x] CDK infra snapshot updated and verified
- [ ] Reviewer: confirm release notes before tagging `v1.3.3` on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)