### PR TITLE
ci: fix "Invalid format" error in dependency-update-test output

### DIFF
--- a/.github/workflows/dependency-update-test.yml
+++ b/.github/workflows/dependency-update-test.yml
@@ -69,8 +69,17 @@ jobs:
           # Get the list of changed dependencies
           git diff origin/main...HEAD -- package-lock.json > /tmp/lockfile-diff.txt || true
 
-          # Count changed packages
-          CHANGED_COUNT=$(grep -c '"version":' /tmp/lockfile-diff.txt || echo "0")
+          # Count changed packages.
+          # `grep -c` already prints "0" when there is no match (and exits
+          # non-zero), so the old `|| echo "0"` appended a SECOND "0", producing
+          # a two-line value ("0\n0"). Writing that to $GITHUB_OUTPUT fails with
+          # "Invalid format '0'". This triggers whenever the PR changes a
+          # package.json (workflow trigger) but the root package-lock.json has no
+          # diff vs the current main (e.g. a PR to develop after main already
+          # carries develop's lockfile). Use `|| true` (grep's own "0" stays) and
+          # a default so the value is always a single line.
+          CHANGED_COUNT=$(grep -c '"version":' /tmp/lockfile-diff.txt || true)
+          CHANGED_COUNT=${CHANGED_COUNT:-0}
           echo "changed_packages=$CHANGED_COUNT" >> $GITHUB_OUTPUT
 
           # Check for major version updates


### PR DESCRIPTION
## Summary

The **Dependency Update Validation** job fails on some PRs with:

```
Invalid format '0'
Unable to process file command 'output' successfully.
Process completed with exit code 1.
```

## Root cause (reproduced)

In `.github/workflows/dependency-update-test.yml`, the *Analyze dependency changes* step does:

```bash
git diff origin/main...HEAD -- package-lock.json > /tmp/lockfile-diff.txt || true
CHANGED_COUNT=$(grep -c '"version":' /tmp/lockfile-diff.txt || echo "0")
echo "changed_packages=$CHANGED_COUNT" >> $GITHUB_OUTPUT
```

`grep -c` **always prints a count** (including `0`) and exits **non-zero** when there is no match. So on an empty diff, `grep -c` prints `0` **and** the `|| echo "0"` fires, giving `CHANGED_COUNT="0\n0"` (two lines). Writing a multi-line value with `key=value` syntax to `$GITHUB_OUTPUT` is invalid → `Invalid format '0'`.

The diff is empty (so the bug fires) when a PR **changes a `package.json`** (which triggers this workflow via `paths`) but the **root `package-lock.json` has no diff vs the current `main`**.

Verified against real PRs:

| PR | main at CI time | `git diff origin/main...HEAD -- package-lock.json` | `CHANGED_COUNT` | result |
|----|-----------------|----------------------------------------------------|-----------------|--------|
| release #485 | behind develop | 23,885 bytes (non-empty) | `65` (one line) | ✅ pass |
| PR to develop after the release | already has develop's lockfile | 0 bytes (empty) | `0\n0` (two lines) | ❌ `Invalid format '0'` |

So this is a **pre-existing latent bug**; release PRs to `main` avoided it only because `main` was behind at the time (non-empty diff).

## Fix

```bash
CHANGED_COUNT=$(grep -c '"version":' /tmp/lockfile-diff.txt || true)
CHANGED_COUNT=${CHANGED_COUNT:-0}
```

`grep`'s own single-line `0` is kept; `|| true` avoids failing under `set -eo pipefail`; the default guards the (unlikely) empty case.

Verified under the Actions default shell (`bash -eo pipefail`): empty diff → `0` (one line), no-match → `0`, N matches → `N` — always a single line, step never aborts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)