### PR TITLE
fix(cli,ci): run infra template tests in CI and make them hermetic

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -92,6 +92,39 @@ jobs:
       - name: Run Unit Tests with Coverage
         run: npm run test:cov
 
+      # Blocking: the scaffolded infra template (packages/cli/templates/infra)
+      # is not an npm workspace member and its tests use a *.test.ts suffix, so
+      # the root jest run (testRegex '.*\.spec\.ts$') never covers them. Run the
+      # template's own type-check and tests here so the CDK snapshot and IAM
+      # guards (e.g. states:SendTaskSuccess scoping) are actually enforced —
+      # this is the gate that would have caught the `aws_stepfunctions`
+      # (undefined identifier) synth break shipped in v1.3.4.
+      # --ignore-scripts matches the root job's install hardening and blocks
+      # third-party postinstall scripts from running in this write-scoped job.
+      # A committed lockfile + `npm ci` would be preferable for reproducibility,
+      # but @aws/pdk's dependency tree does not resolve into an `npm ci`-clean
+      # lockfile and rewrites it on every `npm install`; determinism here is
+      # blocked on removing @aws/pdk (tracked in #486). The type-check and tests
+      # do not import @aws/pdk, so its floating subtree does not affect them.
+      - name: Infra template type-check & tests (blocking)
+        if: matrix.node-version == '20.x'
+        working-directory: packages/cli/templates/infra
+        run: |
+          npm install --ignore-scripts --no-audit --no-fund
+          npx tsc --noEmit
+          npx jest --ci
+
+      # Visibility only (non-blocking): the infra template ships @aws/pdk
+      # (build-time cdk-graph diagram tooling) in production dependencies, whose
+      # transitive tree carries high advisories. It is not an npm workspace
+      # member, so the root production audit above does not cover it. Surface it
+      # here without blocking; the @aws/pdk chain is tracked separately.
+      - name: Infra template audit (non-blocking, visibility)
+        if: matrix.node-version == '20.x'
+        working-directory: packages/cli/templates/infra
+        run: npm audit --omit=dev --audit-level=high
+        continue-on-error: true
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         if: matrix.node-version == '20.x'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 - **core:** Harden command-handler resume against read-after-write races — `waitConfirmToken` now self-resumes when the predecessor command has already finished, closes the residual TOCTOU window via `STARTED|FINISHED` status checks, retries the predecessor `getItem` with exponential backoff, and classifies `checkNextToken` resume failures so a stuck resume raises an alarm instead of failing silently ([#465](https://github.com/mbc-net/mbc-cqrs-serverless/pull/465))
 - **core:** Add `ConsistentRead` support to `DynamoDbService.getItem` and thread it through `CommandService.getItem` / `getNextCommand`, so resume decisions read the latest committed state instead of a possibly stale replica ([#465](https://github.com/mbc-net/mbc-cqrs-serverless/pull/465))
+- **cli:** Fix the scaffolded infra template failing `cdk synth`/`deploy` — the import-CSV Step Functions definition referenced an undefined `aws_stepfunctions` identifier (corrected to `cdk.aws_stepfunctions`), which broke every project scaffolded with `mbc new` on v1.3.4. Upgrade to v1.3.5 to restore deployability ([#465](https://github.com/mbc-net/mbc-cqrs-serverless/pull/465))
 
 ### Features
 
@@ -16,7 +17,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Security
 
-- Restore the blocking `npm audit --omit=dev --audit-level=high` CI gate that was temporarily disabled, and patch `brace-expansion` (top-level `brace-expansion@2` → `5.0.8`); root production audit: 0 critical/high ([#482](https://github.com/mbc-net/mbc-cqrs-serverless/pull/482))
+- Restore the blocking `npm audit --omit=dev --audit-level=high` CI gate that was temporarily disabled, and patch `brace-expansion` (top-level `brace-expansion@2` → `5.0.8`); **root workspace** production audit: 0 critical/high ([#482](https://github.com/mbc-net/mbc-cqrs-serverless/pull/482))
+  - Scope note: the scaffolded infra template (`packages/cli/templates/infra`) is not an npm workspace member and ships `@aws/pdk` (build-time cdk-graph diagram tooling) whose transitive tree still carries high advisories. It is now audited in CI (non-blocking, for visibility) and tracked separately in [#486](https://github.com/mbc-net/mbc-cqrs-serverless/issues/486); the "0 critical/high" figure above applies to the root workspace only.
 
 ## [1.3.4](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.3.4) (2026-07-17)
 

--- a/packages/cli/templates/infra/test/fixtures/app/README.txt
+++ b/packages/cli/templates/infra/test/fixtures/app/README.txt
@@ -1,0 +1,1 @@
+placeholder app asset for hermetic infra tests

--- a/packages/cli/templates/infra/test/fixtures/layer/README.txt
+++ b/packages/cli/templates/infra/test/fixtures/layer/README.txt
@@ -1,0 +1,1 @@
+placeholder layer asset for hermetic infra tests

--- a/packages/cli/templates/infra/test/infra.test.ts
+++ b/packages/cli/templates/infra/test/infra.test.ts
@@ -54,6 +54,17 @@ jest.mock('aws-cdk-lib', () => ({
   },
 }))
 
+// buildApp() shells out to a real `npm ci && npm run build:prod` of the parent
+// application (via execSync). That cannot run in the isolated template / CI
+// context, so it is mocked to return placeholder asset directories, keeping the
+// CDK synthesis hermetic and the snapshot deterministic.
+jest.mock('../libs/build-app', () => ({
+  buildApp: jest.fn(() => ({
+    layerPath: require('path').resolve(__dirname, 'fixtures/layer'),
+    appPath: require('path').resolve(__dirname, 'fixtures/app'),
+  })),
+}))
+
 function replaceKeyValue(obj: any, desKey: string, desVal: string): any {
   if (typeof obj !== 'object' || obj === null) {
     return obj


### PR DESCRIPTION
## Summary

Resolves the CRITICAL/HIGH findings from the v1.3.5 release review ([PR #485](https://github.com/mbc-net/mbc-cqrs-serverless/pull/485)) about the scaffolded infra template (`packages/cli/templates/infra`) having no CI safety net.

## Root cause (verified)

The infra template's tests never ran in CI, for **two** reasons:
1. The root jest config uses `testRegex: '.*\.spec\.ts$'` (rootDir `packages`), which does not match the template's `*.test.ts` file, and no workflow step installs/tests the template.
2. Even run directly, the tests were **not hermetic**: `InfraStack`'s constructor calls `buildApp()`, which shells out to a real `npm ci && npm run build:prod` of the parent app via `execSync`. In a clean/CI checkout (no cached `dist`/`dist_layer`) this fails, so the tests only "passed" when stale build artifacts happened to exist.

This is why the v1.3.4 `aws_stepfunctions` (undefined identifier) synth break shipped undetected — the CDK snapshot and the `SendTaskSuccess` IAM guard were never enforced.

## Changes

- **`test/infra.test.ts`**: mock `../libs/build-app` so `buildApp()` returns placeholder asset dirs (`test/fixtures/{layer,app}`) — synthesis is now hermetic and deterministic. The committed snapshot still matches (asset hashes are normalized via `replaceKeyValue`), so no snapshot churn. The `SendTaskSuccess` guard and full-stack snapshot are validated against the real synthesized template.
- **`.github/workflows/ci-cd.yml`**:
  - Blocking `Infra template type-check & tests` step (node 20.x), hardened with `--ignore-scripts` (matches the root job's install hardening).
  - Non-blocking `npm audit` step for the template (visibility).
- **`CHANGELOG.md`**: document the infra deploy fix (v1.3.5) and scope the "0 critical/high" audit claim to the root workspace.

## Known limitation

A committed lockfile + `npm ci` would be preferable for reproducibility, but `@aws/pdk`'s dependency tree does not resolve into an `npm ci`-clean lockfile and rewrites it on every `npm install` (verified). Determinism here is blocked on removing `@aws/pdk`, tracked in **#486**. The type-check and tests do not import `@aws/pdk`, so its floating subtree does not affect them.

## Review

Re-reviewed with the MBC parallel reviewers; all HIGH (supply-chain `--ignore-scripts`) and MEDIUM (CHANGELOG attribution) findings addressed. The reviewer-suggested `npm ci` fix was verified infeasible due to `@aws/pdk` (see limitation above).

## Test plan

- [x] `npm install --ignore-scripts && npx tsc --noEmit && npx jest --ci` in `packages/cli/templates/infra` — tsc exit 0, 2 tests pass, snapshot passes (matches the new CI step exactly)
- [x] Reproduced the pre-fix red: clean-env `npx jest` failed (2 failed) via `buildApp` before the mock
- [x] `.github/workflows/ci-cd.yml` YAML validated

Docs-site changelog counterpart: [mbc-cqrs-serverless-doc PR #153](https://github.com/mbc-net/mbc-cqrs-serverless-doc/pull/153).

🤖 Generated with [Claude Code](https://claude.com/claude-code)