### PR TITLE
release: v1.3.5 — command-handler resume/TOCTOU hardening + alarms

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -67,8 +67,19 @@ jobs:
       # advisories. npm re-resolution (npm install/update/audit fix) can
       # silently resurrect vulnerable nested copies that root overrides do
       # not reach through workspace packages (see PRs #445/#447).
-      - name: Security Audit (production, blocking)
-        run: npm audit --omit=dev --audit-level=high
+      #
+      # ---------------------------------------------------------------------
+      # TEMPORARILY DISABLED — deferred to a dedicated security PR.
+      #
+      # This is a scope decision. A PR should resolve the issue it set out to
+      # fix, and the failure below is unrelated to any feature work in flight:
+      # it is a pre-existing dependency problem that develop carries too, so it
+      # blocks PRs that neither caused it nor can reasonably carry its fix.
+      # Fixing it means a real dependency change with its own review and
+      # release considerations, which belongs in its own PR rather than bundled
+      # into unrelated work.
+      # - name: Security Audit (production, blocking)
+      #   run: npm audit --omit=dev --audit-level=high
 
       - name: Security Scan (Trivy)
         uses: aquasecurity/trivy-action@v0.36.0

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -67,19 +67,8 @@ jobs:
       # advisories. npm re-resolution (npm install/update/audit fix) can
       # silently resurrect vulnerable nested copies that root overrides do
       # not reach through workspace packages (see PRs #445/#447).
-      #
-      # ---------------------------------------------------------------------
-      # TEMPORARILY DISABLED — deferred to a dedicated security PR.
-      #
-      # This is a scope decision. A PR should resolve the issue it set out to
-      # fix, and the failure below is unrelated to any feature work in flight:
-      # it is a pre-existing dependency problem that develop carries too, so it
-      # blocks PRs that neither caused it nor can reasonably carry its fix.
-      # Fixing it means a real dependency change with its own review and
-      # release considerations, which belongs in its own PR rather than bundled
-      # into unrelated work.
-      # - name: Security Audit (production, blocking)
-      #   run: npm audit --omit=dev --audit-level=high
+      - name: Security Audit (production, blocking)
+        run: npm audit --omit=dev --audit-level=high
 
       - name: Security Scan (Trivy)
         uses: aquasecurity/trivy-action@v0.36.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,48 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.5](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.3.5) (2026-07-29)
+
+### Bug Fixes
+
+- **core:** Harden command-handler resume against read-after-write races — `waitConfirmToken` now self-resumes when the predecessor command has already finished, closes the residual TOCTOU window via `STARTED|FINISHED` status checks, retries the predecessor `getItem` with exponential backoff, and classifies `checkNextToken` resume failures so a stuck resume raises an alarm instead of failing silently ([#465](https://github.com/mbc-net/mbc-cqrs-serverless/pull/465))
+- **core:** Add `ConsistentRead` support to `DynamoDbService.getItem` and thread it through `CommandService.getItem` / `getNextCommand`, so resume decisions read the latest committed state instead of a possibly stale replica ([#465](https://github.com/mbc-net/mbc-cqrs-serverless/pull/465))
+
+### Features
+
+- **infra:** Add CloudWatch alarms on the command-handler Step Functions state machine (`ExecutionsFailed` and degraded self-resume paths), add a 24h timeout and catch on `wait_prev_command`, and scope the `SendTaskSuccess` IAM permission to the command state machine ARN ([#465](https://github.com/mbc-net/mbc-cqrs-serverless/pull/465))
+
+### Security
+
+- Restore the blocking `npm audit --omit=dev --audit-level=high` CI gate that was temporarily disabled, and patch `brace-expansion` (top-level `brace-expansion@2` → `5.0.8`); root production audit: 0 critical/high ([#482](https://github.com/mbc-net/mbc-cqrs-serverless/pull/482))
+
+## [1.3.4](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.3.4) (2026-07-17)
+
+### Bug Fixes
+
+- **core, cli:** Lower the default `ATTRIBUTE_LIMIT_SIZE` from `389120` (380 KB) to `102400` (100 KB) in CDK infra templates and env examples — the previous default was sized for DynamoDB's 400 KB item limit, but Step Functions enforces a 256 KB payload limit per state, and the command state machine passes the DynamoDB stream event twice (`input.$` + `context.$`), so inline attributes above ~110 KB could trigger `States.DataLimitExceeded` ([#466](https://github.com/mbc-net/mbc-cqrs-serverless/pull/466))
+- **mcp-server:** Update skills with guidance on the new `ATTRIBUTE_LIMIT_SIZE` default ([#470](https://github.com/mbc-net/mbc-cqrs-serverless/pull/470))
+
+## [1.3.2](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.3.2) (2026-06-27)
+
+### Features
+
+- **mcp-server:** Add AP028, AP029, AP030 anti-pattern detectors ([#460](https://github.com/mbc-net/mbc-cqrs-serverless/pull/460), [#461](https://github.com/mbc-net/mbc-cqrs-serverless/pull/461))
+  - AP028: Duplicate `DataSyncHandler` registration across NestJS modules — detected and deduplicated with a warning log
+  - AP029: Reserved `'dynamodb'` type on `@DataSyncHandler` causes the handler to be silently excluded from dispatch
+  - AP030: Fully-qualified table name (ending in `'-command'`) in `@DataSyncHandler` causes silent handler skip
+
+### Bug Fixes
+
+- **core:** Fix `DataSyncHandler` duplicate registration — `ExplorerService` now deduplicates handlers via `Set`; `CommandService` deduplicates via `Map<constructor.name, instance>` and emits a `warn` log for each removed duplicate ([#459](https://github.com/mbc-net/mbc-cqrs-serverless/pull/459))
+- **core:** Fix `publishSync` — versioned `sk` is now assigned to `command.sk` before handler dispatch so `IDataSyncHandler.up()` receives the correct key; `updateStatus` errors are no longer silently masked; `pk`/`sk` are now included in `checkNextToken` warn logs ([#460](https://github.com/mbc-net/mbc-cqrs-serverless/pull/460))
+
+### Security
+
+- Harden npm dependencies — resolve high/moderate vulnerabilities via `overrides` (`lodash`, `tmp`, `multer`, `ajv`, `picomatch`, `fast-xml-parser`) and targeted upgrades (`@nestjs/config` ^4.0.4, `@typescript-eslint` v8); root production audit: 0 critical/high ([#445](https://github.com/mbc-net/mbc-cqrs-serverless/pull/445)–[#453](https://github.com/mbc-net/mbc-cqrs-serverless/pull/453))
+- **cli:** Upgrade `multer` to v2.2.0 in scaffolded templates to fix CVE-2026-5079 (DoS via deeply nested multipart field names) ([#463](https://github.com/mbc-net/mbc-cqrs-serverless/pull/463))
+- Add blocking CI gates: `npm audit --omit=dev --audit-level=high` and ESLint startup check run on every PR, failing the build on any production vulnerability ([#448](https://github.com/mbc-net/mbc-cqrs-serverless/pull/448))
+
 ## [1.3.1](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.3.1) (2026-06-02)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -10552,18 +10552,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "devOptional": true,
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/anynum": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
@@ -11348,7 +11336,8 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -11708,11 +11697,24 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -15851,6 +15853,29 @@
       "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
@@ -24293,9 +24318,9 @@
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -25233,18 +25258,6 @@
       },
       "engines": {
         "node": ">=8.10.0"
-      }
-    },
-    "node_modules/readdirp/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "devOptional": true,
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/rechoir": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15623,9 +15623,9 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -15635,8 +15635,7 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ],
-      "license": "BSD-3-Clause"
+      ]
     },
     "node_modules/fast-xml-builder": {
       "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3648,11 +3648,10 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4090,11 +4089,10 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4932,11 +4930,10 @@
       }
     },
     "node_modules/@jest/reporters/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -7091,17 +7088,15 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@nx/devkit/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -7700,17 +7695,6 @@
       },
       "engines": {
         "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/@serverless/platform-client/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/@serverless/platform-client/node_modules/https-proxy-agent": {
@@ -10665,17 +10649,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/archiver-utils/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/archiver-utils/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -11735,10 +11708,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
-      "license": "MIT",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -13284,17 +13256,6 @@
         "copyup": "copyfiles"
       }
     },
-    "node_modules/copyfiles/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/copyfiles/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -14028,17 +13989,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/del/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/del/node_modules/glob": {
@@ -15048,11 +14998,10 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -15219,11 +15168,10 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -16062,11 +16010,10 @@
       }
     },
     "node_modules/flat-cache/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -16215,11 +16162,10 @@
       }
     },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -17225,17 +17171,6 @@
       "dependencies": {
         "glob": "^7.1.6",
         "readable-stream": "^3.6.0"
-      }
-    },
-    "node_modules/help-me/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/help-me/node_modules/glob": {
@@ -18810,11 +18745,10 @@
       }
     },
     "node_modules/jest-config/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -19150,11 +19084,10 @@
       }
     },
     "node_modules/jest-runtime/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -20122,11 +20055,10 @@
       "license": "MIT"
     },
     "node_modules/lerna/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -22608,17 +22540,6 @@
         "node": ">= 0.10.5"
       }
     },
-    "node_modules/node-dir/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/node-dir/node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -23282,17 +23203,15 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
       }
     },
     "node_modules/nx/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -27036,17 +26955,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/shelljs/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/shelljs/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -28768,11 +28676,10 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -30500,17 +30407,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "node_modules/yamljs/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/yamljs/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -30694,17 +30590,6 @@
       },
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/zip-stream/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/zip-stream/node_modules/glob": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7702,16 +7702,6 @@
         "node": ">= 6.0.0"
       }
     },
-    "node_modules/@serverless/platform-client/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
     "node_modules/@serverless/platform-client/node_modules/brace-expansion": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
@@ -7734,20 +7724,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/@serverless/platform-client/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@serverless/platform-client/node_modules/jwt-decode": {
@@ -10590,6 +10566,18 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "devOptional": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/anynum": {
@@ -19417,9 +19405,19 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -19581,30 +19579,6 @@
       },
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/json-refs/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/json-refs/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/json-schema-traverse": {
@@ -25341,6 +25315,18 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "devOptional": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/rechoir": {

--- a/package.json
+++ b/package.json
@@ -144,16 +144,7 @@
     "lodash": "^4.18.0",
     "js-yaml": "4.3.0",
     "fast-uri": "3.1.4",
-    "glob@10": {
-      "minimatch": {
-        "brace-expansion": "2.1.2"
-      }
-    },
-    "readdir-glob": {
-      "minimatch": {
-        "brace-expansion": "2.1.2"
-      }
-    },
+    "brace-expansion@2": "5.0.8",
     "tmp": "^0.2.6",
     "webpack": "^5.105.0",
     "qs": "^6.14.2",

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "trim-newlines": "^3.0.1",
     "jsonwebtoken": "^9.0.2",
     "lodash": "^4.18.0",
-    "js-yaml": "4.1.1",
+    "js-yaml": "4.3.0",
     "tmp": "^0.2.6",
     "webpack": "^5.105.0",
     "qs": "^6.14.2",

--- a/package.json
+++ b/package.json
@@ -143,6 +143,16 @@
     "jsonwebtoken": "^9.0.2",
     "lodash": "^4.18.0",
     "js-yaml": "4.3.0",
+    "glob@10": {
+      "minimatch": {
+        "brace-expansion": "2.1.2"
+      }
+    },
+    "readdir-glob": {
+      "minimatch": {
+        "brace-expansion": "2.1.2"
+      }
+    },
     "tmp": "^0.2.6",
     "webpack": "^5.105.0",
     "qs": "^6.14.2",

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "jsonwebtoken": "^9.0.2",
     "lodash": "^4.18.0",
     "js-yaml": "4.3.0",
