### PR TITLE
docs(changelog): correct v1.3.5 release date to 2026-08-01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.3.5](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.3.5) (2026-07-29)
+## [1.3.5](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.3.5) (2026-08-01)
 
 ### Bug Fixes
 


### PR DESCRIPTION
## Summary

v1.3.5 was tagged and released on **2026-08-01**, but the `CHANGELOG.md` entry still read `(2026-07-29)` (the date used when the entry was first backfilled).

The `v1.3.5` git tag is immutable, so this does not change the already-published release, but it aligns the repository CHANGELOG with the actual release date going forward (and matches the documentation-site changelog / `releases-*.json`, updated in mbc-cqrs-serverless-doc [PR #153](https://github.com/mbc-net/mbc-cqrs-serverless-doc/pull/153)).

## Changes

- `CHANGELOG.md`: v1.3.5 date `2026-07-29` → `2026-08-01` (one line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)