### PR TITLE
fix(deps): restore blocking prod security audit, patch brace-expansion

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -67,19 +67,8 @@ jobs:
       # advisories. npm re-resolution (npm install/update/audit fix) can
       # silently resurrect vulnerable nested copies that root overrides do
       # not reach through workspace packages (see PRs #445/#447).
-      #
-      # ---------------------------------------------------------------------
-      # TEMPORARILY DISABLED — deferred to a dedicated security PR.
-      #
-      # This is a scope decision. A PR should resolve the issue it set out to
-      # fix, and the failure below is unrelated to any feature work in flight:
-      # it is a pre-existing dependency problem that develop carries too, so it
-      # blocks PRs that neither caused it nor can reasonably carry its fix.
-      # Fixing it means a real dependency change with its own review and
-      # release considerations, which belongs in its own PR rather than bundled
-      # into unrelated work.
-      # - name: Security Audit (production, blocking)
-      #   run: npm audit --omit=dev --audit-level=high
+      - name: Security Audit (production, blocking)
+        run: npm audit --omit=dev --audit-level=high
 
       - name: Security Scan (Trivy)
         uses: aquasecurity/trivy-action@v0.36.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -10552,18 +10552,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "devOptional": true,
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/anynum": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
@@ -11348,7 +11336,8 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -11708,11 +11697,24 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -15851,6 +15853,29 @@
       "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
@@ -24293,9 +24318,9 @@
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -25233,18 +25258,6 @@
       },
       "engines": {
         "node": ">=8.10.0"
-      }
-    },
-    "node_modules/readdirp/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "devOptional": true,
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/rechoir": {

--- a/package.json
+++ b/package.json
@@ -144,16 +144,7 @@
     "lodash": "^4.18.0",
     "js-yaml": "4.3.0",
     "fast-uri": "3.1.4",
-    "glob@10": {
-      "minimatch": {
-        "brace-expansion": "2.1.2"
-      }
-    },
-    "readdir-glob": {
-      "minimatch": {
-        "brace-expansion": "2.1.2"
-      }
-    },
+    "brace-expansion@2": "5.0.8",
     "tmp": "^0.2.6",
     "webpack": "^5.105.0",
     "qs": "^6.14.2",


### PR DESCRIPTION
## Summary

Completes the production dependency vulnerability fix and **re-enables the blocking `npm audit --omit=dev --audit-level=high` CI gate** that #465 temporarily disabled.

#465 already bumped `js-yaml` (4.3.0) and `fast-uri` (3.1.4), but pinned `brace-expansion` to `2.1.2` via nested overrides. GHSA-mh99-v99m-4gvg marks **only 5.0.8** as patched, so `2.1.2` is still flagged by `npm audit --omit=dev --audit-level=high` — which is why the blocking gate was commented out to unblock the merge. This PR finishes that fix so the gate can be turned back on.

### Production entry path

The vulnerable `brace-expansion` reaches the production tree through the published `cli` package:

- `@mbc-cqrs-serverless/cli → rimraf@5 → glob@10 → minimatch@9 → brace-expansion`
- `@mbc-cqrs-serverless/cli → archiver → readdir-glob → minimatch → brace-expansion`

Both paths resolve the same hoisted `brace-expansion`, so a single top-level override fixes both.

## Changes

- **`package.json`** — replace the nested `glob@10` / `readdir-glob` → `brace-expansion: 2.1.2` overrides with a single top-level `"brace-expansion@2": "5.0.8"`.
  - The `@2` selector targets only the 2.x line; ESLint's `minimatch@3 → brace-expansion@1.x` copies are untouched (preserves the ESLint startup check, cf. #446).
  - A top-level override keeps `npm ci`'s ideal-tree resolution consistent with the lockfile (nested overrides left a hoisted/nested mismatch that broke `npm ci`).
- **`package-lock.json`** — sync `brace-expansion` to `5.0.8` (+ `balanced-match@4.0.4`); 77-line change, no wholesale dependency bumps.
- **`.github/workflows/ci-cd.yml`** — re-enable the `Security Audit (production, blocking)` step.

## Verification

- `npm audit --omit=dev --audit-level=high` → **exit 0** (0 high/critical; only 1 low + 8 moderate remain in dev-only paths).
- `npm ci --ignore-scripts` succeeds; `npm install --package-lock-only` reaches a fixed point (CI lockfile sync stays green).
- `npm run build` — core & cli build successfully.
- `jest packages/core packages/cli` — 2551 passed / 0 failed (44 skipped).
- Production tree resolves `brace-expansion@5.0.8` (`npm ls brace-expansion --omit=dev`); the 1.x ESLint copies remain untouched.

## Notes

- Node 18 emits a non-fatal `EBADENGINE` warning for `brace-expansion@5.0.8` (`engines: 20 || >=22`); install still succeeds (no `engine-strict`). This is unavoidable while the advisory recognizes only 5.0.8 as patched — it can be relaxed once a Node 18-compatible backport (e.g. 2.1.3) is registered as patched.
- Overrides apply to this monorepo's audit tree only; published `cli` consumers resolve their own `brace-expansion` range, same as for `js-yaml`/`fast-uri`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