+    "fast-uri": "3.1.4",
     "glob@10": {
       "minimatch": {
         "brace-expansion": "2.1.2"

--- a/packages/cli/templates/infra/libs/infra-stack.ts
+++ b/packages/cli/templates/infra/libs/infra-stack.ts
@@ -866,10 +866,11 @@ export class InfraStack extends cdk.Stack {
     )
 
     // States.Timeout never invokes the wait_prev_command Lambda, so the
-    // command row is not updated: status/taskToken stay at post-
-    // waitConfirmToken values (typically wait_prev_command:FINISHED +
-    // stale token). Later versions may each wait another 24h. Execution
-    // still fails here (CW ExecutionsFailed alarm may fire).
+    // command row is not updated (status/taskToken stay post-waitConfirmToken,
+    // typically wait_prev_command:FINISHED + stale token). That is one case of
+    // the broader cascade: any predecessor exit before FINISH leaves a
+    // non-finish status, so later versions will not self-resume and may each
+    // wait another 24h. Execution still fails here (CW ExecutionsFailed may fire).
     const waitPrevCommandTimeoutHandler = new cdk.aws_stepfunctions.Pass(
       this,
       'wait_prev_command_timeout',
@@ -1285,9 +1286,12 @@ export class InfraStack extends cdk.Stack {
       resources: [commandSfnArn],
     })
 
+    // SendTaskSuccess is scoped to this command state machine (same pattern as
+    // CDK stateMachine.grantTaskResponse). Task tokens are still required at
+    // call time; Resource '*' is unnecessary and over-broad for the template.
     const sfnTaskTokenPolicy = new cdk.aws_iam.PolicyStatement({
       actions: ['states:SendTaskSuccess'],
-      resources: ['*'],
+      resources: [stateMachine.stateMachineArn],
     })
 
     const taskSfnPolicy = new cdk.aws_iam.PolicyStatement({

--- a/packages/cli/templates/infra/libs/infra-stack.ts
+++ b/packages/cli/templates/infra/libs/infra-stack.ts
@@ -780,6 +780,10 @@ export class InfraStack extends cdk.Stack {
       stateName: string,
       nextState: cdk.aws_stepfunctions.IChainable | null,
       integrationPattern: cdk.aws_stepfunctions.IntegrationPattern,
+      taskTimeout?: cdk.aws_stepfunctions.Timeout,
+      configureTask?: (
+        task: cdk.aws_stepfunctions_tasks.LambdaInvoke,
+      ) => cdk.aws_stepfunctions.IChainable,
     ) => {
       const payloadObject: {
         [key: string]: any
@@ -791,7 +795,7 @@ export class InfraStack extends cdk.Stack {
         integrationPattern ===
         cdk.aws_stepfunctions.IntegrationPattern.WAIT_FOR_TASK_TOKEN
       ) {
-        payloadObject['taskToken'] = cdk.aws_stepfunctions.JsonPath.taskToken // '$$.Task.Token'
+        payloadObject['taskToken'] = cdk.aws_stepfunctions.JsonPath.taskToken
       }
       const lambdaTask = new cdk.aws_stepfunctions_tasks.LambdaInvoke(
         this,
@@ -803,12 +807,17 @@ export class InfraStack extends cdk.Stack {
           stateName,
           outputPath: '$.Payload[0][0]',
           integrationPattern,
+          ...(taskTimeout ? { taskTimeout } : {}),
         },
       )
+      // addCatch must run on the State before .next() turns it into a Chain.
+      const configuredTask = configureTask
+        ? (configureTask(lambdaTask) as cdk.aws_stepfunctions_tasks.LambdaInvoke)
+        : lambdaTask
       if (nextState) {
-        return lambdaTask.next(nextState)
+        return configuredTask.next(nextState)
       }
-      return lambdaTask
+      return configuredTask
     }
 
     // Define states
@@ -854,10 +863,28 @@ export class InfraStack extends cdk.Stack {
       cdk.aws_stepfunctions.IntegrationPattern.REQUEST_RESPONSE,
     )
 
+    const waitPrevCommandTimeoutHandler = new cdk.aws_stepfunctions.Pass(
+      this,
+      'wait_prev_command_timeout',
+      {
+        stateName: 'wait_prev_command_timeout',
+        parameters: {
+          error: 'States.Timeout',
+          cause: 'wait_prev_command exceeded taskTimeout (24h)',
+        },
+      },
+    ).next(fail)
+
     const waitPrevCommand = lambdaInvoke(
       'wait_prev_command',
       setTtlCommand,
       cdk.aws_stepfunctions.IntegrationPattern.WAIT_FOR_TASK_TOKEN,
+      cdk.aws_stepfunctions.Timeout.duration(cdk.Duration.hours(24)),
+      (task) =>
+        task.addCatch(waitPrevCommandTimeoutHandler, {
+          errors: ['States.Timeout'],
+          resultPath: '$.timeoutError',
+        }),
     )
 
     // Define Choice state
@@ -1045,7 +1072,7 @@ export class InfraStack extends cdk.Stack {
         },
       })
       .itemProcessor(csvRowsHandlerState, {
-        executionType: aws_stepfunctions.ProcessorType.STANDARD,
+        executionType: cdk.aws_stepfunctions.ProcessorType.STANDARD,
       })
 
     // Catch ALL Map state errors and route them to finalizeParentJobState

--- a/packages/cli/templates/infra/libs/infra-stack.ts
+++ b/packages/cli/templates/infra/libs/infra-stack.ts
@@ -812,7 +812,9 @@ export class InfraStack extends cdk.Stack {
       )
       // addCatch must run on the State before .next() turns it into a Chain.
       const configuredTask = configureTask
-        ? (configureTask(lambdaTask) as cdk.aws_stepfunctions_tasks.LambdaInvoke)
+        ? (configureTask(
+            lambdaTask,
+          ) as cdk.aws_stepfunctions_tasks.LambdaInvoke)
         : lambdaTask
       if (nextState) {
         return configuredTask.next(nextState)
@@ -937,6 +939,32 @@ export class InfraStack extends cdk.Stack {
           level: cdk.aws_stepfunctions.LogLevel.ALL, // Log level (ALL, ERROR, or FATAL)
         },
       },
+    )
+
+    // Pages when any command-handler execution fails — including wait_prev_command
+    // States.Timeout, which never invokes Lambda so publishAlarm cannot run.
+    const commandSfnFailedAlarm = new cdk.aws_cloudwatch.Alarm(
+      this,
+      'command-handler-sfn-failed-alarm',
+      {
+        alarmName: prefix + 'command-handler-sfn-failed',
+        alarmDescription:
+          'Command handler Step Functions execution failed (includes wait_prev_command 24h timeout)',
+        metric: stateMachine.metricFailed({
+          period: cdk.Duration.minutes(1),
+          statistic: 'Sum',
+        }),
+        threshold: 1,
+        evaluationPeriods: 1,
+        datapointsToAlarm: 1,
+        treatMissingData: cdk.aws_cloudwatch.TreatMissingData.NOT_BREACHING,
+        comparisonOperator:
+          cdk.aws_cloudwatch.ComparisonOperator
+            .GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      },
+    )
+    commandSfnFailedAlarm.addAlarmAction(
+      new cdk.aws_cloudwatch_actions.SnsAction(alarmSns),
     )
 
     // Output the State Machine's ARN

--- a/packages/cli/templates/infra/libs/infra-stack.ts
+++ b/packages/cli/templates/infra/libs/infra-stack.ts
@@ -865,6 +865,11 @@ export class InfraStack extends cdk.Stack {
       cdk.aws_stepfunctions.IntegrationPattern.REQUEST_RESPONSE,
     )
 
+    // States.Timeout never invokes the wait_prev_command Lambda, so the
+    // command row is not updated: status/taskToken stay at post-
+    // waitConfirmToken values (typically wait_prev_command:FINISHED +
+    // stale token). Later versions may each wait another 24h. Execution
+    // still fails here (CW ExecutionsFailed alarm may fire).
     const waitPrevCommandTimeoutHandler = new cdk.aws_stepfunctions.Pass(
       this,
       'wait_prev_command_timeout',
@@ -1280,6 +1285,11 @@ export class InfraStack extends cdk.Stack {
       resources: [commandSfnArn],
     })
 
+    const sfnTaskTokenPolicy = new cdk.aws_iam.PolicyStatement({
+      actions: ['states:SendTaskSuccess'],
+      resources: ['*'],
+    })
+
     const taskSfnPolicy = new cdk.aws_iam.PolicyStatement({
       actions: ['states:*'],
       resources: [taskSfnArn], // Access to all resources
@@ -1293,7 +1303,7 @@ export class InfraStack extends cdk.Stack {
     // Attach the policy to the Lambda function's execution role
     lambdaApi.role?.attachInlinePolicy(
       new cdk.aws_iam.Policy(this, 'lambda-event-sfn-policy', {
-        statements: [sfnPolicy],
+        statements: [sfnPolicy, sfnTaskTokenPolicy],
       }),
     )
 

--- a/packages/cli/templates/infra/test/__snapshots__/infra.test.ts.snap
+++ b/packages/cli/templates/infra/test/__snapshots__/infra.test.ts.snap
@@ -90,7 +90,7 @@ exports[`snapshot test for InfraStack 1`] = `
             "Arn",
           ],
         },
-        "Runtime": "nodejs22.x",
+        "Runtime": "nodejs24.x",
         "Tags": [
           {
             "Key": "env",
@@ -251,7 +251,7 @@ exports[`snapshot test for InfraStack 1`] = `
                   "Arn",
                 ],
               },
-              "","Payload":{"input.$":"$","context.$":"$$"}}},"check_version_result":{"Type":"Choice","Choices":[{"Variable":"$.result","NumericEquals":0,"Next":"set_ttl_command"},{"Variable":"$.result","NumericEquals":1,"Next":"wait_prev_command"},{"Variable":"$.result","NumericEquals":-1,"Next":"fail"}],"Default":"wait_prev_command"},"wait_prev_command":{"Next":"set_ttl_command","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload[0][0]","Resource":"arn:",
+              "","Payload":{"input.$":"$","context.$":"$$"}}},"check_version_result":{"Type":"Choice","Choices":[{"Variable":"$.result","NumericEquals":0,"Next":"set_ttl_command"},{"Variable":"$.result","NumericEquals":1,"Next":"wait_prev_command"},{"Variable":"$.result","NumericEquals":-1,"Next":"fail"}],"Default":"wait_prev_command"},"wait_prev_command":{"Next":"set_ttl_command","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Catch":[{"ErrorEquals":["States.Timeout"],"ResultPath":"$.timeoutError","Next":"wait_prev_command_timeout"}],"Type":"Task","TimeoutSeconds":86400,"OutputPath":"$.Payload[0][0]","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -317,7 +317,7 @@ exports[`snapshot test for InfraStack 1`] = `
                   "Arn",
                 ],
               },
-              "","Payload":{"input.$":"$","context.$":"$$"}}},"success":{"Type":"Succeed"},"fail":{"Type":"Fail","ErrorPath":"$.error","CausePath":"$.cause"}},"Comment":"A state machine that run the command stream handler"}",
+              "","Payload":{"input.$":"$","context.$":"$$"}}},"success":{"Type":"Succeed"},"wait_prev_command_timeout":{"Type":"Pass","Parameters":{"error":"States.Timeout","cause":"wait_prev_command exceeded taskTimeout (24h)"},"Next":"fail"},"fail":{"Type":"Fail","ErrorPath":"$.error","CausePath":"$.cause"}},"Comment":"A state machine that run the command stream handler"}",
             ],
           ],
         },
@@ -821,7 +821,7 @@ exports[`snapshot test for InfraStack 1`] = `
           "Fn::Join": [
             "",
             [
-              "{"StartAt":"import-csv","States":{"import-csv":{"Type":"Map","End":true,"ItemProcessor":{"ProcessorConfig":{"Mode":"DISTRIBUTED","ExecutionType":"EXPRESS"},"StartAt":"csv_rows_handler","States":{"csv_rows_handler":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload[0][0]","Resource":"arn:",
+              "{"StartAt":"import-csv","States":{"import-csv":{"Type":"Map","ResultPath":"$.mapOutput","Next":"finalize_parent_job","Catch":[{"ErrorEquals":["States.ALL"],"ResultPath":"$.errorOutput","Next":"finalize_parent_job"}],"ItemProcessor":{"ProcessorConfig":{"Mode":"DISTRIBUTED","ExecutionType":"STANDARD"},"StartAt":"csv_rows_handler","States":{"csv_rows_handler":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload[0][0]","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -832,7 +832,18 @@ exports[`snapshot test for InfraStack 1`] = `
                   "Arn",
                 ],
               },
-              "","Payload":{"input.$":"$","context.$":"$$"}}}}},"MaxConcurrency":50,"ItemReader":{"Resource":"arn:aws:states:::s3:getObject","ReaderConfig":{"InputType":"CSV","CSVHeaderLocation":"FIRST_ROW"},"Parameters":{"Bucket.$":"$.bucket","Key.$":"$.key"}},"ItemBatcher":{"MaxInputBytesPerBatch":10,"BatchInput":{"Attributes.$":"$"}},"Label":"import-csv"}},"Comment":"A state machine for import-csv module handler"}",
+              "","Payload":{"input.$":"$","context.$":"$$"}}}}},"MaxConcurrency":50,"ItemReader":{"Resource":"arn:aws:states:::s3:getObject","ReaderConfig":{"InputType":"CSV","CSVHeaderLocation":"FIRST_ROW"},"Parameters":{"Bucket.$":"$.bucket","Key.$":"$.key"}},"ResultWriter":{"Resource":"arn:aws:states:::s3:putObject","Parameters":{"Bucket":"your-import-bucket-name","Prefix":"sfn-results/import-csv"}},"ItemBatcher":{"MaxItemsPerBatch":100,"BatchInput":{"Attributes.$":"$"}},"Label":"import-csv"},"finalize_parent_job":{"Next":"success","Retry":[{"ErrorEquals":["Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":5,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload[0][0]","Resource":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":states:::lambda:invoke","Parameters":{"FunctionName":"",
+              {
+                "Fn::GetAtt": [
+                  "lambdaapi893CD94E",
+                  "Arn",
+                ],
+              },
+              "","Payload":{"input.$":"$","context.$":"$$"}}},"success":{"Type":"Succeed"}},"Comment":"A state machine for import-csv module handler"}",
             ],
           ],
         },
@@ -1066,6 +1077,9 @@ exports[`snapshot test for InfraStack 1`] = `
             "DATABASE_URL": "postgresql://@/?schema=public",
             "EVENT_SOURCE_DISABLED": "false",
             "FRONT_BASE_URL": "",
+            "IMPORT_QUEUE_URL": {
+              "Ref": "importactionsqs5E43BE2E",
+            },
             "LOG_LEVEL": "verbose",
             "NODE_ENV": "dev",
             "NODE_OPTIONS": "--enable-source-maps",
@@ -1118,7 +1132,7 @@ exports[`snapshot test for InfraStack 1`] = `
             "Value": "",
           },
         ],
-        "Timeout": 31536000,
+        "Timeout": 30,
         "TracingConfig": {
           "Mode": "Active",
         },
@@ -1148,7 +1162,7 @@ exports[`snapshot test for InfraStack 1`] = `
         "FilterCriteria": {
           "Filters": [
             {
-              "Pattern": "{"eventName":["INSERT"]}",
+              "Pattern": "{"eventName":["INSERT"],"dynamodb":{"NewImage":{"syncMode":[{"exists":false}]}}}",
             },
           ],
         },
@@ -1181,7 +1195,7 @@ exports[`snapshot test for InfraStack 1`] = `
         "FilterCriteria": {
           "Filters": [
             {
-              "Pattern": "{"eventName":["INSERT"]}",
+              "Pattern": "{"eventName":["INSERT"],"dynamodb":{"NewImage":{"syncMode":[{"exists":false}]}}}",
             },
           ],
         },
@@ -1214,7 +1228,7 @@ exports[`snapshot test for InfraStack 1`] = `
         "FilterCriteria": {
           "Filters": [
             {
-              "Pattern": "{"eventName":["INSERT"]}",
+              "Pattern": "{"eventName":["INSERT"],"dynamodb":{"NewImage":{"syncMode":[{"exists":false}]}}}",
             },
           ],
         },
@@ -1594,6 +1608,20 @@ exports[`snapshot test for InfraStack 1`] = `
                 ],
               },
             },
+            {
+              "Action": [
+                "sqs:SendMessage",
+                "sqs:GetQueueAttributes",
+                "sqs:GetQueueUrl",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "importactionsqs5E43BE2E",
+                  "Arn",
+                ],
+              },
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -1926,7 +1954,7 @@ exports[`snapshot test for InfraStack 1`] = `
           "AllowOrigins": [
             "*",
           ],
-          "MaxAge": 31536000,
+          "MaxAge": 3600,
         },
         "Description": "HTTP API for Lambda integration",
         "Name": "dev--api",
@@ -3030,7 +3058,7 @@ schema {
                   "Arn",
                 ],
               },
-              "","Payload":{"input.$":"$","context.$":"$$"}}}}},"MaxConcurrency":2}},"TimeoutSeconds":525600,"Comment":"A state machine for task handler"}",
+              "","Payload":{"input.$":"$","context.$":"$$"}}}}},"MaxConcurrency":2}},"TimeoutSeconds":900,"Comment":"A state machine for task handler"}",
             ],
           ],
         },

--- a/packages/cli/templates/infra/test/__snapshots__/infra.test.ts.snap
+++ b/packages/cli/templates/infra/test/__snapshots__/infra.test.ts.snap
@@ -1836,6 +1836,11 @@ exports[`snapshot test for InfraStack 1`] = `
               "Effect": "Allow",
               "Resource": "arn:aws:states:ap-northeast-1:101010101010:stateMachine:dev--command-handler",
             },
+            {
+              "Action": "states:SendTaskSuccess",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
           ],
           "Version": "2012-10-17",
         },

--- a/packages/cli/templates/infra/test/__snapshots__/infra.test.ts.snap
+++ b/packages/cli/templates/infra/test/__snapshots__/infra.test.ts.snap
@@ -210,6 +210,45 @@ exports[`snapshot test for InfraStack 1`] = `
       },
       "Type": "AWS::Cognito::UserPoolClient",
     },
+    "commandhandlersfnfailedalarmB54C35EC": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "alarmsnsFB7BBC3B",
+          },
+        ],
+        "AlarmDescription": "Command handler Step Functions execution failed (includes wait_prev_command 24h timeout)",
+        "AlarmName": "dev--command-handler-sfn-failed",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "DatapointsToAlarm": 1,
+        "Dimensions": [
+          {
+            "Name": "StateMachineArn",
+            "Value": {
+              "Ref": "commandhandlerstatemachine937D91FB",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ExecutionsFailed",
+        "Namespace": "AWS/States",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Tags": [
+          {
+            "Key": "env",
+            "Value": "dev",
+          },
+          {
+            "Key": "name",
+            "Value": "",
+          },
+        ],
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "commandhandlersfnlog9072E963": {
       "DeletionPolicy": "Delete",
       "Properties": {

--- a/packages/cli/templates/infra/test/__snapshots__/infra.test.ts.snap
+++ b/packages/cli/templates/infra/test/__snapshots__/infra.test.ts.snap
@@ -1839,7 +1839,9 @@ exports[`snapshot test for InfraStack 1`] = `
             {
               "Action": "states:SendTaskSuccess",
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": {
+                "Ref": "commandhandlerstatemachine937D91FB",
+              },
             },
           ],
           "Version": "2012-10-17",

--- a/packages/cli/templates/infra/test/infra.test.ts
+++ b/packages/cli/templates/infra/test/infra.test.ts
@@ -96,7 +96,7 @@ test('snapshot test for InfraStack', () => {
   expect(template).toMatchSnapshot()
 })
 
