### PR TITLE
fix(deps): restore blocking prod security audit, patch brace-expansion

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -67,19 +67,8 @@ jobs:
       # advisories. npm re-resolution (npm install/update/audit fix) can
       # silently resurrect vulnerable nested copies that root overrides do
       # not reach through workspace packages (see PRs #445/#447).
-      #
-      # ---------------------------------------------------------------------
-      # TEMPORARILY DISABLED — deferred to a dedicated security PR.
-      #
-      # This is a scope decision. A PR should resolve the issue it set out to
-      # fix, and the failure below is unrelated to any feature work in flight:
-      # it is a pre-existing dependency problem that develop carries too, so it
-      # blocks PRs that neither caused it nor can reasonably carry its fix.
-      # Fixing it means a real dependency change with its own review and
-      # release considerations, which belongs in its own PR rather than bundled
-      # into unrelated work.
-      # - name: Security Audit (production, blocking)
-      #   run: npm audit --omit=dev --audit-level=high
+      - name: Security Audit (production, blocking)
+        run: npm audit --omit=dev --audit-level=high
 
       - name: Security Scan (Trivy)
         uses: aquasecurity/trivy-action@v0.36.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -10552,18 +10552,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "devOptional": true,
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/anynum": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
@@ -11348,7 +11336,8 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -11708,11 +11697,24 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -15851,6 +15853,29 @@
       "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
@@ -24293,9 +24318,9 @@
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -25233,18 +25258,6 @@
       },
       "engines": {
         "node": ">=8.10.0"
-      }
-    },
-    "node_modules/readdirp/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "devOptional": true,
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/rechoir": {

--- a/package.json
+++ b/package.json
@@ -144,16 +144,7 @@
     "lodash": "^4.18.0",
     "js-yaml": "4.3.0",
     "fast-uri": "3.1.4",
-    "glob@10": {
-      "minimatch": {
-        "brace-expansion": "2.1.2"
-      }
-    },
-    "readdir-glob": {
-      "minimatch": {
-        "brace-expansion": "2.1.2"
-      }
-    },
+    "brace-expansion@2": "5.0.8",
     "tmp": "^0.2.6",
     "webpack": "^5.105.0",
     "qs": "^6.14.2",


### PR DESCRIPTION
## 概要

本番依存の残存脆弱性を解消し、PR #465 が一時的に無効化した「Security Audit (production, blocking)」CI ゲート（`npm audit --omit=dev --audit-level=high`）を復活させます。

develop には既に `js-yaml=4.3.0`・`fast-uri=3.1.4` の override が入っており、残る high は **brace-expansion** のみでした。

## 変更内容

- **`package.json`**: nested override（`glob@10>minimatch>brace-expansion:2.1.2` と `readdir-glob>minimatch>brace-expansion:2.1.2`）を、トップレベル `"brace-expansion@2": "5.0.8"` に置換。
  - GHSA-mh99-v99m-4gvg（brace-expansion DoS/OOM）は **patched=5.0.8 のみ認定**のため、2.1.2 は audit で赤のまま。
  - 依存経路: `@mbc-cqrs-serverless/cli → rimraf@5 → glob@10 → minimatch@9 → brace-expansion`（および archiver 経由の readdir-glob）。
  - ESLint の 1.x コピー（`minimatch@3 → brace-expansion 1.x`）は不変。ESLint startup check を保護（cf. #446）。
- **`.github/workflows/ci-cd.yml`**: 「Security Audit (production, blocking)」ステップをコメント解除して復活。
- **`package-lock.json`**: 本番ツリーの hoisted brace-expansion を 5.0.8 に更新し、`balanced-match@4.0.4` を追加（差分 77 行。既存の picomatch drift 修正を含む）。

## なぜトップレベル override か

`npm ci` は package.json から ideal tree を再計算して lock を検証します。nested override は「override パスに nested 5.0.8 ＋ hoisted 2.1.3」を要求し hoisted-5.0.8 の lock と食い違って `npm ci` が失敗します。トップレベル `brace-expansion@2` は「2.x を全て 5.0.8 に」という単純な ideal（hoisted 5.0.8）となり lock と一致します。

## 検証

- `npm ci --ignore-scripts`: 成功（lock 同期済み、`npm install --package-lock-only` の fixed point に到達）
- `npm audit --omit=dev --audit-level=high`: **exit 0**（high/critical ゼロ）
- `npm ls brace-expansion --omit=dev`: 本番パス `→ brace-expansion@5.0.8 overridden`
- build: `@mbc-cqrs-serverless/core` / `@mbc-cqrs-serverless/cli` 成功
- test: `jest packages/core packages/cli` → 113 suites / 2551 passed / 0 fail（44 skip）

## 既知の残存リスク

- brace-expansion 5.0.8 の engines は `20 || >=22`。`.npmrc` に engine-strict が無いため Node 18 CI マトリクスでは EBADENGINE 警告のみ（非致命・インストールは成功）。advisory が 5.0.8 のみを patched 認定している以上、Node 18 互換のクリーンな代替は現状なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