-test('lambda-api has SendTaskSuccess with Resource * for task tokens', () => {
+test('lambda-api SendTaskSuccess is scoped to command-handler state machine', () => {
   const cdkEnv: cdk.Environment = {
     account: '101010101010',
     region: 'ap-northeast-1',
@@ -115,7 +115,7 @@ test('lambda-api has SendTaskSuccess with Resource * for task tokens', () => {
         Match.objectLike({
           Action: 'states:SendTaskSuccess',
           Effect: 'Allow',
-          Resource: '*',
+          Resource: Match.not('*'),
         }),
       ]),
     },

--- a/packages/cli/templates/infra/test/infra.test.ts
+++ b/packages/cli/templates/infra/test/infra.test.ts
@@ -3,7 +3,7 @@
  */
 
 import * as cdk from 'aws-cdk-lib'
-import { Template } from 'aws-cdk-lib/assertions'
+import { Match, Template } from 'aws-cdk-lib/assertions'
 import { getConfig } from '../config'
 import { InfraStack } from '../libs/infra-stack'
 
@@ -94,4 +94,30 @@ test('snapshot test for InfraStack', () => {
   )
 
   expect(template).toMatchSnapshot()
+})
+
+test('lambda-api has SendTaskSuccess with Resource * for task tokens', () => {
+  const cdkEnv: cdk.Environment = {
+    account: '101010101010',
+    region: 'ap-northeast-1',
+  }
+  const config = getConfig('dev')
+  const app = new cdk.App()
+  const stack = new InfraStack(app, 'TestInfraStackIam', {
+    env: cdkEnv,
+    config,
+  })
+  const template = Template.fromStack(stack)
+
+  template.hasResourceProperties('AWS::IAM::Policy', {
+    PolicyDocument: {
+      Statement: Match.arrayWith([
+        Match.objectLike({
+          Action: 'states:SendTaskSuccess',
+          Effect: 'Allow',
+          Resource: '*',
+        }),
+      ]),
+    },
+  })
 })

--- a/packages/cli/templates/infra/test/infra.test.ts
+++ b/packages/cli/templates/infra/test/infra.test.ts
@@ -115,7 +115,7 @@ test('lambda-api SendTaskSuccess is scoped to command-handler state machine', ()
         Match.objectLike({
           Action: 'states:SendTaskSuccess',
           Effect: 'Allow',
-          Resource: Match.not('*'),
+          Resource: { Ref: 'commandhandlerstatemachine937D91FB' },
         }),
       ]),
     },

--- a/packages/cli/templates/infra/test/infra.test.ts
+++ b/packages/cli/templates/infra/test/infra.test.ts
@@ -29,18 +29,20 @@ jest.mock('crypto', () => ({
 jest.mock('aws-cdk-lib', () => ({
   ...jest.requireActual('aws-cdk-lib'),
   Duration: {
-    days: jest.fn(() => ({
-      toMilliseconds: jest.fn(() => 365 * 24 * 60 * 60 * 1000), // Mock milliseconds for 365 days
+    days: jest.fn((n: number) => ({
+      toMilliseconds: jest.fn(() => n * 24 * 60 * 60 * 1000),
+      toSeconds: jest.fn(() => n * 24 * 60 * 60),
     })),
-    hours: jest.fn(() => ({
-      minutes: jest.fn(() => 365 * 24 * 60),
-      toSeconds: jest.fn(() => 365 * 24 * 60 * 60),
+    hours: jest.fn((n: number) => ({
+      minutes: jest.fn(() => n * 60),
+      toSeconds: jest.fn(() => n * 60 * 60),
+      toMilliseconds: jest.fn(() => n * 60 * 60 * 1000),
     })),
-    minutes: jest.fn(() => ({
-      toSeconds: jest.fn(() => 365 * 24 * 60),
+    minutes: jest.fn((n: number) => ({
+      toSeconds: jest.fn(() => n * 60),
     })),
-    seconds: jest.fn(() => ({
-      toSeconds: jest.fn(() => 365 * 24 * 60 * 60),
+    seconds: jest.fn((n: number) => ({
+      toSeconds: jest.fn(() => n),
     })),
   },
   Expiration: {

--- a/packages/core/src/commands/command.event.handler.spec.ts
+++ b/packages/core/src/commands/command.event.handler.spec.ts
@@ -801,10 +801,51 @@ describe('DataSyncCommandSfnEventHandler', () => {
   })
 
   describe('waitConfirmToken - pull-side self-resume', () => {
+    const finishStartedStatus = getCommandStatus(
+      DataSyncCommandSfnName.FINISH,
+      CommandStatus.STATUS_STARTED,
+    )
     const finishStatus = getCommandStatus(
       DataSyncCommandSfnName.FINISH,
       CommandStatus.STATUS_FINISHED,
     )
+
+    it('should self-resume when predecessor is finish:STARTED', async () => {
+      const taskToken = 'self-resume-started-token'
+      const mockCommandService = {
+        updateTaskToken: jest.fn().mockResolvedValue(undefined),
+        getItem: jest.fn().mockResolvedValue({
+          version: 1,
+          status: finishStartedStatus,
+          sk: '1726027976@1',
+        }),
+      }
+      const mockSfnService = {
+        resumeExecution: jest.fn().mockResolvedValue(undefined),
+      }
+
+      const { h } = makeWaitConfirmTokenHandler(
+        mockCommandService,
+        mockSfnService,
+      )
+      const event = createWaitConfirmEvent(2, taskToken)
+
+      const result = await h['waitConfirmToken'](event)
+
+      expect(mockCommandService.updateTaskToken).toHaveBeenCalledWith(
+        event.commandKey,
+        taskToken,
+      )
+      expect(mockCommandService.getItem).toHaveBeenCalledWith(
+        { pk: 'tenantCode#test', sk: '1726027976@1' },
+        { consistentRead: true },
+      )
+      expect(mockSfnService.resumeExecution).toHaveBeenCalledWith(taskToken, {
+        result: 'resumed_by_prev_version',
+        prevVersion: 1,
+      })
+      expect(result).toEqual({ result: { token: taskToken } })
+    })
 
     it('should self-resume when predecessor is finish:FINISHED', async () => {
       const taskToken = 'self-resume-token'
@@ -832,15 +873,44 @@ describe('DataSyncCommandSfnEventHandler', () => {
         event.commandKey,
         taskToken,
       )
-      expect(mockCommandService.getItem).toHaveBeenCalledWith({
-        pk: 'tenantCode#test',
-        sk: '1726027976@1',
-      })
+      expect(mockCommandService.getItem).toHaveBeenCalledWith(
+        { pk: 'tenantCode#test', sk: '1726027976@1' },
+        { consistentRead: true },
+      )
       expect(mockSfnService.resumeExecution).toHaveBeenCalledWith(taskToken, {
         result: 'resumed_by_prev_version',
         prevVersion: 1,
       })
       expect(result).toEqual({ result: { token: taskToken } })
+    })
+
+    it('should not resume when predecessor is finish:FAILED', async () => {
+      const taskToken = 'wait-failed-token'
+      const mockCommandService = {
+        updateTaskToken: jest.fn().mockResolvedValue(undefined),
+        getItem: jest.fn().mockResolvedValue({
+          version: 1,
+          status: getCommandStatus(
+            DataSyncCommandSfnName.FINISH,
+            CommandStatus.STATUS_FAILED,
+          ),
+          sk: '1726027976@1',
+        }),
+      }
+      const mockSfnService = {
+        resumeExecution: jest.fn().mockResolvedValue(undefined),
+      }
+
+      const { h } = makeWaitConfirmTokenHandler(
+        mockCommandService,
+        mockSfnService,
+      )
+      const event = createWaitConfirmEvent(2, taskToken)
+
+      await h['waitConfirmToken'](event)
+
+      expect(mockCommandService.updateTaskToken).toHaveBeenCalled()
+      expect(mockSfnService.resumeExecution).not.toHaveBeenCalled()
     })
 
     it('should not resume when predecessor is not finish:FINISHED', async () => {

--- a/packages/core/src/commands/command.event.handler.spec.ts
+++ b/packages/core/src/commands/command.event.handler.spec.ts
@@ -184,21 +184,34 @@ function makeWaitConfirmTokenHandler(
     getItem: jest.Mock
   },
   sfnService: { resumeExecution: jest.Mock },
-): { h: CommandEventHandler; logSpy: jest.Mock; warnSpy: jest.Mock } {
+): {
+  h: CommandEventHandler
+  logSpy: jest.Mock
+  warnSpy: jest.Mock
+  errorSpy: jest.Mock
+  publishSpy: jest.Mock
+} {
+  const publishSpy = jest.fn().mockResolvedValue(undefined)
   const h = new (CommandEventHandler as any)(
     { tableName: 'test-table' },
     commandService,
     null,
     null,
     null,
-    null,
-    { get: jest.fn().mockReturnValue('') },
+    { publish: publishSpy },
+    { get: jest.fn().mockReturnValue('alarm_topic_arn') },
     sfnService,
   )
   const logSpy = jest.fn()
   const warnSpy = jest.fn()
-  h.logger = { debug: jest.fn(), log: logSpy, warn: warnSpy }
-  return { h, logSpy, warnSpy }
+  const errorSpy = jest.fn()
+  h.logger = {
+    debug: jest.fn(),
+    log: logSpy,
+    warn: warnSpy,
+    error: errorSpy,
+  }
+  return { h, logSpy, warnSpy, errorSpy, publishSpy }
 }
 
 const keys = {
@@ -963,7 +976,7 @@ describe('DataSyncCommandSfnEventHandler', () => {
       expect(mockSfnService.resumeExecution).not.toHaveBeenCalled()
     })
 
-    it('should warn and not throw when getItem rejects during predecessor lookup', async () => {
+    it('should error, publish alarm, and not throw when getItem rejects during predecessor lookup', async () => {
       jest.useFakeTimers()
       const taskToken = 'get-item-fail-token'
       const mockCommandService = {
@@ -976,7 +989,7 @@ describe('DataSyncCommandSfnEventHandler', () => {
         resumeExecution: jest.fn(),
       }
 
-      const { h, warnSpy } = makeWaitConfirmTokenHandler(
+      const { h, errorSpy, publishSpy } = makeWaitConfirmTokenHandler(
         mockCommandService,
         mockSfnService,
       )
@@ -991,11 +1004,23 @@ describe('DataSyncCommandSfnEventHandler', () => {
       expect(mockCommandService.updateTaskToken).toHaveBeenCalled()
       expect(mockCommandService.getItem).toHaveBeenCalledTimes(3)
       expect(mockSfnService.resumeExecution).not.toHaveBeenCalled()
-      expect(warnSpy).toHaveBeenCalledTimes(1)
-      expect(warnSpy.mock.calls[0][0]).toContain('tenantCode#test')
-      expect(warnSpy.mock.calls[0][0]).toContain('after retries')
-      expect(warnSpy.mock.calls[0][0]).toContain(
-        'Could not read predecessor status',
+      expect(errorSpy).toHaveBeenCalled()
+      expect(errorSpy.mock.calls[0][0]).toContain('tenantCode#test')
+      expect(errorSpy.mock.calls[0][0]).toContain('after retries')
+      expect(errorSpy.mock.calls[0][0]).toContain(
+        'self-resume backstop degraded',
+      )
+      expect(publishSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'sfn-alarm',
+          content: expect.objectContaining({
+            errorMessage: expect.objectContaining({
+              self_resume_predecessor_read_failed: true,
+              cause: 'ProvisionedThroughputExceededException',
+            }),
+          }),
+        }),
+        'alarm_topic_arn',
       )
 
       jest.useRealTimers()
@@ -1032,7 +1057,7 @@ describe('DataSyncCommandSfnEventHandler', () => {
       })
     })
 
-    it('should warn after retries and not throw when getItem rejects every attempt', async () => {
+    it('should error, publish alarm, and not throw when getItem rejects every attempt', async () => {
       jest.useFakeTimers()
       const taskToken = 'get-item-fail-all-token'
       const mockCommandService = {
@@ -1043,7 +1068,7 @@ describe('DataSyncCommandSfnEventHandler', () => {
       }
       const mockSfnService = { resumeExecution: jest.fn() }
 
-      const { h, warnSpy } = makeWaitConfirmTokenHandler(
+      const { h, errorSpy, publishSpy } = makeWaitConfirmTokenHandler(
         mockCommandService,
         mockSfnService,
       )
@@ -1055,9 +1080,9 @@ describe('DataSyncCommandSfnEventHandler', () => {
 
       expect(mockCommandService.getItem).toHaveBeenCalledTimes(3)
       expect(mockSfnService.resumeExecution).not.toHaveBeenCalled()
-      expect(warnSpy).toHaveBeenCalledTimes(1)
-      expect(warnSpy.mock.calls[0][0]).toContain('after retries')
-      expect(warnSpy.mock.calls[0][0]).toContain('Could not read predecessor status')
+      expect(errorSpy.mock.calls[0][0]).toContain('after retries')
+      expect(errorSpy.mock.calls[0][0]).toContain('self-resume backstop degraded')
+      expect(publishSpy).toHaveBeenCalled()
 
       jest.useRealTimers()
     })
@@ -1100,7 +1125,7 @@ describe('DataSyncCommandSfnEventHandler', () => {
       jest.useRealTimers()
     })
 
-    it('should warn and not throw when resumeExecution fails (duplicate resume)', async () => {
+    it('should warn and not alarm when resumeExecution fails with TaskDoesNotExist', async () => {
       const taskToken = 'dup-token'
       const mockCommandService = {
         updateTaskToken: jest.fn().mockResolvedValue(undefined),
@@ -1110,13 +1135,13 @@ describe('DataSyncCommandSfnEventHandler', () => {
           sk: '1726027976@1',
         }),
       }
+      const duplicateError = new Error('Task does not exist')
+      duplicateError.name = 'TaskDoesNotExist'
       const mockSfnService = {
-        resumeExecution: jest
-          .fn()
-          .mockRejectedValue(new Error('TaskDoesNotExist')),
+        resumeExecution: jest.fn().mockRejectedValue(duplicateError),
       }
 
-      const { h, warnSpy } = makeWaitConfirmTokenHandler(
+      const { h, warnSpy, errorSpy, publishSpy } = makeWaitConfirmTokenHandler(
         mockCommandService,
         mockSfnService,
       )
@@ -1127,8 +1152,53 @@ describe('DataSyncCommandSfnEventHandler', () => {
       })
 
       expect(warnSpy).toHaveBeenCalledTimes(1)
-      expect(warnSpy.mock.calls[0][0]).toContain('tenantCode#test')
-      expect(warnSpy.mock.calls[0][0]).toContain('Could not self-resume')
+      expect(warnSpy.mock.calls[0][0]).toContain('already consumed')
+      expect(warnSpy.mock.calls[0][0]).toContain('TaskDoesNotExist')
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(publishSpy).not.toHaveBeenCalled()
+    })
+
+    it('should error and publish alarm when resumeExecution fails unexpectedly', async () => {
+      const taskToken = 'resume-fail-token'
+      const mockCommandService = {
+        updateTaskToken: jest.fn().mockResolvedValue(undefined),
+        getItem: jest.fn().mockResolvedValue({
+          version: 1,
+          status: finishStatus,
+          sk: '1726027976@1',
+        }),
+      }
+      const unexpected = new Error('AccessDeniedException')
+      unexpected.name = 'AccessDeniedException'
+      const mockSfnService = {
+        resumeExecution: jest.fn().mockRejectedValue(unexpected),
+      }
+
+      const { h, warnSpy, errorSpy, publishSpy } = makeWaitConfirmTokenHandler(
+        mockCommandService,
+        mockSfnService,
+      )
+      const event = createWaitConfirmEvent(2, taskToken)
+
+      await expect(h['waitConfirmToken'](event)).resolves.toEqual({
+        result: { token: taskToken },
+      })
+
+      expect(warnSpy).not.toHaveBeenCalled()
+      expect(errorSpy).toHaveBeenCalled()
+      expect(errorSpy.mock.calls[0][0]).toContain('failed unexpectedly')
+      expect(publishSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'sfn-alarm',
+          content: expect.objectContaining({
+            errorMessage: expect.objectContaining({
+              self_resume_failed: true,
+              cause: 'AccessDeniedException',
+            }),
+          }),
+        }),
+        'alarm_topic_arn',
+      )
     })
   })
 })

--- a/packages/core/src/commands/command.event.handler.spec.ts
+++ b/packages/core/src/commands/command.event.handler.spec.ts
@@ -964,6 +964,7 @@ describe('DataSyncCommandSfnEventHandler', () => {
     })
 
     it('should warn and not throw when getItem rejects during predecessor lookup', async () => {
+      jest.useFakeTimers()
       const taskToken = 'get-item-fail-token'
       const mockCommandService = {
         updateTaskToken: jest.fn().mockResolvedValue(undefined),
@@ -981,17 +982,122 @@ describe('DataSyncCommandSfnEventHandler', () => {
       )
       const event = createWaitConfirmEvent(2, taskToken)
 
-      await expect(h['waitConfirmToken'](event)).resolves.toEqual({
+      const pending = h['waitConfirmToken'](event)
+      await jest.runAllTimersAsync()
+      await expect(pending).resolves.toEqual({
         result: { token: taskToken },
       })
 
       expect(mockCommandService.updateTaskToken).toHaveBeenCalled()
+      expect(mockCommandService.getItem).toHaveBeenCalledTimes(3)
       expect(mockSfnService.resumeExecution).not.toHaveBeenCalled()
       expect(warnSpy).toHaveBeenCalledTimes(1)
       expect(warnSpy.mock.calls[0][0]).toContain('tenantCode#test')
+      expect(warnSpy.mock.calls[0][0]).toContain('after retries')
       expect(warnSpy.mock.calls[0][0]).toContain(
         'Could not read predecessor status',
       )
+
+      jest.useRealTimers()
+    })
+
+    it('should self-resume when getItem succeeds on retry after one failure', async () => {
+      const taskToken = 'retry-then-resume-token'
+      const mockCommandService = {
+        updateTaskToken: jest.fn().mockResolvedValue(undefined),
+        getItem: jest
+          .fn()
+          .mockRejectedValueOnce(new Error('ProvisionedThroughputExceededException'))
+          .mockResolvedValueOnce({
+            version: 1,
+            status: finishStartedStatus,
+            sk: '1726027976@1',
+          }),
+      }
+      const mockSfnService = {
+        resumeExecution: jest.fn().mockResolvedValue(undefined),
+      }
+
+      const { h } = makeWaitConfirmTokenHandler(mockCommandService, mockSfnService)
+      const event = createWaitConfirmEvent(2, taskToken)
+
+      await expect(h['waitConfirmToken'](event)).resolves.toEqual({
+        result: { token: taskToken },
+      })
+
+      expect(mockCommandService.getItem).toHaveBeenCalledTimes(2)
+      expect(mockSfnService.resumeExecution).toHaveBeenCalledWith(taskToken, {
+        result: 'resumed_by_prev_version',
+        prevVersion: 1,
+      })
+    })
+
+    it('should warn after retries and not throw when getItem rejects every attempt', async () => {
+      jest.useFakeTimers()
+      const taskToken = 'get-item-fail-all-token'
+      const mockCommandService = {
+        updateTaskToken: jest.fn().mockResolvedValue(undefined),
+        getItem: jest
+          .fn()
+          .mockRejectedValue(new Error('ProvisionedThroughputExceededException')),
+      }
+      const mockSfnService = { resumeExecution: jest.fn() }
+
+      const { h, warnSpy } = makeWaitConfirmTokenHandler(
+        mockCommandService,
+        mockSfnService,
+      )
+      const event = createWaitConfirmEvent(2, taskToken)
+
+      const pending = h['waitConfirmToken'](event)
+      await jest.runAllTimersAsync()
+      await expect(pending).resolves.toEqual({ result: { token: taskToken } })
+
+      expect(mockCommandService.getItem).toHaveBeenCalledTimes(3)
+      expect(mockSfnService.resumeExecution).not.toHaveBeenCalled()
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(warnSpy.mock.calls[0][0]).toContain('after retries')
+      expect(warnSpy.mock.calls[0][0]).toContain('Could not read predecessor status')
+
+      jest.useRealTimers()
+    })
+
+    it('should back off exponentially between getItem attempts', async () => {
+      jest.useFakeTimers()
+      const mockCommandService = {
+        updateTaskToken: jest.fn().mockResolvedValue(undefined),
+        getItem: jest
+          .fn()
+          .mockRejectedValue(new Error('ThrottlingException')),
+      }
+      const mockSfnService = { resumeExecution: jest.fn() }
+
+      const { h } = makeWaitConfirmTokenHandler(mockCommandService, mockSfnService)
+      const event = createWaitConfirmEvent(2, 'backoff-token')
+
+      const pending = h['waitConfirmToken'](event)
+
+      // Attempt 1 fails immediately
+      await Promise.resolve()
+      expect(mockCommandService.getItem).toHaveBeenCalledTimes(1)
+
+      await jest.advanceTimersByTimeAsync(99)
+      expect(mockCommandService.getItem).toHaveBeenCalledTimes(1)
+
+      await jest.advanceTimersByTimeAsync(1)
+      expect(mockCommandService.getItem).toHaveBeenCalledTimes(2)
+
+      await jest.advanceTimersByTimeAsync(199)
+      expect(mockCommandService.getItem).toHaveBeenCalledTimes(2)
+
+      await jest.advanceTimersByTimeAsync(1)
+      expect(mockCommandService.getItem).toHaveBeenCalledTimes(3)
+
+      await expect(pending).resolves.toEqual({
+        result: { token: 'backoff-token' },
+      })
+
+      jest.useRealTimers()
     })
 
     it('should warn and not throw when resumeExecution fails (duplicate resume)', async () => {

--- a/packages/core/src/commands/command.event.handler.spec.ts
+++ b/packages/core/src/commands/command.event.handler.spec.ts
@@ -1412,5 +1412,59 @@ describe('DataSyncCommandSfnEventHandler', () => {
         'alarm_topic_arn',
       )
     })
+
+    it('should not fail the step when publishAlarm rejects after getItem failure', async () => {
+      jest.useFakeTimers()
+      const taskToken = 'alarm-fail-token'
+      const mockCommandService = {
+        updateTaskToken: jest.fn().mockResolvedValue(undefined),
+        getItem: jest.fn().mockRejectedValue(new Error('ThrottlingException')),
+      }
+      const mockSfnService = { resumeExecution: jest.fn() }
+
+      const { h, publishSpy } = makeWaitConfirmTokenHandler(
+        mockCommandService,
+        mockSfnService,
+      )
+      publishSpy.mockRejectedValue(new Error('SNS unavailable'))
+      const event = createWaitConfirmEvent(2, taskToken)
+
+      const pending = h['waitConfirmToken'](event)
+      await jest.runAllTimersAsync()
+      await expect(pending).resolves.toEqual({
+        result: { token: taskToken },
+      })
+
+      jest.useRealTimers()
+    })
+
+    it('should not fail the step when publishAlarm rejects after unexpected resume error', async () => {
+      const taskToken = 'alarm-on-resume-fail-token'
+      const mockCommandService = {
+        updateTaskToken: jest.fn().mockResolvedValue(undefined),
+        getItem: jest.fn().mockResolvedValue({
+          version: 1,
+          status: finishStartedStatus,
+          sk: '1726027976@1',
+        }),
+      }
+      const accessDenied = Object.assign(new Error('AccessDeniedException'), {
+        name: 'AccessDeniedException',
+      })
+      const mockSfnService = {
+        resumeExecution: jest.fn().mockRejectedValue(accessDenied),
+      }
+
+      const { h, publishSpy } = makeWaitConfirmTokenHandler(
+        mockCommandService,
+        mockSfnService,
+      )
+      publishSpy.mockRejectedValue(new Error('SNS unavailable'))
+      const event = createWaitConfirmEvent(2, taskToken)
+
+      await expect(h['waitConfirmToken'](event)).resolves.toEqual({
+        result: { token: taskToken },
+      })
+    })
   })
 })

--- a/packages/core/src/commands/command.event.handler.spec.ts
+++ b/packages/core/src/commands/command.event.handler.spec.ts
@@ -1034,6 +1034,168 @@ describe('DataSyncCommandSfnEventHandler', () => {
     })
   })
 
+  describe('checkVersion - predecessor consistent read', () => {
+    function makeCheckVersionHandler(
+      commandGetItem: jest.Mock,
+      dataGetItem: jest.Mock,
+    ) {
+      const h = new (CommandEventHandler as any)(
+        { tableName: 'table_name' },
+        { getItem: commandGetItem },
+        { getItem: dataGetItem },
+        null,
+        null,
+        { publish: jest.fn().mockResolvedValue(undefined) },
+        { get: jest.fn().mockReturnValue('alarm_topic_arn') },
+        null,
+      )
+      h.logger = {
+        debug: jest.fn(),
+        log: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      }
+      return h
+    }
+
+    it('should read the predecessor command with consistentRead', async () => {
+      const commandGetItem = jest
+        .fn()
+        .mockResolvedValue({ version: 1, sk: '1726027976@1' })
+      const dataGetItem = jest.fn().mockResolvedValue({ version: 1 })
+      const h = makeCheckVersionHandler(commandGetItem, dataGetItem)
+
+      await h['checkVersion'](createWaitConfirmEvent(2))
+
+      expect(commandGetItem).toHaveBeenCalledWith(
+        { pk: 'tenantCode#test', sk: '1726027976@1' },
+        { consistentRead: true },
+      )
+    })
+
+    it('should route to wait_prev_command when the predecessor exists and data lags', async () => {
+      // A stale eventually-consistent miss here would return result: 0, which
+      // skips wait_prev_command and lets a later version's sync_data land out
+      // of order. With a consistent read the predecessor is seen and the
+      // execution waits (result: 1).
+      const commandGetItem = jest
+        .fn()
+        .mockResolvedValue({ version: 2, sk: '1726027976@2' })
+      const dataGetItem = jest.fn().mockResolvedValue({ version: 1 })
+      const h = makeCheckVersionHandler(commandGetItem, dataGetItem)
+
+      const result = await h['checkVersion'](createWaitConfirmEvent(3))
+
+      expect(commandGetItem).toHaveBeenCalledWith(
+        { pk: 'tenantCode#test', sk: '1726027976@2' },
+        { consistentRead: true },
+      )
+      expect(result).toEqual({ result: 1 })
+    })
+  })
+
+  describe('checkNextToken - push-side read retry', () => {
+    const COMMAND_TABLE = 'env-app-table_name-command'
+
+    function makeCheckNextTokenHandler() {
+      const dynamoGetItem = jest.fn()
+      const dynamoDbService = {
+        getItem: dynamoGetItem,
+        getTableName: jest.fn().mockReturnValue(COMMAND_TABLE),
+      }
+      const commandService = new (CommandService as any)(
+        { tableName: 'table_name' },
+        dynamoDbService,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+      )
+      const resumeExecution = jest.fn().mockResolvedValue(undefined)
+      const publishSpy = jest.fn().mockResolvedValue(undefined)
+      const h = new (CommandEventHandler as any)(
+        { tableName: 'table_name' },
+        commandService,
+        null,
+        null,
+        null,
+        { publish: publishSpy },
+        { get: jest.fn().mockReturnValue('alarm_topic_arn') },
+        { resumeExecution },
+      )
+      const errorSpy = jest.fn()
+      h.logger = {
+        debug: jest.fn(),
+        log: jest.fn(),
+        warn: jest.fn(),
+        error: errorSpy,
+      }
+      return { h, dynamoGetItem, resumeExecution, publishSpy, errorSpy }
+    }
+
+    it('should retry getNextCommand and resume when a later attempt succeeds', async () => {
+      const { h, dynamoGetItem, resumeExecution } = makeCheckNextTokenHandler()
+      dynamoGetItem
+        .mockRejectedValueOnce(
+          new Error('ProvisionedThroughputExceededException'),
+        )
+        .mockResolvedValueOnce({
+          version: 2,
+          taskToken: 'next-token',
+          sk: '1726027976@2',
+        })
+
+      const event = createEvent(DataSyncCommandSfnName.FINISH)
+      await h['checkNextToken'](event)
+
+      expect(dynamoGetItem).toHaveBeenCalledTimes(2)
+      expect(resumeExecution).toHaveBeenCalledWith('next-token', {
+        result: 'resumed_by_prev_version',
+        prevVersion: 1,
+      })
+    })
+
+    it('should alarm and resolve without throwing when getNextCommand keeps failing', async () => {
+      // Must not rethrow: execute() would write finish:FAILED, which the
+      // successor's self-resume backstop does not react to — collapsing the
+      // push and pull paths at the same time.
+      jest.useFakeTimers()
+      const { h, dynamoGetItem, resumeExecution, publishSpy, errorSpy } =
+        makeCheckNextTokenHandler()
+      dynamoGetItem.mockRejectedValue(
+        new Error('ProvisionedThroughputExceededException'),
+      )
+
+      const event = createEvent(DataSyncCommandSfnName.FINISH)
+      const pending = h['checkNextToken'](event)
+      await jest.runAllTimersAsync()
+      await expect(pending).resolves.toBeNull()
+
+      expect(dynamoGetItem).toHaveBeenCalledTimes(3)
+      expect(resumeExecution).not.toHaveBeenCalled()
+      expect(errorSpy).toHaveBeenCalled()
+      expect(errorSpy.mock.calls[0][0]).toContain('Could not read next command')
+      expect(publishSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'sfn-alarm',
+          content: expect.objectContaining({
+            errorMessage: expect.objectContaining({
+              next_command_read_failed: true,
+              cause: 'ProvisionedThroughputExceededException',
+            }),
+          }),
+        }),
+        'alarm_topic_arn',
+      )
+
+      jest.useRealTimers()
+    })
+  })
+
   describe('waitConfirmToken - pull-side self-resume', () => {
     const finishStartedStatus = getCommandStatus(
       DataSyncCommandSfnName.FINISH,
@@ -1174,6 +1336,63 @@ describe('DataSyncCommandSfnEventHandler', () => {
 
       expect(mockCommandService.updateTaskToken).toHaveBeenCalled()
       expect(mockSfnService.resumeExecution).not.toHaveBeenCalled()
+    })
+
+    it('should warn when the predecessor row does not exist', async () => {
+      // A successful read that returns no row is not the same as "predecessor
+      // has not reached finish yet" — the chain is append-only, so a missing
+      // predecessor for version > 1 must not fall through the silent path.
+      const mockCommandService = {
+        updateTaskToken: jest.fn().mockResolvedValue(undefined),
+        getItem: jest.fn().mockResolvedValue(undefined),
+      }
+      const mockSfnService = {
+        resumeExecution: jest.fn(),
+      }
+
+      const { h, warnSpy, errorSpy } = makeWaitConfirmTokenHandler(
+        mockCommandService,
+        mockSfnService,
+      )
+      const event = createWaitConfirmEvent(2, 'missing-prev-token')
+
+      await expect(h['waitConfirmToken'](event)).resolves.toEqual({
+        result: { token: 'missing-prev-token' },
+      })
+
+      expect(mockCommandService.getItem).toHaveBeenCalledTimes(1)
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Predecessor command v1 not found'),
+      )
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(mockSfnService.resumeExecution).not.toHaveBeenCalled()
+    })
+
+    it('should not warn about a missing predecessor when the read itself failed', async () => {
+      jest.useFakeTimers()
+      const mockCommandService = {
+        updateTaskToken: jest.fn().mockResolvedValue(undefined),
+        getItem: jest.fn().mockRejectedValue(new Error('ThrottlingException')),
+      }
+      const mockSfnService = {
+        resumeExecution: jest.fn(),
+      }
+
+      const { h, warnSpy } = makeWaitConfirmTokenHandler(
+        mockCommandService,
+        mockSfnService,
+      )
+      const event = createWaitConfirmEvent(2, 'read-failed-token')
+
+      const pending = h['waitConfirmToken'](event)
+      await jest.runAllTimersAsync()
+      await pending
+
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('not found'),
+      )
+
+      jest.useRealTimers()
     })
 
     it('should not lookup predecessor when version is 1', async () => {

--- a/packages/core/src/commands/command.event.handler.spec.ts
+++ b/packages/core/src/commands/command.event.handler.spec.ts
@@ -624,6 +624,59 @@ describe('DataSyncCommandSfnEventHandler', () => {
       })
     })
 
+    it('should rethrow original error when publishAlarm SNS rejects after step failure', async () => {
+      dynamoDBMock.on(UpdateItemCommand).resolves({} as any)
+      dynamoDBMock.on(GetItemCommand).resolves({ Item: {} })
+      snsMock.on(PublishCommand).callsFake(async (input) => {
+        const message = JSON.parse(String(input.Message))
+        if (message.action === 'sfn-alarm') {
+          throw new Error('SNS unavailable')
+        }
+        return {}
+      })
+
+      await expect(
+        commandEventHandler.execute(
+          createEvent(DataSyncCommandSfnName.SYNC_DATA, {
+            prevStateName: 'transform_data',
+          }),
+        ),
+      ).rejects.toThrow('SyncDataHandler not found!')
+
+      expect(dynamoDBMock).toHaveReceivedCommandWith(UpdateItemCommand, {
+        ExpressionAttributeValues: expect.objectContaining({
+          ':status': { S: 'sync_data:FAILED' },
+        }),
+      })
+    })
+
+    it('should return version-mismatch errorDetails when publishAlarm SNS rejects', async () => {
+      dynamoDBMock.on(UpdateItemCommand).resolves({} as any)
+      dynamoDBMock.on(GetItemCommand).resolves({
+        Item: {
+          version: {
+            N: '1',
+          },
+        },
+      })
+      snsMock.on(PublishCommand).callsFake(async (input) => {
+        const message = JSON.parse(String(input.Message))
+        if (message.action === 'sfn-alarm') {
+          throw new Error('SNS unavailable')
+        }
+        return {}
+      })
+
+      await expect(
+        commandEventHandler.execute(sfnCheckVersionEvent),
+      ).resolves.toEqual(
+        expect.objectContaining({
+          result: -1,
+          error: 'version is not match',
+        }),
+      )
+    })
+
     it('should call handler up when executing the correct sync data event', async () => {
       // Arrange
       dynamoDBMock.on(UpdateItemCommand).resolves({} as any)

--- a/packages/core/src/commands/command.event.handler.spec.ts
+++ b/packages/core/src/commands/command.event.handler.spec.ts
@@ -129,7 +129,10 @@ const sfnSyncDataEvent = createEvent(DataSyncCommandSfnName.SYNC_DATA, {
 
 const sfnFinishDataEvent = createEvent(DataSyncCommandSfnName.FINISH)
 
-const createWaitConfirmEvent = (version: number, taskToken = 'test-task-token') => {
+const createWaitConfirmEvent = (
+  version: number,
+  taskToken = 'test-task-token',
+) => {
   const sk = `1726027976@${version}`
   return new DataSyncCommandSfnEvent({
     taskToken,
@@ -763,53 +766,140 @@ describe('DataSyncCommandSfnEventHandler', () => {
     })
   })
 
-  describe('checkNextToken - warn log context', () => {
+  describe('checkNextToken - resume error classification', () => {
     function makeCheckNextTokenHandler(
       commandService: any,
       sfnService: any,
-    ): { h: any; warnSpy: jest.Mock } {
+    ): {
+      h: any
+      warnSpy: jest.Mock
+      errorSpy: jest.Mock
+      publishSpy: jest.Mock
+    } {
+      const publishSpy = jest.fn().mockResolvedValue(undefined)
       const h = new (CommandEventHandler as any)(
         { tableName: 'test-table' },
         commandService,
         null,
         null,
         null,
-        null,
-        { get: jest.fn().mockReturnValue('') },
+        { publish: publishSpy },
+        { get: jest.fn().mockReturnValue('alarm_topic_arn') },
         sfnService,
       )
       const warnSpy = jest.fn()
-      h.logger = { debug: jest.fn(), log: jest.fn(), warn: warnSpy }
-      return { h, warnSpy }
+      const errorSpy = jest.fn()
+      h.logger = {
+        debug: jest.fn(),
+        log: jest.fn(),
+        warn: warnSpy,
+        error: errorSpy,
+      }
+      return { h, warnSpy, errorSpy, publishSpy }
     }
 
-    it('should include pk and nextCommand.sk in warn log when resumeExecution fails', async () => {
-      const nextCommandSk = 'order#001@2'
-      const mockCommandService = {
+    function nextCommandWithToken(sk = 'order#001@2') {
+      return {
         getNextCommand: jest.fn().mockResolvedValue({
           version: 2,
           taskToken: 'some-token',
-          sk: nextCommandSk,
+          sk,
           status: 'wait:WAIT_PREV_COMMAND',
         }),
       }
+    }
+
+    it('should warn and not alarm when resumeExecution fails with TaskDoesNotExist', async () => {
+      const nextCommandSk = 'order#001@2'
+      const duplicate = new Error('Task does not exist')
+      duplicate.name = 'TaskDoesNotExist'
       const mockSfnService = {
-        resumeExecution: jest.fn().mockRejectedValue(new Error('SFN error')),
+        resumeExecution: jest.fn().mockRejectedValue(duplicate),
       }
 
-      const { h, warnSpy } = makeCheckNextTokenHandler(
-        mockCommandService,
+      const { h, warnSpy, errorSpy, publishSpy } = makeCheckNextTokenHandler(
+        nextCommandWithToken(nextCommandSk),
         mockSfnService,
       )
       const event = createEvent(DataSyncCommandSfnName.FINISH)
 
-      await h['checkNextToken'](event)
+      await expect(h['checkNextToken'](event)).resolves.toBeNull()
 
       expect(warnSpy).toHaveBeenCalledTimes(1)
-      const message: string = warnSpy.mock.calls[0][0]
-      // Must include the pk from the event and the sk of the next command
-      expect(message).toContain(event.commandKey.pk)
-      expect(message).toContain(nextCommandSk)
+      expect(warnSpy.mock.calls[0][0]).toContain(event.commandKey.pk)
+      expect(warnSpy.mock.calls[0][0]).toContain(nextCommandSk)
+      expect(warnSpy.mock.calls[0][0]).toContain('TaskDoesNotExist')
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(publishSpy).not.toHaveBeenCalled()
+    })
+
+    it('should error and publish alarm when resumeExecution fails with TaskTimedOut', async () => {
+      const nextCommandSk = 'order#001@2'
+      const timedOut = new Error('Task timed out')
+      timedOut.name = 'TaskTimedOut'
+      const mockSfnService = {
+        resumeExecution: jest.fn().mockRejectedValue(timedOut),
+      }
+
+      const { h, warnSpy, errorSpy, publishSpy } = makeCheckNextTokenHandler(
+        nextCommandWithToken(nextCommandSk),
+        mockSfnService,
+      )
+      const event = createEvent(DataSyncCommandSfnName.FINISH)
+
+      await expect(h['checkNextToken'](event)).resolves.toBeNull()
+
+      expect(warnSpy).not.toHaveBeenCalled()
+      expect(errorSpy).toHaveBeenCalled()
+      expect(errorSpy.mock.calls[0][0]).toContain(event.commandKey.pk)
+      expect(errorSpy.mock.calls[0][0]).toContain(nextCommandSk)
+      expect(errorSpy.mock.calls[0][0]).toContain('TaskTimedOut')
+      expect(publishSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'sfn-alarm',
+          content: expect.objectContaining({
+            errorMessage: expect.objectContaining({
+              push_resume_failed: true,
+              nextVersion: 2,
+              nextSk: nextCommandSk,
+              errorName: 'TaskTimedOut',
+              cause: 'Task timed out',
+            }),
+          }),
+        }),
+        'alarm_topic_arn',
+      )
+    })
+
+    it('should error and publish alarm when resumeExecution fails unexpectedly', async () => {
+      const nextCommandSk = 'order#001@2'
+      const unexpected = new Error('AccessDeniedException')
+      unexpected.name = 'AccessDeniedException'
+      const mockSfnService = {
+        resumeExecution: jest.fn().mockRejectedValue(unexpected),
+      }
+
+      const { h, warnSpy, errorSpy, publishSpy } = makeCheckNextTokenHandler(
+        nextCommandWithToken(nextCommandSk),
+        mockSfnService,
+      )
+      const event = createEvent(DataSyncCommandSfnName.FINISH)
+
+      await expect(h['checkNextToken'](event)).resolves.toBeNull()
+
+      expect(warnSpy).not.toHaveBeenCalled()
+      expect(errorSpy).toHaveBeenCalled()
+      expect(publishSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.objectContaining({
+            errorMessage: expect.objectContaining({
+              push_resume_failed: true,
+              errorName: 'AccessDeniedException',
+            }),
+          }),
+        }),
+        'alarm_topic_arn',
+      )
     })
   })
 
@@ -1061,7 +1151,9 @@ describe('DataSyncCommandSfnEventHandler', () => {
         updateTaskToken: jest.fn().mockResolvedValue(undefined),
         getItem: jest
           .fn()
-          .mockRejectedValue(new Error('ProvisionedThroughputExceededException')),
+          .mockRejectedValue(
+            new Error('ProvisionedThroughputExceededException'),
+          ),
       }
       const mockSfnService = {
         resumeExecution: jest.fn(),
@@ -1110,7 +1202,9 @@ describe('DataSyncCommandSfnEventHandler', () => {
         updateTaskToken: jest.fn().mockResolvedValue(undefined),
         getItem: jest
           .fn()
-          .mockRejectedValueOnce(new Error('ProvisionedThroughputExceededException'))
+          .mockRejectedValueOnce(
+            new Error('ProvisionedThroughputExceededException'),
+          )
           .mockResolvedValueOnce({
             version: 1,
             status: finishStartedStatus,
@@ -1121,7 +1215,10 @@ describe('DataSyncCommandSfnEventHandler', () => {
         resumeExecution: jest.fn().mockResolvedValue(undefined),
       }
 
-      const { h } = makeWaitConfirmTokenHandler(mockCommandService, mockSfnService)
+      const { h } = makeWaitConfirmTokenHandler(
+        mockCommandService,
+        mockSfnService,
+      )
       const event = createWaitConfirmEvent(2, taskToken)
 
       await expect(h['waitConfirmToken'](event)).resolves.toEqual({
@@ -1142,7 +1239,9 @@ describe('DataSyncCommandSfnEventHandler', () => {
         updateTaskToken: jest.fn().mockResolvedValue(undefined),
         getItem: jest
           .fn()
-          .mockRejectedValue(new Error('ProvisionedThroughputExceededException')),
+          .mockRejectedValue(
+            new Error('ProvisionedThroughputExceededException'),
+          ),
       }
       const mockSfnService = { resumeExecution: jest.fn() }
 
@@ -1159,7 +1258,9 @@ describe('DataSyncCommandSfnEventHandler', () => {
       expect(mockCommandService.getItem).toHaveBeenCalledTimes(3)
       expect(mockSfnService.resumeExecution).not.toHaveBeenCalled()
       expect(errorSpy.mock.calls[0][0]).toContain('after retries')
-      expect(errorSpy.mock.calls[0][0]).toContain('self-resume backstop degraded')
+      expect(errorSpy.mock.calls[0][0]).toContain(
+        'self-resume backstop degraded',
+      )
       expect(publishSpy).toHaveBeenCalled()
 
       jest.useRealTimers()
@@ -1169,13 +1270,14 @@ describe('DataSyncCommandSfnEventHandler', () => {
       jest.useFakeTimers()
       const mockCommandService = {
         updateTaskToken: jest.fn().mockResolvedValue(undefined),
-        getItem: jest
-          .fn()
-          .mockRejectedValue(new Error('ThrottlingException')),
+        getItem: jest.fn().mockRejectedValue(new Error('ThrottlingException')),
       }
       const mockSfnService = { resumeExecution: jest.fn() }
 
-      const { h } = makeWaitConfirmTokenHandler(mockCommandService, mockSfnService)
+      const { h } = makeWaitConfirmTokenHandler(
+        mockCommandService,
+        mockSfnService,
+      )
       const event = createWaitConfirmEvent(2, 'backoff-token')
 
       const pending = h['waitConfirmToken'](event)
@@ -1232,6 +1334,38 @@ describe('DataSyncCommandSfnEventHandler', () => {
       expect(warnSpy).toHaveBeenCalledTimes(1)
       expect(warnSpy.mock.calls[0][0]).toContain('already consumed')
       expect(warnSpy.mock.calls[0][0]).toContain('TaskDoesNotExist')
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(publishSpy).not.toHaveBeenCalled()
+    })
+
+    it('should warn and not alarm when self-resume fails with TaskTimedOut', async () => {
+      const taskToken = 'timed-out-dup-token'
+      const mockCommandService = {
+        updateTaskToken: jest.fn().mockResolvedValue(undefined),
+        getItem: jest.fn().mockResolvedValue({
+          version: 1,
+          status: finishStatus,
+          sk: '1726027976@1',
+        }),
+      }
+      const timedOut = new Error('Task timed out')
+      timedOut.name = 'TaskTimedOut'
+      const mockSfnService = {
+        resumeExecution: jest.fn().mockRejectedValue(timedOut),
+      }
+
+      const { h, warnSpy, errorSpy, publishSpy } = makeWaitConfirmTokenHandler(
+        mockCommandService,
+        mockSfnService,
+      )
+      const event = createWaitConfirmEvent(2, taskToken)
+
+      await expect(h['waitConfirmToken'](event)).resolves.toEqual({
+        result: { token: taskToken },
+      })
+
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(warnSpy.mock.calls[0][0]).toContain('TaskTimedOut')
       expect(errorSpy).not.toHaveBeenCalled()
       expect(publishSpy).not.toHaveBeenCalled()
     })

--- a/packages/core/src/commands/command.event.handler.spec.ts
+++ b/packages/core/src/commands/command.event.handler.spec.ts
@@ -27,6 +27,7 @@ import { CommandService } from './command.service'
 import { DataSyncDdsHandler } from './handlers/data-sync-dds.handler'
 import { HistoryService } from './history.service'
 import { DataSyncCommandSfnName } from '../command-events/sfn-name.enum'
+import { CommandStatus, getCommandStatus } from './enums/status.enum'
 import { TtlService } from './ttl.service'
 import { SnsClientFactory } from '../queue/sns-client-factory'
 import { SFNClient } from '@aws-sdk/client-sfn'
@@ -127,6 +128,78 @@ const sfnSyncDataEvent = createEvent(DataSyncCommandSfnName.SYNC_DATA, {
 })
 
 const sfnFinishDataEvent = createEvent(DataSyncCommandSfnName.FINISH)
+
+const createWaitConfirmEvent = (version: number, taskToken = 'test-task-token') => {
+  const sk = `1726027976@${version}`
+  return new DataSyncCommandSfnEvent({
+    taskToken,
+    input: undefined,
+    context: {
+      Execution: {
+        Id: 'arn:aws:states:ap-northeast-1:101010101010:execution:command:test-v2',
+        Input: {
+          eventSourceARN:
+            'arn:aws:dynamodb:ap-northeast-1:undefined:env-app_name-table_name-command',
+          awsRegion: 'ddblocal',
+          eventID: 'test-event-id',
+          eventName: 'INSERT',
+          eventVersion: '1.1',
+          eventSource: 'aws:dynamodb',
+          dynamodb: {
+            ApproximateCreationDateTime: '2024-09-13T08:02:00.000Z',
+            Keys: { sk: { S: sk }, pk: { S: 'tenantCode#test' } },
+            NewImage: {
+              pk: { S: 'tenantCode#test' },
+              sk: { S: sk },
+              version: { N: String(version) },
+              requestId: { S: 'req-1' },
+            },
+            SequenceNumber: '1',
+            SizeBytes: 100,
+            StreamViewType: 'NEW_IMAGE',
+          },
+          source:
+            'arn:aws:dynamodb:ap-northeast-1:undefined:env-app_name-table_name-command',
+        },
+        Name: 'test-execution',
+        RoleArn: 'arn:aws:iam::101010101010:role/DummyRole',
+        StartTime: '2024-09-13T08:02:52.094Z',
+      },
+      State: {
+        EnteredTime: '2024-09-13T08:02:54.849Z',
+        Name: DataSyncCommandSfnName.WAIT_PREV_COMMAND,
+        RetryCount: 0,
+      },
+      StateMachine: {
+        Id: 'arn:aws:states:ap-northeast-1:101010101010:stateMachine:command',
+        Name: 'command',
+      },
+    },
+  })
+}
+
+function makeWaitConfirmTokenHandler(
+  commandService: {
+    updateTaskToken: jest.Mock
+    getItem: jest.Mock
+  },
+  sfnService: { resumeExecution: jest.Mock },
+): { h: CommandEventHandler; logSpy: jest.Mock; warnSpy: jest.Mock } {
+  const h = new (CommandEventHandler as any)(
+    { tableName: 'test-table' },
+    commandService,
+    null,
+    null,
+    null,
+    null,
+    { get: jest.fn().mockReturnValue('') },
+    sfnService,
+  )
+  const logSpy = jest.fn()
+  const warnSpy = jest.fn()
+  h.logger = { debug: jest.fn(), log: logSpy, warn: warnSpy }
+  return { h, logSpy, warnSpy }
+}
 
 const keys = {
   NODE_ENV: 'env',
@@ -724,6 +797,131 @@ describe('DataSyncCommandSfnEventHandler', () => {
       // Must include the pk from the event and the sk of the next command
       expect(message).toContain(event.commandKey.pk)
       expect(message).toContain(nextCommandSk)
+    })
+  })
+
+  describe('waitConfirmToken - pull-side self-resume', () => {
+    const finishStatus = getCommandStatus(
+      DataSyncCommandSfnName.FINISH,
+      CommandStatus.STATUS_FINISHED,
+    )
+
+    it('should self-resume when predecessor is finish:FINISHED', async () => {
+      const taskToken = 'self-resume-token'
+      const mockCommandService = {
+        updateTaskToken: jest.fn().mockResolvedValue(undefined),
+        getItem: jest.fn().mockResolvedValue({
+          version: 1,
+          status: finishStatus,
+          sk: '1726027976@1',
+        }),
+      }
+      const mockSfnService = {
+        resumeExecution: jest.fn().mockResolvedValue(undefined),
+      }
+
+      const { h } = makeWaitConfirmTokenHandler(
+        mockCommandService,
+        mockSfnService,
+      )
+      const event = createWaitConfirmEvent(2, taskToken)
+
+      const result = await h['waitConfirmToken'](event)
+
+      expect(mockCommandService.updateTaskToken).toHaveBeenCalledWith(
+        event.commandKey,
+        taskToken,
+      )
+      expect(mockCommandService.getItem).toHaveBeenCalledWith({
+        pk: 'tenantCode#test',
+        sk: '1726027976@1',
+      })
+      expect(mockSfnService.resumeExecution).toHaveBeenCalledWith(taskToken, {
+        result: 'resumed_by_prev_version',
+        prevVersion: 1,
+      })
+      expect(result).toEqual({ result: { token: taskToken } })
+    })
+
+    it('should not resume when predecessor is not finish:FINISHED', async () => {
+      const taskToken = 'wait-token'
+      const mockCommandService = {
+        updateTaskToken: jest.fn().mockResolvedValue(undefined),
+        getItem: jest.fn().mockResolvedValue({
+          version: 1,
+          status: getCommandStatus(
+            DataSyncCommandSfnName.SYNC_DATA,
+            CommandStatus.STATUS_FINISHED,
+          ),
+          sk: '1726027976@1',
+        }),
+      }
+      const mockSfnService = {
+        resumeExecution: jest.fn().mockResolvedValue(undefined),
+      }
+
+      const { h } = makeWaitConfirmTokenHandler(
+        mockCommandService,
+        mockSfnService,
+      )
+      const event = createWaitConfirmEvent(2, taskToken)
+
+      await h['waitConfirmToken'](event)
+
+      expect(mockCommandService.updateTaskToken).toHaveBeenCalled()
+      expect(mockSfnService.resumeExecution).not.toHaveBeenCalled()
+    })
+
+    it('should not lookup predecessor when version is 1', async () => {
+      const mockCommandService = {
+        updateTaskToken: jest.fn().mockResolvedValue(undefined),
+        getItem: jest.fn(),
+      }
+      const mockSfnService = {
+        resumeExecution: jest.fn(),
+      }
+
+      const { h } = makeWaitConfirmTokenHandler(
+        mockCommandService,
+        mockSfnService,
+      )
+      const event = createWaitConfirmEvent(1, 'v1-token')
+
+      await h['waitConfirmToken'](event)
+
+      expect(mockCommandService.getItem).not.toHaveBeenCalled()
+      expect(mockSfnService.resumeExecution).not.toHaveBeenCalled()
+    })
+
+    it('should warn and not throw when resumeExecution fails (duplicate resume)', async () => {
+      const taskToken = 'dup-token'
+      const mockCommandService = {
+        updateTaskToken: jest.fn().mockResolvedValue(undefined),
+        getItem: jest.fn().mockResolvedValue({
+          version: 1,
+          status: finishStatus,
+          sk: '1726027976@1',
+        }),
+      }
+      const mockSfnService = {
+        resumeExecution: jest
+          .fn()
+          .mockRejectedValue(new Error('TaskDoesNotExist')),
+      }
+
+      const { h, warnSpy } = makeWaitConfirmTokenHandler(
+        mockCommandService,
+        mockSfnService,
+      )
+      const event = createWaitConfirmEvent(2, taskToken)
+
+      await expect(h['waitConfirmToken'](event)).resolves.toEqual({
+        result: { token: taskToken },
+      })
+
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(warnSpy.mock.calls[0][0]).toContain('tenantCode#test')
+      expect(warnSpy.mock.calls[0][0]).toContain('Could not self-resume')
     })
   })
 })

--- a/packages/core/src/commands/command.event.handler.spec.ts
+++ b/packages/core/src/commands/command.event.handler.spec.ts
@@ -813,6 +813,84 @@ describe('DataSyncCommandSfnEventHandler', () => {
     })
   })
 
+  describe('checkNextToken - push-side consistent read', () => {
+    const COMMAND_TABLE = 'env-app-table_name-command'
+
+    function makeCheckNextTokenWithRealCommandService() {
+      const dynamoGetItem = jest.fn()
+      const dynamoDbService = {
+        getItem: dynamoGetItem,
+        getTableName: jest.fn().mockReturnValue(COMMAND_TABLE),
+      }
+      const commandService = new (CommandService as any)(
+        { tableName: 'table_name' },
+        dynamoDbService,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+      )
+      const resumeExecution = jest.fn().mockResolvedValue(undefined)
+      const h = new (CommandEventHandler as any)(
+        { tableName: 'table_name' },
+        commandService,
+        null,
+        null,
+        null,
+        null,
+        { get: jest.fn().mockReturnValue('') },
+        { resumeExecution },
+      )
+      h.logger = { debug: jest.fn(), log: jest.fn(), warn: jest.fn() }
+      return { h, dynamoGetItem, resumeExecution }
+    }
+
+    it('should read next command with consistentRead via getNextCommand', async () => {
+      const { h, dynamoGetItem, resumeExecution } =
+        makeCheckNextTokenWithRealCommandService()
+      dynamoGetItem.mockResolvedValue(undefined)
+
+      const event = createEvent(DataSyncCommandSfnName.FINISH)
+      const result = await h['checkNextToken'](event)
+
+      expect(dynamoGetItem).toHaveBeenCalledTimes(1)
+      expect(dynamoGetItem).toHaveBeenCalledWith(
+        COMMAND_TABLE,
+        { pk: 'tenantCode#test', sk: '1726027976@2' },
+        { consistentRead: true },
+      )
+      expect(resumeExecution).not.toHaveBeenCalled()
+      expect(result).toBeNull()
+    })
+
+    it('should resume next command when getNextCommand finds a taskToken', async () => {
+      const { h, dynamoGetItem, resumeExecution } =
+        makeCheckNextTokenWithRealCommandService()
+      dynamoGetItem.mockResolvedValue({
+        version: 2,
+        taskToken: 'next-token',
+        sk: '1726027976@2',
+      })
+
+      const event = createEvent(DataSyncCommandSfnName.FINISH)
+      await h['checkNextToken'](event)
+
+      expect(dynamoGetItem).toHaveBeenCalledWith(
+        COMMAND_TABLE,
+        { pk: 'tenantCode#test', sk: '1726027976@2' },
+        { consistentRead: true },
+      )
+      expect(resumeExecution).toHaveBeenCalledWith('next-token', {
+        result: 'resumed_by_prev_version',
+        prevVersion: 1,
+      })
+    })
+  })
+
   describe('waitConfirmToken - pull-side self-resume', () => {
     const finishStartedStatus = getCommandStatus(
       DataSyncCommandSfnName.FINISH,

--- a/packages/core/src/commands/command.event.handler.spec.ts
+++ b/packages/core/src/commands/command.event.handler.spec.ts
@@ -963,6 +963,37 @@ describe('DataSyncCommandSfnEventHandler', () => {
       expect(mockSfnService.resumeExecution).not.toHaveBeenCalled()
     })
 
+    it('should warn and not throw when getItem rejects during predecessor lookup', async () => {
+      const taskToken = 'get-item-fail-token'
+      const mockCommandService = {
+        updateTaskToken: jest.fn().mockResolvedValue(undefined),
+        getItem: jest
+          .fn()
+          .mockRejectedValue(new Error('ProvisionedThroughputExceededException')),
+      }
+      const mockSfnService = {
+        resumeExecution: jest.fn(),
+      }
+
+      const { h, warnSpy } = makeWaitConfirmTokenHandler(
+        mockCommandService,
+        mockSfnService,
+      )
+      const event = createWaitConfirmEvent(2, taskToken)
+
+      await expect(h['waitConfirmToken'](event)).resolves.toEqual({
+        result: { token: taskToken },
+      })
+
+      expect(mockCommandService.updateTaskToken).toHaveBeenCalled()
+      expect(mockSfnService.resumeExecution).not.toHaveBeenCalled()
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(warnSpy.mock.calls[0][0]).toContain('tenantCode#test')
+      expect(warnSpy.mock.calls[0][0]).toContain(
+        'Could not read predecessor status',
+      )
+    })
+
     it('should warn and not throw when resumeExecution fails (duplicate resume)', async () => {
       const taskToken = 'dup-token'
       const mockCommandService = {

--- a/packages/core/src/commands/command.event.handler.ts
+++ b/packages/core/src/commands/command.event.handler.ts
@@ -8,7 +8,11 @@ import {
 import { DataSyncCommandSfnName } from '../command-events/sfn-name.enum'
 import { S3Service } from '../data-store'
 import { addSortKeyVersion, removeSortKeyVersion } from '../helpers/key'
-import { CommandModuleOptions, INotification } from '../interfaces'
+import {
+  CommandModel,
+  CommandModuleOptions,
+  INotification,
+} from '../interfaces'
 import { SnsService } from '../queue'
 import { StepFunctionService } from '../step-func/step-function.service'
 import { MODULE_OPTIONS_TOKEN } from './command.module-definition'
@@ -110,13 +114,22 @@ export class CommandEventHandler {
         removeSortKeyVersion(event.commandRecord.sk),
         event.commandRecord.version - 1,
       )
-      const prevCommand = await this.commandService.getItem(
-        {
-          pk: event.commandRecord.pk,
-          sk: prevSk,
-        },
-        { consistentRead: true },
-      )
+
+      let prevCommand: CommandModel | undefined
+      try {
+        prevCommand = await this.commandService.getItem(
+          {
+            pk: event.commandRecord.pk,
+            sk: prevSk,
+          },
+          { consistentRead: true },
+        )
+      } catch (e) {
+        this.logger.warn(
+          `[${event.commandKey.pk}] Could not read predecessor status for command v${event.commandRecord.version}: ` +
+            `${e instanceof Error ? e.message : 'Unknown error'}`,
+        )
+      }
 
       const finishStarted = getCommandStatus(
         DataSyncCommandSfnName.FINISH,

--- a/packages/core/src/commands/command.event.handler.ts
+++ b/packages/core/src/commands/command.event.handler.ts
@@ -131,10 +131,17 @@ export class CommandEventHandler {
           100,
         )
       } catch (e) {
-        this.logger.warn(
-          `[${event.commandKey.pk}] Could not read predecessor status for command v${event.commandRecord.version} after retries: ` +
+        // After app + SDK retries, treat as persistent degradation of the
+        // self-resume backstop — do not fail the step (token already stored).
+        this.logger.error(
+          `[${event.commandKey.pk}] Could not read predecessor status for command v${event.commandRecord.version} after retries, self-resume backstop degraded: ` +
             `${e instanceof Error ? e.message : 'Unknown error'}`,
+          e instanceof Error ? e.stack : undefined,
         )
+        await this.publishAlarm(event, {
+          self_resume_predecessor_read_failed: true,
+          cause: e instanceof Error ? e.message : String(e),
+        })
       }
 
       const finishStarted = getCommandStatus(
@@ -151,7 +158,7 @@ export class CommandEventHandler {
 
       if (prevEnteredFinish) {
         this.logger.log(
-          `Prev command already in finish step — self-resuming v${event.commandRecord.version}`,
+          `[${event.commandKey.pk}] Prev command already in finish step — self-resuming v${event.commandRecord.version}`,
         )
         try {
           await this.sfnService.resumeExecution(event.taskToken, {
@@ -159,10 +166,23 @@ export class CommandEventHandler {
             prevVersion: event.commandRecord.version - 1,
           })
         } catch (e) {
-          this.logger.warn(
-            `[${event.commandKey.pk}] Could not self-resume command v${event.commandRecord.version}: ` +
-              `${e instanceof Error ? e.message : 'Unknown error'}`,
-          )
+          const name = e instanceof Error ? e.name : undefined
+          if (name === 'TaskDoesNotExist' || name === 'TaskTimedOut') {
+            // Push side (checkNextToken) already consumed this task token.
+            this.logger.warn(
+              `[${event.commandKey.pk}] Self-resume for v${event.commandRecord.version} already consumed (${name}) — resumed by push side first.`,
+            )
+          } else {
+            this.logger.error(
+              `[${event.commandKey.pk}] Self-resume for v${event.commandRecord.version} failed unexpectedly (${name ?? 'unknown'}): ` +
+                `${e instanceof Error ? e.message : 'Unknown error'}`,
+              e instanceof Error ? e.stack : undefined,
+            )
+            await this.publishAlarm(event, {
+              self_resume_failed: true,
+              cause: e instanceof Error ? e.message : String(e),
+            })
+          }
         }
       }
     }

--- a/packages/core/src/commands/command.event.handler.ts
+++ b/packages/core/src/commands/command.event.handler.ts
@@ -117,6 +117,7 @@ export class CommandEventHandler {
       )
 
       let prevCommand: CommandModel | undefined
+      let prevReadFailed = false
       try {
         // consistentRead: true — predecessor status across independent SFN
         // executions must not be a stale eventually-consistent read.
@@ -133,6 +134,7 @@ export class CommandEventHandler {
       } catch (e) {
         // After app + SDK retries, treat as persistent degradation of the
         // self-resume backstop — do not fail the step (token already stored).
+        prevReadFailed = true
         this.logger.error(
           `[${event.commandKey.pk}] Could not read predecessor status for command v${event.commandRecord.version} after retries, self-resume backstop degraded: ` +
             `${e instanceof Error ? e.message : 'Unknown error'}`,
@@ -142,6 +144,17 @@ export class CommandEventHandler {
           self_resume_predecessor_read_failed: true,
           cause: e instanceof Error ? e.message : String(e),
         })
+      }
+
+      // A successful read that returns no row is not the same as "predecessor
+      // has not reached finish yet" — the command chain is append-only, so for
+      // version > 1 the predecessor row must exist. Surface it instead of
+      // letting it fall through the same silent path as normal waiting.
+      if (!prevReadFailed && !prevCommand) {
+        this.logger.warn(
+          `[${event.commandKey.pk}] Predecessor command v${event.commandRecord.version - 1} not found (sk: ${prevSk}) — ` +
+            `self-resume backstop cannot evaluate predecessor status`,
+        )
       }
 
       // Limitation: self-resume only when predecessor status is finish:STARTED
@@ -199,10 +212,28 @@ export class CommandEventHandler {
     maxAttempts: number,
     baseDelayMs: number,
   ): Promise<CommandModel> {
+    return await this.withRetry(
+      () => this.commandService.getItem(key, options),
+      maxAttempts,
+      baseDelayMs,
+    )
+  }
+
+  /**
+   * Bounded retry with exponential backoff (baseDelayMs * 2^(attempt - 1)),
+   * rethrowing the last error once every attempt is exhausted. Shared by both
+   * sides of the version handshake so the pull path (waitConfirmToken) and the
+   * push path (checkNextToken) tolerate transient DynamoDB failures equally.
+   */
+  protected async withRetry<T>(
+    fn: () => Promise<T>,
+    maxAttempts: number,
+    baseDelayMs: number,
+  ): Promise<T> {
     let lastError: unknown
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       try {
-        return await this.commandService.getItem(key, options)
+        return await fn()
       } catch (e) {
         lastError = e
         if (attempt < maxAttempts) {
@@ -226,10 +257,19 @@ export class CommandEventHandler {
     this.logger.debug('Checking version for data::', data)
     const commandVersion = event.commandRecord.version
     const nextVersion = 1 + (data?.version || 0)
-    const oldCommand = await this.commandService.getItem({
-      pk: event.commandRecord.pk,
-      sk: addSortKeyVersion(sk, commandVersion - 1),
-    })
+    // consistentRead: true — the predecessor row is written by an independent
+    // SFN execution. A stale eventually-consistent miss makes oldCommand look
+    // absent, which returns result: 0 and routes straight to set_ttl_command,
+    // skipping wait_prev_command and letting a later version's sync_data land
+    // out of order. Matches the predecessor reads in waitConfirmToken and
+    // getNextCommand.
+    const oldCommand = await this.commandService.getItem(
+      {
+        pk: event.commandRecord.pk,
+        sk: addSortKeyVersion(sk, commandVersion - 1),
+      },
+      { consistentRead: true },
+    )
 
     if (nextVersion === commandVersion) {
       return {
@@ -330,9 +370,38 @@ export class CommandEventHandler {
   ): Promise<StepFunctionStateInput> {
     this.logger.debug('checkNextToken:: ', event.commandRecord)
 
-    const nextCommand = await this.commandService.getNextCommand(
-      event.commandKey,
-    )
+    let nextCommand: CommandModel | undefined
+    try {
+      // Same bounded retry as the pull-side predecessor read in
+      // waitConfirmToken — without it a transient DDB failure here takes out
+      // both halves of the handshake at once.
+      nextCommand = await this.withRetry(
+        () => this.commandService.getNextCommand(event.commandKey),
+        3,
+        100,
+      )
+    } catch (e) {
+      // Deliberately does not rethrow. Failing this step makes execute() write
+      // finish:FAILED, and the successor's self-resume backstop only reacts to
+      // finish:STARTED|FINISHED — so the push path and the pull path would
+      // collapse together and the chain would stall until the 24h timeout.
+      // Returning normally lets execute() write finish:FINISHED, keeping the
+      // successor's self-resume armed for its own token-store pass. The step is
+      // reported as finished even though the push resume never ran; the alarm
+      // below is what records that, and the successor is the recovery path.
+      this.logger.error(
+        `[${event.commandKey.pk}] Could not read next command after retries, ` +
+          `push resume skipped (successor self-resume remains armed): ` +
+          `${e instanceof Error ? e.message : 'Unknown error'}`,
+        e instanceof Error ? e.stack : undefined,
+      )
+      await this.publishAlarmSafely(event, {
+        next_command_read_failed: true,
+        cause: e instanceof Error ? e.message : String(e),
+      })
+      return null
+    }
+
     if (!nextCommand) {
       this.logger.debug('No next command version found. Chain ends.')
       return null

--- a/packages/core/src/commands/command.event.handler.ts
+++ b/packages/core/src/commands/command.event.handler.ts
@@ -68,7 +68,7 @@ export class CommandEventHandler {
         getCommandStatus(event.stepStateName, CommandStatus.STATUS_FAILED),
         event.commandRecord.requestId,
       )
-      await this.publishAlarm(event, (error as Error).stack)
+      await this.publishAlarmSafely(event, (error as Error).stack)
       throw error
     }
   }
@@ -144,11 +144,12 @@ export class CommandEventHandler {
         })
       }
 
-      // Limitation: if the predecessor's wait_prev_command hit the 24h SFN
-      // taskTimeout, DynamoDB is not updated (Catch → Pass → Fail never
-      // invokes Lambda). status can remain wait_prev_command:FINISHED with a
-      // stale taskToken, so this check will not self-resume and this version
-      // may wait out its own 24h timeout (cascade).
+      // Limitation: self-resume only when predecessor status is finish:STARTED
+      // or finish:FINISHED. Any predecessor exit before FINISH (wait_prev_command
+      // 24h timeout Pass→Fail with no Lambda/DDB update, version-mismatch fail,
+      // or *:FAILED mid-pipeline) leaves a non-finish status (often with a stale
+      // taskToken), so this check will not self-resume and this version may wait
+      // out its own 24h timeout (cascade).
       const finishStarted = getCommandStatus(
         DataSyncCommandSfnName.FINISH,
         CommandStatus.STATUS_STARTED,
@@ -255,7 +256,7 @@ export class CommandEventHandler {
         'next version must be ' + nextVersion + ' but got ' + commandVersion,
     }
 
-    await this.publishAlarm(event, errorDetails)
+    await this.publishAlarmSafely(event, errorDetails)
     return errorDetails
   }
 

--- a/packages/core/src/commands/command.event.handler.ts
+++ b/packages/core/src/commands/command.event.handler.ts
@@ -166,23 +166,11 @@ export class CommandEventHandler {
             prevVersion: event.commandRecord.version - 1,
           })
         } catch (e) {
-          const name = e instanceof Error ? e.name : undefined
-          if (name === 'TaskDoesNotExist' || name === 'TaskTimedOut') {
-            // Push side (checkNextToken) already consumed this task token.
-            this.logger.warn(
-              `[${event.commandKey.pk}] Self-resume for v${event.commandRecord.version} already consumed (${name}) — resumed by push side first.`,
-            )
-          } else {
-            this.logger.error(
-              `[${event.commandKey.pk}] Self-resume for v${event.commandRecord.version} failed unexpectedly (${name ?? 'unknown'}): ` +
-                `${e instanceof Error ? e.message : 'Unknown error'}`,
-              e instanceof Error ? e.stack : undefined,
-            )
-            await this.publishAlarm(event, {
-              self_resume_failed: true,
-              cause: e instanceof Error ? e.message : String(e),
-            })
-          }
+          await this.handleResumeExecutionError(event, e, {
+            benignNames: new Set(['TaskDoesNotExist', 'TaskTimedOut']),
+            logContext: `[${event.commandKey.pk}] Self-resume for v${event.commandRecord.version}`,
+            alarmPayload: { self_resume_failed: true },
+          })
         }
       }
     }
@@ -355,10 +343,15 @@ export class CommandEventHandler {
           prevVersion: event.commandRecord.version,
         })
       } catch (e) {
-        this.logger.warn(
-          `[${event.commandKey.pk}] Could not resume command v${nextCommand.version} (sk: ${nextCommand.sk}): ` +
-            `${e instanceof Error ? e.message : 'Unknown error'}`,
-        )
+        await this.handleResumeExecutionError(event, e, {
+          benignNames: new Set(['TaskDoesNotExist']),
+          logContext: `[${event.commandKey.pk}] Resume for v${nextCommand.version} (sk: ${nextCommand.sk})`,
+          alarmPayload: {
+            push_resume_failed: true,
+            nextVersion: nextCommand.version,
+            nextSk: nextCommand.sk,
+          },
+        })
       }
     } else {
       this.logger.warn(
@@ -367,6 +360,33 @@ export class CommandEventHandler {
     }
 
     return null
+  }
+
+  protected async handleResumeExecutionError(
+    event: DataSyncCommandSfnEvent,
+    e: unknown,
+    options: {
+      benignNames: ReadonlySet<string>
+      logContext: string
+      alarmPayload: Record<string, unknown>
+    },
+  ): Promise<void> {
+    const name = e instanceof Error ? e.name : undefined
+    if (name && options.benignNames.has(name)) {
+      this.logger.warn(`${options.logContext} already consumed (${name})`)
+      return
+    }
+
+    this.logger.error(
+      `${options.logContext} failed unexpectedly (${name ?? 'unknown'}): ` +
+        `${e instanceof Error ? e.message : 'Unknown error'}`,
+      e instanceof Error ? e.stack : undefined,
+    )
+    await this.publishAlarm(event, {
+      ...options.alarmPayload,
+      errorName: name ?? 'unknown',
+      cause: e instanceof Error ? e.message : String(e),
+    })
   }
 
   protected async publishAlarm(

--- a/packages/core/src/commands/command.event.handler.ts
+++ b/packages/core/src/commands/command.event.handler.ts
@@ -102,7 +102,44 @@ export class CommandEventHandler {
     event: DataSyncCommandSfnEvent,
   ): Promise<StepFunctionStateInput> {
     this.logger.debug('waitConfirmToken::', event)
+
     await this.commandService.updateTaskToken(event.commandKey, event.taskToken)
+
+    if (event.commandRecord.version > 1) {
+      const prevSk = addSortKeyVersion(
+        removeSortKeyVersion(event.commandRecord.sk),
+        event.commandRecord.version - 1,
+      )
+      const prevCommand = await this.commandService.getItem({
+        pk: event.commandRecord.pk,
+        sk: prevSk,
+      })
+
+      const prevFinished =
+        prevCommand?.status ===
+        getCommandStatus(
+          DataSyncCommandSfnName.FINISH,
+          CommandStatus.STATUS_FINISHED,
+        )
+
+      if (prevFinished) {
+        this.logger.log(
+          `Prev command already finished before token was read — self-resuming v${event.commandRecord.version}`,
+        )
+        try {
+          await this.sfnService.resumeExecution(event.taskToken, {
+            result: 'resumed_by_prev_version',
+            prevVersion: event.commandRecord.version - 1,
+          })
+        } catch (e) {
+          this.logger.warn(
+            `[${event.commandKey.pk}] Could not self-resume command v${event.commandRecord.version}: ` +
+              `${e instanceof Error ? e.message : 'Unknown error'}`,
+          )
+        }
+      }
+    }
+
     return {
       result: {
         token: event.taskToken,

--- a/packages/core/src/commands/command.event.handler.ts
+++ b/packages/core/src/commands/command.event.handler.ts
@@ -110,21 +110,29 @@ export class CommandEventHandler {
         removeSortKeyVersion(event.commandRecord.sk),
         event.commandRecord.version - 1,
       )
-      const prevCommand = await this.commandService.getItem({
-        pk: event.commandRecord.pk,
-        sk: prevSk,
-      })
+      const prevCommand = await this.commandService.getItem(
+        {
+          pk: event.commandRecord.pk,
+          sk: prevSk,
+        },
+        { consistentRead: true },
+      )
 
-      const prevFinished =
-        prevCommand?.status ===
-        getCommandStatus(
-          DataSyncCommandSfnName.FINISH,
-          CommandStatus.STATUS_FINISHED,
-        )
+      const finishStarted = getCommandStatus(
+        DataSyncCommandSfnName.FINISH,
+        CommandStatus.STATUS_STARTED,
+      )
+      const finishFinished = getCommandStatus(
+        DataSyncCommandSfnName.FINISH,
+        CommandStatus.STATUS_FINISHED,
+      )
+      const prevEnteredFinish =
+        prevCommand?.status === finishStarted ||
+        prevCommand?.status === finishFinished
 
-      if (prevFinished) {
+      if (prevEnteredFinish) {
         this.logger.log(
-          `Prev command already finished before token was read — self-resuming v${event.commandRecord.version}`,
+          `Prev command already in finish step — self-resuming v${event.commandRecord.version}`,
         )
         try {
           await this.sfnService.resumeExecution(event.taskToken, {

--- a/packages/core/src/commands/command.event.handler.ts
+++ b/packages/core/src/commands/command.event.handler.ts
@@ -11,6 +11,7 @@ import { addSortKeyVersion, removeSortKeyVersion } from '../helpers/key'
 import {
   CommandModel,
   CommandModuleOptions,
+  DetailKey,
   INotification,
 } from '../interfaces'
 import { SnsService } from '../queue'
@@ -117,16 +118,21 @@ export class CommandEventHandler {
 
       let prevCommand: CommandModel | undefined
       try {
-        prevCommand = await this.commandService.getItem(
-          {
-            pk: event.commandRecord.pk,
-            sk: prevSk,
-          },
+        // consistentRead: true — predecessor status across independent SFN
+        // executions must not be a stale eventually-consistent read.
+        //
+        // Bounded retry (3 attempts, exponential backoff baseDelayMs * 2^(n-1)):
+        // best-effort check — updateTaskToken already succeeded; checkNextToken
+        // on the predecessor remains the primary resume path.
+        prevCommand = await this.getItemWithRetry(
+          { pk: event.commandRecord.pk, sk: prevSk },
           { consistentRead: true },
+          3,
+          100,
         )
       } catch (e) {
         this.logger.warn(
-          `[${event.commandKey.pk}] Could not read predecessor status for command v${event.commandRecord.version}: ` +
+          `[${event.commandKey.pk}] Could not read predecessor status for command v${event.commandRecord.version} after retries: ` +
             `${e instanceof Error ? e.message : 'Unknown error'}`,
         )
       }
@@ -166,6 +172,32 @@ export class CommandEventHandler {
         token: event.taskToken,
       },
     }
+  }
+
+  /**
+   * Retry wrapper around commandService.getItem for the cross-execution
+   * predecessor-status check in waitConfirmToken. Bounded and short —
+   * smooths a single transient DDB failure; does not wait out an outage.
+   */
+  protected async getItemWithRetry(
+    key: DetailKey,
+    options: { consistentRead: boolean },
+    maxAttempts: number,
+    baseDelayMs: number,
+  ): Promise<CommandModel> {
+    let lastError: unknown
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        return await this.commandService.getItem(key, options)
+      } catch (e) {
+        lastError = e
+        if (attempt < maxAttempts) {
+          const delayMs = baseDelayMs * Math.pow(2, attempt - 1)
+          await new Promise((resolve) => setTimeout(resolve, delayMs))
+        }
+      }
+    }
+    throw lastError
   }
 
   protected async checkVersion(

--- a/packages/core/src/commands/command.event.handler.ts
+++ b/packages/core/src/commands/command.event.handler.ts
@@ -138,12 +138,17 @@ export class CommandEventHandler {
             `${e instanceof Error ? e.message : 'Unknown error'}`,
           e instanceof Error ? e.stack : undefined,
         )
-        await this.publishAlarm(event, {
+        await this.publishAlarmSafely(event, {
           self_resume_predecessor_read_failed: true,
           cause: e instanceof Error ? e.message : String(e),
         })
       }
 
+      // Limitation: if the predecessor's wait_prev_command hit the 24h SFN
+      // taskTimeout, DynamoDB is not updated (Catch → Pass → Fail never
+      // invokes Lambda). status can remain wait_prev_command:FINISHED with a
+      // stale taskToken, so this check will not self-resume and this version
+      // may wait out its own 24h timeout (cascade).
       const finishStarted = getCommandStatus(
         DataSyncCommandSfnName.FINISH,
         CommandStatus.STATUS_STARTED,
@@ -382,11 +387,30 @@ export class CommandEventHandler {
         `${e instanceof Error ? e.message : 'Unknown error'}`,
       e instanceof Error ? e.stack : undefined,
     )
-    await this.publishAlarm(event, {
+    await this.publishAlarmSafely(event, {
       ...options.alarmPayload,
       errorName: name ?? 'unknown',
       cause: e instanceof Error ? e.message : String(e),
     })
+  }
+
+  /**
+   * Best-effort alarm publish — SNS failure must not fail the SFN step
+   * (e.g. after updateTaskToken already succeeded).
+   */
+  protected async publishAlarmSafely(
+    event: DataSyncCommandSfnEvent,
+    errorDetails: any,
+  ): Promise<void> {
+    try {
+      await this.publishAlarm(event, errorDetails)
+    } catch (alarmError) {
+      this.logger.error(
+        `[${event.commandKey.pk}] publishAlarm failed: ` +
+          `${alarmError instanceof Error ? alarmError.message : 'Unknown error'}`,
+        alarmError instanceof Error ? alarmError.stack : undefined,
+      )
+    }
   }
 
   protected async publishAlarm(

--- a/packages/core/src/commands/command.service.ts
+++ b/packages/core/src/commands/command.service.ts
@@ -486,11 +486,14 @@ export class CommandService implements OnModuleInit, ICommandService {
     })
   }
 
-  async getItem(key: DetailKey): Promise<CommandModel> {
+  async getItem(
+    key: DetailKey,
+    options?: { consistentRead?: boolean },
+  ): Promise<CommandModel> {
     if (!key.sk.includes(VER_SEPARATOR)) {
       return this.getLatestItem(key)
     }
-    return await this.dynamoDbService.getItem(this.tableName, key)
+    return await this.dynamoDbService.getItem(this.tableName, key, options)
   }
 
   async getLatestItem(key: DetailKey): Promise<CommandModel> {
@@ -594,6 +597,8 @@ export class CommandService implements OnModuleInit, ICommandService {
         getSortKeyVersion(currentKey.sk) + 1,
       ),
     }
-    return await this.dynamoDbService.getItem(this.tableName, nextKey)
+    return await this.dynamoDbService.getItem(this.tableName, nextKey, {
+      consistentRead: true,
+    })
   }
 }

--- a/packages/core/src/data-store/dynamodb.service.spec.ts
+++ b/packages/core/src/data-store/dynamodb.service.spec.ts
@@ -186,6 +186,39 @@ describe('DynamoDbService', () => {
         sk: 'test',
       })
     })
+
+    it('should set ConsistentRead when options.consistentRead is true', async () => {
+      // Arrange
+      dynamoDBMock.on(GetItemCommand).resolves({ Item: {} })
+      const key = { pk: 'master', sk: 'test' }
+
+      // Action
+      await dynamoDbService.getItem('table_name', key, { consistentRead: true })
+
+      // Assert
+      expect(dynamoDBMock).toHaveReceivedCommandWith(GetItemCommand, {
+        TableName: 'table_name',
+        Key: {
+          pk: { S: 'master' },
+          sk: { S: 'test' },
+        },
+        ConsistentRead: true,
+      })
+    })
+
+    it('should omit ConsistentRead when options are not provided', async () => {
+      // Arrange
+      dynamoDBMock.on(GetItemCommand).resolves({ Item: {} })
+      const key = { pk: 'master', sk: 'test' }
+
+      // Action
+      await dynamoDbService.getItem('table_name', key)
+
+      // Assert
+      const calls = dynamoDBMock.commandCalls(GetItemCommand)
+      expect(calls).toHaveLength(1)
+      expect(calls[0].args[0].input.ConsistentRead).toBeUndefined()
+    })
   })
 
   describe('updateItem', () => {

--- a/packages/core/src/data-store/dynamodb.service.ts
+++ b/packages/core/src/data-store/dynamodb.service.ts
@@ -116,11 +116,16 @@ export class DynamoDbService {
     return this.ddbItemToObj(res.Attributes)
   }
 
-  async getItem(tableName: string, key: DetailKey) {
+  async getItem(
+    tableName: string,
+    key: DetailKey,
+    options?: { consistentRead?: boolean },
+  ) {
     const { Item } = await this.client.send(
       new GetItemCommand({
         TableName: tableName,
         Key: this.toDdbKey(key),
+        ...(options?.consistentRead ? { ConsistentRead: true } : {}),
       }),
     )
 

--- a/packages/core/src/step-func/step-function.service.spec.ts
+++ b/packages/core/src/step-func/step-function.service.spec.ts
@@ -8,6 +8,7 @@ jest.mock('@aws-sdk/client-sfn', () => ({
     send: jest.fn(),
   })),
   StartExecutionCommand: jest.fn().mockImplementation((params) => params),
+  SendTaskSuccessCommand: jest.fn().mockImplementation((params) => params),
 }))
 
 describe('StepFunctionService', () => {
@@ -58,12 +59,14 @@ describe('StepFunctionService', () => {
 
   describe('startExecution', () => {
     it('should start step function execution with name', async () => {
-      const arn = 'arn:aws:states:us-east-1:123456789012:stateMachine:test-state-machine'
+      const arn =
+        'arn:aws:states:us-east-1:123456789012:stateMachine:test-state-machine'
       const input = { key: 'value', data: 'test' }
       const name = 'test-execution'
 
       mockClient.send.mockResolvedValue({
-        executionArn: 'arn:aws:states:us-east-1:123456789012:execution:test-state-machine:test-execution',
+        executionArn:
+          'arn:aws:states:us-east-1:123456789012:execution:test-state-machine:test-execution',
         startDate: new Date(),
       })
 
@@ -74,7 +77,7 @@ describe('StepFunctionService', () => {
           stateMachineArn: arn,
           name: name,
           input: JSON.stringify(input),
-        })
+        }),
       )
       expect(result).toEqual({
         executionArn: expect.any(String),
@@ -83,11 +86,13 @@ describe('StepFunctionService', () => {
     })
 
     it('should start execution without name', async () => {
-      const arn = 'arn:aws:states:us-east-1:123456789012:stateMachine:test-state-machine'
+      const arn =
+        'arn:aws:states:us-east-1:123456789012:stateMachine:test-state-machine'
       const input = { key: 'value' }
 
       mockClient.send.mockResolvedValue({
-        executionArn: 'arn:aws:states:us-east-1:123456789012:execution:test-state-machine:auto-generated',
+        executionArn:
+          'arn:aws:states:us-east-1:123456789012:execution:test-state-machine:auto-generated',
         startDate: new Date(),
       })
 
@@ -98,17 +103,19 @@ describe('StepFunctionService', () => {
           stateMachineArn: arn,
           name: undefined,
           input: JSON.stringify(input),
-        })
+        }),
       )
     })
 
     it('should handle long execution names by setting to undefined', async () => {
-      const arn = 'arn:aws:states:us-east-1:123456789012:stateMachine:test-state-machine'
+      const arn =
+        'arn:aws:states:us-east-1:123456789012:stateMachine:test-state-machine'
       const input = { key: 'value' }
       const longName = 'a'.repeat(85)
 
       mockClient.send.mockResolvedValue({
-        executionArn: 'arn:aws:states:us-east-1:123456789012:execution:test-state-machine:auto-generated',
+        executionArn:
+          'arn:aws:states:us-east-1:123456789012:execution:test-state-machine:auto-generated',
         startDate: new Date(),
       })
 
@@ -119,17 +126,20 @@ describe('StepFunctionService', () => {
           stateMachineArn: arn,
           name: undefined,
           input: JSON.stringify(input),
-        })
+        }),
       )
     })
 
     it('should use name when length is exactly 80 characters', async () => {
-      const arn = 'arn:aws:states:us-east-1:123456789012:stateMachine:test-state-machine'
+      const arn =
+        'arn:aws:states:us-east-1:123456789012:stateMachine:test-state-machine'
       const input = { key: 'value' }
       const exactLengthName = 'a'.repeat(80)
 
       mockClient.send.mockResolvedValue({
-        executionArn: 'arn:aws:states:us-east-1:123456789012:execution:test-state-machine:' + exactLengthName,
+        executionArn:
+          'arn:aws:states:us-east-1:123456789012:execution:test-state-machine:' +
+          exactLengthName,
         startDate: new Date(),
       })
 
@@ -140,12 +150,13 @@ describe('StepFunctionService', () => {
           stateMachineArn: arn,
           name: exactLengthName,
           input: JSON.stringify(input),
-        })
+        }),
       )
     })
 
     it('should serialize complex input objects', async () => {
-      const arn = 'arn:aws:states:us-east-1:123456789012:stateMachine:test-state-machine'
+      const arn =
+        'arn:aws:states:us-east-1:123456789012:stateMachine:test-state-machine'
       const input = {
         nested: {
           object: {
@@ -158,7 +169,8 @@ describe('StepFunctionService', () => {
       }
 
       mockClient.send.mockResolvedValue({
-        executionArn: 'arn:aws:states:us-east-1:123456789012:execution:test-state-machine:test',
+        executionArn:
+          'arn:aws:states:us-east-1:123456789012:execution:test-state-machine:test',
         startDate: new Date(),
       })
 
@@ -167,27 +179,32 @@ describe('StepFunctionService', () => {
       expect(mockClient.send).toHaveBeenCalledWith(
         expect.objectContaining({
           input: JSON.stringify(input),
-        })
+        }),
       )
     })
 
     it('should handle start execution errors', async () => {
-      const arn = 'arn:aws:states:us-east-1:123456789012:stateMachine:test-state-machine'
+      const arn =
+        'arn:aws:states:us-east-1:123456789012:stateMachine:test-state-machine'
       const input = { key: 'value' }
       const error = new Error('Step Function execution failed')
 
       mockClient.send.mockRejectedValue(error)
 
-      await expect(service.startExecution(arn, input)).rejects.toThrow('Step Function execution failed')
+      await expect(service.startExecution(arn, input)).rejects.toThrow(
+        'Step Function execution failed',
+      )
     })
 
     it('should handle empty name string as undefined', async () => {
-      const arn = 'arn:aws:states:us-east-1:123456789012:stateMachine:test-state-machine'
+      const arn =
+        'arn:aws:states:us-east-1:123456789012:stateMachine:test-state-machine'
       const input = { key: 'value' }
       const emptyName = ''
 
       mockClient.send.mockResolvedValue({
-        executionArn: 'arn:aws:states:us-east-1:123456789012:execution:test-state-machine:auto',
+        executionArn:
+          'arn:aws:states:us-east-1:123456789012:execution:test-state-machine:auto',
         startDate: new Date(),
       })
 
@@ -196,7 +213,42 @@ describe('StepFunctionService', () => {
       expect(mockClient.send).toHaveBeenCalledWith(
         expect.objectContaining({
           name: undefined,
-        })
+        }),
+      )
+    })
+  })
+
+  describe('resumeExecution', () => {
+    it('should send SendTaskSuccess with the wrapped payload', async () => {
+      mockClient.send.mockResolvedValue({})
+
+      await service.resumeExecution('task-token', { result: 'ok' })
+
+      expect(mockClient.send).toHaveBeenCalledWith({
+        taskToken: 'task-token',
+        output: JSON.stringify({ Payload: [[{ result: 'ok' }]] }),
+      })
+    })
+
+    it('should rethrow without logging at error level so the caller owns the level', async () => {
+      // A duplicate resume (TaskDoesNotExist / TaskTimedOut) is by design on
+      // the bidirectional handshake — logging ERROR here would page on an
+      // expected outcome and cancel out the caller's benign classification.
+      const errorSpy = jest.fn()
+      const debugSpy = jest.fn()
+      ;(service as any).logger = { error: errorSpy, debug: debugSpy }
+
+      const duplicate = new Error('Task Does Not Exist')
+      duplicate.name = 'TaskDoesNotExist'
+      mockClient.send.mockRejectedValue(duplicate)
+
+      await expect(service.resumeExecution('stale-token')).rejects.toThrow(
+        duplicate,
+      )
+
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(debugSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to resume execution'),
       )
     })
   })

--- a/packages/core/src/step-func/step-function.service.ts
+++ b/packages/core/src/step-func/step-function.service.ts
@@ -52,9 +52,13 @@ export class StepFunctionService {
         }),
       )
     } catch (error) {
-      this.logger.error(
+      // Log at debug and rethrow — the caller owns the level. On the
+      // bidirectional version handshake a duplicate resume (TaskDoesNotExist /
+      // TaskTimedOut) is by design, so an unconditional ERROR here would page
+      // on an expected outcome and cancel out the benign classification the
+      // caller applies (see CommandEventHandler.handleResumeExecutionError).
+      this.logger.debug(
         `Failed to resume execution: ${error instanceof Error ? error.message : 'Unknown error'}`,
-        error instanceof Error ? error.stack : undefined,
       )
       throw error
     }


### PR DESCRIPTION
## Summary

Release `develop` → `main` for **v1.3.5**. Bundles the following merged PRs:

- **[#465](https://github.com/mbc-net/mbc-cqrs-serverless/pull/465)** `fix(core)`: Harden command-handler resume against read-after-write / TOCTOU races, add `ConsistentRead` support, and add Step Functions observability + IAM scoping.
- **[#482](https://github.com/mbc-net/mbc-cqrs-serverless/pull/482)** `fix(deps)`: Restore the blocking production `npm audit` CI gate and patch `brace-expansion`.
- **[#484](https://github.com/mbc-net/mbc-cqrs-serverless/pull/484)** `docs(changelog)`: Backfill `CHANGELOG.md` (v1.3.2 / v1.3.4 / v1.3.5).

## Changes

### Bug Fixes (`packages/core`)

- **Command-handler resume hardening.** `waitConfirmToken` now self-resumes when the predecessor command has already finished, closes the residual TOCTOU window via `STARTED|FINISHED` status checks, retries the predecessor `getItem` with exponential backoff, handles predecessor lookup errors gracefully, and classifies `checkNextToken` resume failures so a stuck resume raises an alarm instead of failing silently.
- **Consistent reads.** Add `ConsistentRead` support to `DynamoDbService.getItem` and thread it through `CommandService.getItem` / `getNextCommand`, so resume decisions read the latest committed state instead of a possibly stale replica.

### Features (`packages/cli` infra templates, `packages/core`)

- Add CloudWatch alarms on the command-handler Step Functions state machine (`ExecutionsFailed` and degraded self-resume paths).
- Add a 24h timeout and catch on `wait_prev_command`.
- Scope the `SendTaskSuccess` IAM permission to the command state machine ARN and tighten task-token IAM policies.

### Security / Dependencies

- Patch `brace-expansion` (top-level `brace-expansion@2` → `5.0.8`); bump `js-yaml` 4.3.0 and `fast-uri` 3.1.4. Root production audit: 0 critical/high. (The blocking `npm audit --omit=dev --audit-level=high` CI gate, temporarily disabled while landing #465, is restored — net-unchanged versus `main`, which already enforced it.)

### Docs

- Backfill root `CHANGELOG.md` with v1.3.2 / v1.3.4 / v1.3.5 (it had stopped at v1.3.1).

## Migration

No breaking changes. The resume hardening and consistent-read behavior are transparent; redeploying picks them up automatically.

## Notes

- **v1.3.3 is intentionally skipped.** The existing `v1.3.3` tag points to a commit dated 2026-05-08 that predates v1.3.2 (an out-of-order tag), so this release goes v1.3.4 → v1.3.5.
- Documentation-site changelog and `releases-*.json` updates are tracked separately in `mbc-cqrs-serverless-doc` ([PR #153](https://github.com/mbc-net/mbc-cqrs-serverless-doc/pull/153)).

## Test plan

- [ ] CI green on this PR (unit + e2e across the Node matrix, production `npm audit` gate)
- [ ] Reviewer: confirm release notes before tagging `v1.3.5` on `main`