### PR TITLE
Release v1.4.0: configurable domain table names + registerAsync

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,9 @@ module.exports = {
     '**/*.spec.ts',
     '**/*.test.ts',
     'examples/**',
+    // Scaffolding templates are excluded from tsconfig and reference
+    // generated-app paths, so they cannot be type-aware linted.
+    '**/src/templates/**',
   ],
   rules: {
     '@typescript-eslint/interface-name-prefix': 'off',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.3.5](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.3.5) (2026-07-29)
+## [1.3.5](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.3.5) (2026-08-01)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.4.0](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.4.0) (2026-08-02)
+
+### Features
+
+- **core, master, directory, survey-template, ui-setting:** Make the DynamoDB table names of the domain modules configurable via a backward-compatible `tableName?` option, and add `registerAsync` support to all four modules. Defaults are unchanged (`master` / `directory` / `survey` / `master`), so existing apps upgrade with no code changes ([#493](https://github.com/mbc-net/mbc-cqrs-serverless/pull/493))
+  - **directory:** `DirectoryStorageModule` additionally accepts `pkPrefix?` (default `DIRECTORY`) and `prismaModelName?` (default `directory`). The `directory` → `document` rename ([#469](https://github.com/mbc-net/mbc-cqrs-serverless/pull/469)) is now expressed as opt-in configuration (`tableName: 'document'`, `pkPrefix: 'DOCUMENT'`, `prismaModelName: 'document'`) rather than a forced default
+- **mcp-server:** Add the v1.3.5 → v1.4.0 migration guide to the `mbc-migrate` skill (configurable table names, how to change a table name, and the central master-table caveat) ([#494](https://github.com/mbc-net/mbc-cqrs-serverless/pull/494))
+
+### Changes (behavior)
+
+- **master, directory, survey-template:** `prismaService` is now always required at registration (previously validated only when `enableController: true`). A missing value now fails fast at startup with a clear message instead of a cryptic dependency-resolution error. Pass `prismaService` explicitly if you registered with `enableController: false` and relied on a globally-provided token ([#493](https://github.com/mbc-net/mbc-cqrs-serverless/pull/493))
+- **master, ui-setting:** When `MasterModule` and `SettingModule` share the default `master` table, the framework logs a startup warning if both own the `master_CommandEventHandler` alias (data-sync ownership becomes import-order dependent). Set `registerEventHandlerAlias: false` on `SettingModule` so `MasterModule` owns the alias ([#493](https://github.com/mbc-net/mbc-cqrs-serverless/pull/493))
+- **master:** `MasterModule` logs a warning if its `tableName` is overridden — the `master` table is a framework-wide config store read at a fixed `master-data` name by `TtlService` and the sequence package, so renaming it is not fully supported ([#493](https://github.com/mbc-net/mbc-cqrs-serverless/pull/493))
+- **core:** `CommandModule.registerAsync()` now throws a clear error (it cannot build the `<tableName>_CommandEventHandler` alias asynchronously); compose CommandModule via `register()` or a domain module ([#493](https://github.com/mbc-net/mbc-cqrs-serverless/pull/493))
+
 ## [1.3.5](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.3.5) (2026-08-01)
 
 ### Bug Fixes

--- a/packages/core/src/commands/command-module.helper.ts
+++ b/packages/core/src/commands/command-module.helper.ts
@@ -1,5 +1,4 @@
 import { DynamicModule, Provider, Type } from '@nestjs/common'
-import { ModuleRef } from '@nestjs/core'
 
 import { IDataSyncHandler } from '../interfaces/data-sync-handler.interface'
 import { CommandModule } from './command.module'
@@ -67,9 +66,21 @@ export function buildPrismaProviderSync(
 }
 
 /**
- * Build the `PRISMA_SERVICE` provider for the `registerAsync()` path. The
- * concrete PrismaService class is resolved at runtime from the module options
- * token (populated by the caller's async factory) via {@link ModuleRef}.
+ * Build the `PRISMA_SERVICE` provider for the `registerAsync()` path.
+ *
+ * The async factory must return the **resolved PrismaService instance** (not the
+ * class) under `prismaService` — typically by injecting it:
+ *
+ * ```ts
+ * registerAsync({ imports: [PrismaModule], inject: [PrismaService],
+ *   useFactory: (prisma) => ({ prismaService: prisma }) })
+ * ```
+ *
+ * The instance is aliased to the token directly, so Nest's own dependency graph
+ * guarantees PrismaService is constructed first (even when it is provided
+ * asynchronously via `forRootAsync`). Resolving the class via `ModuleRef.get`
+ * here would NOT be ordered against an async PrismaService and could inject
+ * `null`.
  */
 export function buildPrismaProviderAsync(
   optionsToken: string | symbol,
@@ -77,17 +88,15 @@ export function buildPrismaProviderAsync(
 ): Provider {
   return {
     provide: prismaToken,
-    inject: [ModuleRef, optionsToken],
-    useFactory: (
-      moduleRef: ModuleRef,
-      options: { prismaService?: Type<any> },
-    ) => {
+    inject: [optionsToken],
+    useFactory: (options: { prismaService?: any }) => {
       if (!options?.prismaService) {
         throw new Error(
-          `${String(prismaToken)}: 'prismaService' is required (registerAsync factory must return it).`,
+          `${String(prismaToken)}: registerAsync's useFactory must resolve and ` +
+            `return the PrismaService instance under 'prismaService'.`,
         )
       }
-      return moduleRef.get(options.prismaService, { strict: false })
+      return options.prismaService
     },
   }
 }

--- a/packages/core/src/commands/command-module.helper.ts
+++ b/packages/core/src/commands/command-module.helper.ts
@@ -1,0 +1,79 @@
+import { DynamicModule, Provider, Type } from '@nestjs/common'
+import { ModuleRef } from '@nestjs/core'
+
+import { IDataSyncHandler } from '../interfaces/data-sync-handler.interface'
+import { CommandModule } from './command.module'
+
+/**
+ * Structural (build-time) options that every domain module forwards to
+ * {@link CommandModule}. The table name is a deploy-time constant, so it must be
+ * known synchronously at module-composition time — the `<tableName>_CommandEventHandler`
+ * provider alias is created eagerly by `CommandModule.register`.
+ */
+export interface DomainCommandModuleOptions {
+  /** Raw DynamoDB base table name (physical name = `${NODE_ENV}-${APP_NAME}-${tableName}`). */
+  tableName?: string
+  dataSyncHandlers?: Type<IDataSyncHandler>[]
+}
+
+/**
+ * Compose {@link CommandModule} for a domain module, applying the domain's
+ * default table name when the caller omitted one.
+ *
+ * Used by BOTH `register()` and `registerAsync()` so the static
+ * `<tableName>_CommandEventHandler` alias is always generated from a
+ * build-time-known table name (dynamic provider tokens cannot be produced from
+ * an async factory result).
+ */
+export function buildDomainCommandModule(
+  defaultTableName: string,
+  options: DomainCommandModuleOptions,
+): DynamicModule {
+  return CommandModule.register({
+    tableName: options.tableName ?? defaultTableName,
+    dataSyncHandlers: options.dataSyncHandlers,
+  })
+}
+
+/**
+ * Build the `PRISMA_SERVICE` provider for the synchronous `register()` path.
+ * Fails fast when `prismaService` is missing, because the domain services
+ * inject the token unconditionally.
+ */
+export function buildPrismaProviderSync(
+  prismaService: Type<any> | undefined,
+  token: string | symbol,
+): Provider {
+  if (!prismaService) {
+    throw new Error(
+      `${String(token)}: 'prismaService' is required for this module.`,
+    )
+  }
+  return { provide: token, useExisting: prismaService }
+}
+
+/**
+ * Build the `PRISMA_SERVICE` provider for the `registerAsync()` path. The
+ * concrete PrismaService class is resolved at runtime from the module options
+ * token (populated by the caller's async factory) via {@link ModuleRef}.
+ */
+export function buildPrismaProviderAsync(
+  optionsToken: string | symbol,
+  prismaToken: string | symbol,
+): Provider {
+  return {
+    provide: prismaToken,
+    inject: [ModuleRef, optionsToken],
+    useFactory: (
+      moduleRef: ModuleRef,
+      options: { prismaService?: Type<any> },
+    ) => {
+      if (!options?.prismaService) {
+        throw new Error(
+          `${String(prismaToken)}: 'prismaService' is required (registerAsync factory must return it).`,
+        )
+      }
+      return moduleRef.get(options.prismaService, { strict: false })
+    },
+  }
+}

--- a/packages/core/src/commands/command-module.helper.ts
+++ b/packages/core/src/commands/command-module.helper.ts
@@ -96,6 +96,13 @@ export function buildPrismaProviderAsync(
             `return the PrismaService instance under 'prismaService'.`,
         )
       }
+      if (typeof options.prismaService === 'function') {
+        throw new Error(
+          `${String(prismaToken)}: registerAsync's useFactory returned the ` +
+            `PrismaService CLASS, not an instance. Inject and return the instance: ` +
+            `{ inject: [PrismaService], useFactory: (p) => ({ prismaService: p }) }.`,
+        )
+      }
       return options.prismaService
     },
   }

--- a/packages/core/src/commands/command-module.helper.ts
+++ b/packages/core/src/commands/command-module.helper.ts
@@ -40,8 +40,14 @@ export function buildDomainCommandModule(
   defaultTableName: string,
   options: DomainCommandModuleOptions,
 ): DynamicModule {
+  const tableName = options.tableName ?? defaultTableName
+  if (!tableName) {
+    throw new Error(
+      `tableName must be a non-empty string (received '${tableName}').`,
+    )
+  }
   return CommandModule.register({
-    tableName: options.tableName ?? defaultTableName,
+    tableName,
     dataSyncHandlers: options.dataSyncHandlers,
     registerHandlerProviders: false,
     registerEventHandlerAlias: options.registerEventHandlerAlias ?? true,

--- a/packages/core/src/commands/command-module.helper.ts
+++ b/packages/core/src/commands/command-module.helper.ts
@@ -14,6 +14,12 @@ export interface DomainCommandModuleOptions {
   /** Raw DynamoDB base table name (physical name = `${NODE_ENV}-${APP_NAME}-${tableName}`). */
   tableName?: string
   dataSyncHandlers?: Type<IDataSyncHandler>[]
+  /**
+   * Whether this module owns the `<tableName>_CommandEventHandler` alias.
+   * Defaults to `true`. Set to `false` when sharing a table already owned by
+   * another module (avoids a duplicate-alias collision).
+   */
+  registerEventHandlerAlias?: boolean
 }
 
 /**
@@ -24,6 +30,12 @@ export interface DomainCommandModuleOptions {
  * `<tableName>_CommandEventHandler` alias is always generated from a
  * build-time-known table name (dynamic provider tokens cannot be produced from
  * an async factory result).
+ *
+ * The `dataSyncHandlers` are NOT registered as CommandModule providers here
+ * (`registerHandlerProviders: false`) — the domain module registers them as its
+ * own providers so they can resolve domain-scoped tokens (e.g. PRISMA_SERVICE).
+ * CommandService still resolves them globally via
+ * `ModuleRef.get(HandlerClass, { strict: false })`.
  */
 export function buildDomainCommandModule(
   defaultTableName: string,
@@ -32,6 +44,8 @@ export function buildDomainCommandModule(
   return CommandModule.register({
     tableName: options.tableName ?? defaultTableName,
     dataSyncHandlers: options.dataSyncHandlers,
+    registerHandlerProviders: false,
+    registerEventHandlerAlias: options.registerEventHandlerAlias ?? true,
   })
 }
 

--- a/packages/core/src/commands/command.module.ts
+++ b/packages/core/src/commands/command.module.ts
@@ -78,4 +78,21 @@ export class CommandModule extends ConfigurableModuleClass {
       ...module,
     }
   }
+
+  /**
+   * Not supported. The `<tableName>_CommandEventHandler` alias and
+   * dataSyncHandlers wiring must be composed at build time (the table name is a
+   * deploy-time constant), which the inherited async builder cannot do — it
+   * would silently produce a module with no alias, failing the Step Functions
+   * data-sync pipeline at runtime. Use {@link CommandModule.register} (domain
+   * modules compose it via `buildDomainCommandModule`).
+   */
+  static registerAsync(): DynamicModule {
+    throw new Error(
+      'CommandModule.registerAsync() is not supported: the table name must be ' +
+        'known at build time to register the `<tableName>_CommandEventHandler` ' +
+        'alias. Use CommandModule.register(), or a domain module that composes it ' +
+        'via buildDomainCommandModule.',
+    )
+  }
 }

--- a/packages/core/src/commands/command.module.ts
+++ b/packages/core/src/commands/command.module.ts
@@ -45,6 +45,20 @@ export class CommandModule extends ConfigurableModuleClass {
       registerEventHandlerAlias = true,
     } = options
 
+    // A module that defers the alias to another owner cannot run its own
+    // data-sync handlers on the asynchronous (Step Functions) pipeline — that
+    // pipeline only invokes the alias owner's CommandService. Fail fast rather
+    // than dropping them silently for async commands.
+    if (!registerEventHandlerAlias && dataSyncHandlers.length > 0) {
+      throw new Error(
+        `[${tableName}] dataSyncHandlers were provided together with ` +
+          `registerEventHandlerAlias:false. These handlers would not run on the ` +
+          `asynchronous (Step Functions) data-sync pipeline, which only invokes the ` +
+          `owner of the '${tableName}_CommandEventHandler' alias. Register them on ` +
+          `the alias-owning module instead.`,
+      )
+    }
+
     if (registerEventHandlerAlias) {
       module.providers.push({
         // data-sync-handler uses dynamic command event handler to handle step function events of command execution

--- a/packages/core/src/commands/command.module.ts
+++ b/packages/core/src/commands/command.module.ts
@@ -38,15 +38,27 @@ export class CommandModule extends ConfigurableModuleClass {
   static register(options: typeof OPTIONS_TYPE): DynamicModule {
     const module = super.register(options)
 
-    const { tableName, dataSyncHandlers = [] } = options
-    module.providers.push(
-      {
+    const {
+      tableName,
+      dataSyncHandlers = [],
+      registerHandlerProviders = true,
+      registerEventHandlerAlias = true,
+    } = options
+
+    if (registerEventHandlerAlias) {
+      module.providers.push({
         // data-sync-handler uses dynamic command event handler to handle step function events of command execution
         provide: tableName + '_CommandEventHandler',
         useExisting: CommandEventHandler,
-      },
-      ...dataSyncHandlers,
-    )
+      })
+    }
+
+    // When false, the handlers are provided by the importing (domain) module so
+    // they can resolve domain-scoped tokens; CommandService still resolves them
+    // globally via ModuleRef.get(HandlerClass, { strict: false }).
+    if (registerHandlerProviders) {
+      module.providers.push(...dataSyncHandlers)
+    }
 
     return {
       ...module,

--- a/packages/core/src/commands/command.service.ts
+++ b/packages/core/src/commands/command.service.ts
@@ -79,21 +79,26 @@ export class CommandService implements OnModuleInit, ICommandService {
   }
 
   onModuleInit() {
-    // Fail fast when two CommandModule instances own the same table's
+    // Detect how many CommandModule instances own this table's
     // `<tableName>_CommandEventHandler` alias. The Step Functions data-sync
-    // pipeline resolves the alias non-strictly, so a duplicate would silently
-    // shadow one module's data-sync handlers depending on import order.
+    // pipeline resolves the alias non-strictly, so a duplicate can shadow one
+    // module's data-sync handlers depending on import order.
     const aliasCount = this.explorerService.countCommandEventHandlerAliases?.(
       this.options.tableName,
     )
     if (typeof aliasCount === 'number') {
       if (aliasCount > 1) {
-        throw new Error(
+        // Warn (not throw) to preserve backward compatibility for existing
+        // MasterModule + SettingModule deployments that already share a table.
+        // Set `registerEventHandlerAlias: false` on the non-owning module for
+        // deterministic single-owner behavior.
+        this.logger.warn(
           `[${this.options.tableName}] ${aliasCount} CommandModule registrations own the ` +
-            `'${this.options.tableName}_CommandEventHandler' alias. A DynamoDB table must be ` +
-            `owned by exactly one CommandModule data-sync pipeline. When MasterModule and ` +
-            `ui-setting's SettingModule share this table, set 'registerEventHandlerAlias: false' ` +
-            `on SettingModule so MasterModule owns the alias.`,
+            `'${this.options.tableName}_CommandEventHandler' alias. The Step Functions data-sync ` +
+            `pipeline resolves it non-strictly, so which module's data-sync handlers run is ` +
+            `import-order dependent. When MasterModule and ui-setting's SettingModule share this ` +
+            `table, set 'registerEventHandlerAlias: false' on SettingModule so MasterModule owns ` +
+            `the alias.`,
         )
       }
       // This module deferred the alias but no other module owns it — the Step

--- a/packages/core/src/commands/command.service.ts
+++ b/packages/core/src/commands/command.service.ts
@@ -79,6 +79,23 @@ export class CommandService implements OnModuleInit, ICommandService {
   }
 
   onModuleInit() {
+    // Fail fast when two CommandModule instances own the same table's
+    // `<tableName>_CommandEventHandler` alias. The Step Functions data-sync
+    // pipeline resolves the alias non-strictly, so a duplicate would silently
+    // shadow one module's data-sync handlers depending on import order.
+    const aliasCount = this.explorerService.countCommandEventHandlerAliases?.(
+      this.options.tableName,
+    )
+    if (typeof aliasCount === 'number' && aliasCount > 1) {
+      throw new Error(
+        `[${this.options.tableName}] ${aliasCount} CommandModule registrations own the ` +
+          `'${this.options.tableName}_CommandEventHandler' alias. A DynamoDB table must be ` +
+          `owned by exactly one CommandModule data-sync pipeline. When MasterModule and ` +
+          `ui-setting's SettingModule share this table, set 'registerEventHandlerAlias: false' ` +
+          `on SettingModule so MasterModule owns the alias.`,
+      )
+    }
+
     if (!this.options.disableDefaultHandler) {
       this[DATA_SYNC_HANDLER] = [this.dataSyncDdsHandler]
     }

--- a/packages/core/src/commands/command.service.ts
+++ b/packages/core/src/commands/command.service.ts
@@ -86,14 +86,30 @@ export class CommandService implements OnModuleInit, ICommandService {
     const aliasCount = this.explorerService.countCommandEventHandlerAliases?.(
       this.options.tableName,
     )
-    if (typeof aliasCount === 'number' && aliasCount > 1) {
-      throw new Error(
-        `[${this.options.tableName}] ${aliasCount} CommandModule registrations own the ` +
-          `'${this.options.tableName}_CommandEventHandler' alias. A DynamoDB table must be ` +
-          `owned by exactly one CommandModule data-sync pipeline. When MasterModule and ` +
-          `ui-setting's SettingModule share this table, set 'registerEventHandlerAlias: false' ` +
-          `on SettingModule so MasterModule owns the alias.`,
-      )
+    if (typeof aliasCount === 'number') {
+      if (aliasCount > 1) {
+        throw new Error(
+          `[${this.options.tableName}] ${aliasCount} CommandModule registrations own the ` +
+            `'${this.options.tableName}_CommandEventHandler' alias. A DynamoDB table must be ` +
+            `owned by exactly one CommandModule data-sync pipeline. When MasterModule and ` +
+            `ui-setting's SettingModule share this table, set 'registerEventHandlerAlias: false' ` +
+            `on SettingModule so MasterModule owns the alias.`,
+        )
+      }
+      // This module deferred the alias but no other module owns it — the Step
+      // Functions data-sync pipeline would fail at runtime on the first async
+      // command. Fail fast at startup instead.
+      if (
+        aliasCount === 0 &&
+        this.options.registerEventHandlerAlias === false
+      ) {
+        throw new Error(
+          `[${this.options.tableName}] registerEventHandlerAlias:false was set, but no other ` +
+            `CommandModule owns the '${this.options.tableName}_CommandEventHandler' alias for ` +
+            `this table. Import the owning module (e.g. MasterModule) with a matching tableName, ` +
+            `or remove registerEventHandlerAlias:false so this module owns the alias.`,
+        )
+      }
     }
 
     if (!this.options.disableDefaultHandler) {

--- a/packages/core/src/commands/index.ts
+++ b/packages/core/src/commands/index.ts
@@ -1,6 +1,7 @@
 export * from './command.event.handler'
 export * from './command.module'
 export * from './command.service'
+export * from './command-module.helper'
 export * from './data.service'
 export * from './enums'
 export * from './handlers'

--- a/packages/core/src/integration/cross-package-integration.spec.ts
+++ b/packages/core/src/integration/cross-package-integration.spec.ts
@@ -110,18 +110,18 @@ describe('Cross-Package Integration', () => {
     })
 
     describe('Directory package key patterns', () => {
-      const DIRECTORY_PREFIX = 'DIRECTORY'
+      const DIRECTORY_PREFIX = 'DOCUMENT'
 
       it('should generate directory PK with tenant code', () => {
         const pk = generatePk(DIRECTORY_PREFIX, 'COMPANY_X')
-        expect(pk).toBe('DIRECTORY#COMPANY_X')
+        expect(pk).toBe('DOCUMENT#COMPANY_X')
       })
 
       it('should generate complete ID from PK and SK', () => {
         const pk = generatePk(DIRECTORY_PREFIX, 'COMPANY_X')
         const sk = 'folder-ulid-123'
         const id = generateId(pk, sk)
-        expect(id).toBe('DIRECTORY#COMPANY_X#folder-ulid-123')
+        expect(id).toBe('DOCUMENT#COMPANY_X#folder-ulid-123')
       })
     })
   })
@@ -162,7 +162,7 @@ describe('Cross-Package Integration', () => {
      */
     function extractTenantFromPk(pk: string): string | null {
       const match = pk.match(
-        /^(TENANT|SETTING|MASTER|SEQUENCE|TASK|DIRECTORY)#([^#]+)/,
+        /^(TENANT|SETTING|MASTER|SEQUENCE|TASK|DOCUMENT)#([^#]+)/,
       )
       return match ? match[2] : null
     }
@@ -219,8 +219,8 @@ describe('Cross-Package Integration', () => {
         expect(extractTenantFromPk('TASK#CLIENT_1')).toBe('CLIENT_1')
       })
 
-      it('should extract tenant from DIRECTORY PK', () => {
-        expect(extractTenantFromPk('DIRECTORY#CORP_ABC')).toBe('CORP_ABC')
+      it('should extract tenant from DOCUMENT PK', () => {
+        expect(extractTenantFromPk('DOCUMENT#CORP_ABC')).toBe('CORP_ABC')
       })
 
       it('should return null for invalid PK', () => {
@@ -304,9 +304,10 @@ describe('Cross-Package Integration', () => {
     /**
      * Parses SK to extract base SK and version
      */
-    function parseVersionedSk(
-      sk: string,
-    ): { baseSk: string; version?: number } {
+    function parseVersionedSk(sk: string): {
+      baseSk: string
+      version?: number
+    } {
       const parts = sk.split(VER_SEPARATOR)
       if (parts.length === 2) {
         return {
@@ -445,7 +446,9 @@ describe('Cross-Package Integration', () => {
       ): { pk: string; sk: string } {
         return {
           pk: `SEQUENCE${KEY_SEPARATOR}${tenantCode}`,
-          sk: [config.typeCode, rotateValue].filter(Boolean).join(KEY_SEPARATOR),
+          sk: [config.typeCode, rotateValue]
+            .filter(Boolean)
+            .join(KEY_SEPARATOR),
         }
       }
 
@@ -542,7 +545,7 @@ describe('Cross-Package Integration', () => {
         data: Partial<DirectoryItem>,
       ): DirectoryItem {
         return {
-          pk: `DIRECTORY${KEY_SEPARATOR}${tenantCode}`,
+          pk: `DOCUMENT${KEY_SEPARATOR}${tenantCode}`,
           sk: itemId,
           tenantCode,
           name: data.name || 'Untitled',
@@ -558,7 +561,7 @@ describe('Cross-Package Integration', () => {
           type: 'folder',
         })
 
-        expect(folder.pk).toBe('DIRECTORY#ORG_123')
+        expect(folder.pk).toBe('DOCUMENT#ORG_123')
         expect(folder.sk).toBe('ulid-folder-001')
         expect(folder.tenantCode).toBe('ORG_123')
       })
@@ -635,9 +638,10 @@ describe('Cross-Package Integration', () => {
       /**
        * Generates SK prefix for begins_with queries
        */
-      function skBeginsWithExpression(
-        prefix: string,
-      ): { expression: string; values: Record<string, string> } {
+      function skBeginsWithExpression(prefix: string): {
+        expression: string
+        values: Record<string, string>
+      } {
         return {
           expression: 'begins_with(sk, :prefix)',
           values: { ':prefix': `${prefix}${KEY_SEPARATOR}` },
@@ -782,7 +786,9 @@ describe('Cross-Package Integration', () => {
       }
     }
 
-    function projectDataFromEvents(events: CommandEvent[]): DataSnapshot | null {
+    function projectDataFromEvents(
+      events: CommandEvent[],
+    ): DataSnapshot | null {
       if (events.length === 0) return null
 
       const sorted = [...events].sort((a, b) => a.version - b.version)

--- a/packages/core/src/integration/cross-package-integration.spec.ts
+++ b/packages/core/src/integration/cross-package-integration.spec.ts
@@ -110,18 +110,18 @@ describe('Cross-Package Integration', () => {
     })
 
     describe('Directory package key patterns', () => {
-      const DIRECTORY_PREFIX = 'DOCUMENT'
+      const DIRECTORY_PREFIX = 'DIRECTORY'
 
       it('should generate directory PK with tenant code', () => {
         const pk = generatePk(DIRECTORY_PREFIX, 'COMPANY_X')
-        expect(pk).toBe('DOCUMENT#COMPANY_X')
+        expect(pk).toBe('DIRECTORY#COMPANY_X')
       })
 
       it('should generate complete ID from PK and SK', () => {
         const pk = generatePk(DIRECTORY_PREFIX, 'COMPANY_X')
         const sk = 'folder-ulid-123'
         const id = generateId(pk, sk)
-        expect(id).toBe('DOCUMENT#COMPANY_X#folder-ulid-123')
+        expect(id).toBe('DIRECTORY#COMPANY_X#folder-ulid-123')
       })
     })
   })
@@ -162,7 +162,7 @@ describe('Cross-Package Integration', () => {
      */
     function extractTenantFromPk(pk: string): string | null {
       const match = pk.match(
-        /^(TENANT|SETTING|MASTER|SEQUENCE|TASK|DOCUMENT)#([^#]+)/,
+        /^(TENANT|SETTING|MASTER|SEQUENCE|TASK|DIRECTORY)#([^#]+)/,
       )
       return match ? match[2] : null
     }
@@ -219,8 +219,8 @@ describe('Cross-Package Integration', () => {
         expect(extractTenantFromPk('TASK#CLIENT_1')).toBe('CLIENT_1')
       })
 
-      it('should extract tenant from DOCUMENT PK', () => {
-        expect(extractTenantFromPk('DOCUMENT#CORP_ABC')).toBe('CORP_ABC')
+      it('should extract tenant from DIRECTORY PK', () => {
+        expect(extractTenantFromPk('DIRECTORY#CORP_ABC')).toBe('CORP_ABC')
       })
 
       it('should return null for invalid PK', () => {
@@ -326,9 +326,9 @@ describe('Cross-Package Integration', () => {
       })
 
       it('should support VERSION_FIRST constant', () => {
-        const baseSk = 'DOCUMENT#DOC001'
+        const baseSk = 'DIRECTORY#DOC001'
         const historySk = generateHistorySk(baseSk, VERSION_FIRST)
-        expect(historySk).toBe('DOCUMENT#DOC001@0')
+        expect(historySk).toBe('DIRECTORY#DOC001@0')
       })
     })
 
@@ -545,7 +545,7 @@ describe('Cross-Package Integration', () => {
         data: Partial<DirectoryItem>,
       ): DirectoryItem {
         return {
-          pk: `DOCUMENT${KEY_SEPARATOR}${tenantCode}`,
+          pk: `DIRECTORY${KEY_SEPARATOR}${tenantCode}`,
           sk: itemId,
           tenantCode,
           name: data.name || 'Untitled',
@@ -561,7 +561,7 @@ describe('Cross-Package Integration', () => {
           type: 'folder',
         })
 
-        expect(folder.pk).toBe('DOCUMENT#ORG_123')
+        expect(folder.pk).toBe('DIRECTORY#ORG_123')
         expect(folder.sk).toBe('ulid-folder-001')
         expect(folder.tenantCode).toBe('ORG_123')
       })

--- a/packages/core/src/interfaces/command-module-options.interface.ts
+++ b/packages/core/src/interfaces/command-module-options.interface.ts
@@ -31,4 +31,23 @@ export interface CommandModuleOptions {
   dataSyncHandlers?: Type<IDataSyncHandler>[]
   /** If true, disables the default data sync handler */
   disableDefaultHandler?: boolean
+  /**
+   * Whether `dataSyncHandlers` are registered as providers of CommandModule
+   * itself. Defaults to `true` (backward compatible).
+   *
+   * Set to `false` when the handlers are provided by the importing (domain)
+   * module instead — e.g. when they inject a token such as `PRISMA_SERVICE`
+   * that only exists in the domain module's scope. CommandService still resolves
+   * them globally via `ModuleRef.get(HandlerClass, { strict: false })`.
+   */
+  registerHandlerProviders?: boolean
+  /**
+   * Whether to register the `<tableName>_CommandEventHandler` alias provider
+   * that the Step Functions data-sync pipeline resolves. Defaults to `true`.
+   *
+   * Set to `false` on a module that shares a physical table already owned by
+   * another module (which registers the alias), to avoid a duplicate-alias
+   * collision. Exactly one module per table must register the alias.
+   */
+  registerEventHandlerAlias?: boolean
 }

--- a/packages/core/src/services/explorer.service.ts
+++ b/packages/core/src/services/explorer.service.ts
@@ -62,6 +62,23 @@ export class ExplorerService {
     )
   }
 
+  /**
+   * Count how many modules register the `<tableName>_CommandEventHandler` alias
+   * provider. More than one indicates two CommandModule instances competing for
+   * the same physical table's data-sync pipeline (the alias is resolved
+   * non-strictly, so only one — import-order dependent — would win).
+   */
+  countCommandEventHandlerAliases(tableName: string): number {
+    const token = `${tableName}_CommandEventHandler`
+    let count = 0
+    for (const module of this.modulesContainer.values()) {
+      if (module.providers.has(token)) {
+        count++
+      }
+    }
+    return count
+  }
+
   flatMap<T>(
     modules: Module[],
     callback: (instance: InstanceWrapper) => Type<any> | undefined,

--- a/packages/directory/README.md
+++ b/packages/directory/README.md
@@ -70,6 +70,13 @@ DirectoryStorageModule.registerAsync({
 > into `<name>-command`, `<name>-data`, and `<name>-history` — do **not** add
 > those suffixes yourself. Mirror the same three physical tables in your IaC.
 > Migrating existing data to a renamed table is the application's responsibility.
+>
+> **Unique table name:** give each domain module its own `tableName`. Sharing one
+> physical table across modules is only wired for `MasterModule` + ui-setting's
+> `SettingModule` (via `registerEventHandlerAlias`). Pointing another module at a
+> table already owned by a different module registers a second
+> `<tableName>_CommandEventHandler` alias — the app logs a warning and which
+> module's data-sync handlers run becomes import-order dependent.
 
 ## Documentation
 

--- a/packages/directory/README.md
+++ b/packages/directory/README.md
@@ -59,6 +59,8 @@ DirectoryStorageModule.register({
 // even when Prisma is provided via forRootAsync).
 DirectoryStorageModule.registerAsync({
   tableName: 'document',
+  pkPrefix: 'DOCUMENT',
+  prismaModelName: 'document',
   imports: [PrismaModule],
   inject: [PrismaService],
   useFactory: (prisma) => ({ prismaService: prisma }),

--- a/packages/directory/README.md
+++ b/packages/directory/README.md
@@ -54,12 +54,14 @@ DirectoryStorageModule.register({
 })
 
 // Async configuration is also supported. The table name is a build-time
-// constant, so it is passed as a plain field; the factory only resolves
-// runtime dependencies such as prismaService.
+// constant, so it is passed as a plain field; the factory must resolve and
+// return the PrismaService INSTANCE (inject it so Nest orders it correctly,
+// even when Prisma is provided via forRootAsync).
 DirectoryStorageModule.registerAsync({
   tableName: 'document',
-  inject: [],
-  useFactory: () => ({ prismaService: PrismaService }),
+  imports: [PrismaModule],
+  inject: [PrismaService],
+  useFactory: (prisma) => ({ prismaService: prisma }),
 })
 ```
 

--- a/packages/directory/README.md
+++ b/packages/directory/README.md
@@ -32,6 +32,43 @@ npm install @mbc-cqrs-serverless/directory
 - `PUT /api/directory/:id` - Update a specific file or folder
 - `DELETE /api/directory/:id` - Delete a specific file or folder
 
+## Configurable table name
+
+`DirectoryStorageModule` stores its data on the `directory` DynamoDB table by
+default. You can override this (and related identifiers) with backward-compatible
+options — omitting them keeps the current behavior.
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `tableName` | `directory` | Raw DynamoDB base table name. Physical tables become `${NODE_ENV}-${APP_NAME}-${tableName}` (`-command` / `-data` / `-history`). |
+| `pkPrefix` | `DIRECTORY` | Partition-key prefix (before `#`). |
+| `prismaModelName` | `directory` | Prisma model accessor used for RDS reads. |
+
+```ts
+DirectoryStorageModule.register({
+  enableController: true,
+  prismaService: PrismaService,
+  tableName: 'document',
+  pkPrefix: 'DOCUMENT',
+  prismaModelName: 'document',
+})
+
+// Async configuration is also supported. The table name is a build-time
+// constant, so it is passed as a plain field; the factory only resolves
+// runtime dependencies such as prismaService.
+DirectoryStorageModule.registerAsync({
+  tableName: 'document',
+  inject: [],
+  useFactory: () => ({ prismaService: PrismaService }),
+})
+```
+
+> **Provisioning:** When you use a custom `tableName`, add **only the raw base
+> name** (e.g. `"document"`) to `prisma/dynamodbs/cqrs.json`. The CLI expands it
+> into `<name>-command`, `<name>-data`, and `<name>-history` — do **not** add
+> those suffixes yourself. Mirror the same three physical tables in your IaC.
+> Migrating existing data to a renamed table is the application's responsibility.
+
 ## Documentation
 
 Visit https://mbc-cqrs-serverless.mbc-net.com/ to view the full documentation.

--- a/packages/directory/src/directory.module-definition.ts
+++ b/packages/directory/src/directory.module-definition.ts
@@ -28,16 +28,15 @@ export interface DirectoryStorageModuleAsyncOptions
   prismaModelName?: string
   inject?: any[]
   /**
-   * Resolves the runtime module options. Must return at least `{ prismaService }`
-   * so the domain services (which inject PRISMA_SERVICE) can be constructed.
-   * Optional only to stay assignment-compatible with the inherited
-   * `registerAsync` signature; omitting it makes PRISMA_SERVICE fail fast.
+   * Resolves the runtime module options. Must return the resolved PrismaService
+   * **instance** under `prismaService` (typically by injecting it), so the domain
+   * services (which inject PRISMA_SERVICE) can be constructed. Optional only to
+   * stay assignment-compatible with the inherited `registerAsync` signature;
+   * omitting it makes PRISMA_SERVICE fail fast.
    */
   useFactory?: (
     ...args: any[]
-  ) =>
-    | Promise<Pick<DirectoryStorageModuleOptions, 'prismaService'>>
-    | Pick<DirectoryStorageModuleOptions, 'prismaService'>
+  ) => Promise<{ prismaService?: any }> | { prismaService?: any }
 }
 
 export const { ConfigurableModuleClass, MODULE_OPTIONS_TOKEN, OPTIONS_TYPE } =

--- a/packages/directory/src/directory.module-definition.ts
+++ b/packages/directory/src/directory.module-definition.ts
@@ -1,13 +1,43 @@
 import { IDataSyncHandler } from '@mbc-cqrs-serverless/core'
-import { ConfigurableModuleBuilder } from '@nestjs/common'
-import { Type } from '@nestjs/common'
+import { ConfigurableModuleBuilder, ModuleMetadata, Type } from '@nestjs/common'
 
 export const PRISMA_SERVICE = 'PrismaServiceInjectToken'
+
+export const DEFAULT_DIRECTORY_TABLE_NAME = 'directory'
+export const DEFAULT_DIRECTORY_PK_PREFIX = 'DIRECTORY'
+export const DEFAULT_DIRECTORY_PRISMA_MODEL = 'directory'
 
 export interface DirectoryStorageModuleOptions {
   enableController?: boolean
   dataSyncHandlers?: Type<IDataSyncHandler>[]
   prismaService?: Type<any>
+  /** DynamoDB base table name. Default: 'directory'. */
+  tableName?: string
+  /** Partition-key prefix (before the key separator). Default: 'DIRECTORY'. */
+  pkPrefix?: string
+  /** Prisma model accessor used for RDS reads. Default: 'directory'. */
+  prismaModelName?: string
+}
+
+export interface DirectoryStorageModuleAsyncOptions
+  extends Pick<ModuleMetadata, 'imports'> {
+  enableController?: boolean
+  dataSyncHandlers?: Type<IDataSyncHandler>[]
+  tableName?: string
+  pkPrefix?: string
+  prismaModelName?: string
+  inject?: any[]
+  /**
+   * Resolves the runtime module options. Must return at least `{ prismaService }`
+   * so the domain services (which inject PRISMA_SERVICE) can be constructed.
+   * Optional only to stay assignment-compatible with the inherited
+   * `registerAsync` signature; omitting it makes PRISMA_SERVICE fail fast.
+   */
+  useFactory?: (
+    ...args: any[]
+  ) =>
+    | Promise<Pick<DirectoryStorageModuleOptions, 'prismaService'>>
+    | Pick<DirectoryStorageModuleOptions, 'prismaService'>
 }
 
 export const { ConfigurableModuleClass, MODULE_OPTIONS_TOKEN, OPTIONS_TYPE } =

--- a/packages/directory/src/directory.module.spec.ts
+++ b/packages/directory/src/directory.module.spec.ts
@@ -50,6 +50,15 @@ describe('DirectoryStorageModule', () => {
         /prismaService/,
       )
     })
+
+    it('throws fast on an empty tableName', () => {
+      expect(() =>
+        DirectoryStorageModule.register({
+          prismaService: MockPrismaService,
+          tableName: '',
+        }),
+      ).toThrow(/non-empty/)
+    })
   })
 
   describe('registerAsync', () => {

--- a/packages/directory/src/directory.module.spec.ts
+++ b/packages/directory/src/directory.module.spec.ts
@@ -58,13 +58,18 @@ describe('DirectoryStorageModule', () => {
         imports: [
           SupportModule,
           DirectoryStorageModule.registerAsync({
-            inject: [],
-            useFactory: () => ({ prismaService: MockPrismaService }),
+            inject: [MockPrismaService],
+            useFactory: (prisma: MockPrismaService) => ({
+              prismaService: prisma,
+            }),
           }),
         ],
       }).compile()
+      await moduleRef.init()
 
-      expect(moduleRef.get(DirectoryService)).toBeDefined()
+      const svc = moduleRef.get(DirectoryService)
+      expect(svc).toBeDefined()
+      expect((svc as any).prismaService).toBeInstanceOf(MockPrismaService)
       await moduleRef.close()
     })
   })

--- a/packages/directory/src/directory.module.spec.ts
+++ b/packages/directory/src/directory.module.spec.ts
@@ -1,0 +1,71 @@
+import { CommandModule, StepFunctionService } from '@mbc-cqrs-serverless/core'
+import { Global, Module } from '@nestjs/common'
+import { ConfigModule } from '@nestjs/config'
+import { Test } from '@nestjs/testing'
+
+import { DirectoryStorageModule } from './directory.module'
+import { DirectoryService } from './directory.service'
+
+class MockPrismaService {}
+
+@Global()
+@Module({
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      ignoreEnvFile: true,
+      load: [() => ({ NODE_ENV: 'local', APP_NAME: 'app' })],
+    }),
+  ],
+  providers: [StepFunctionService, MockPrismaService],
+  exports: [StepFunctionService, MockPrismaService],
+})
+class SupportModule {}
+
+describe('DirectoryStorageModule', () => {
+  afterEach(() => jest.restoreAllMocks())
+
+  describe('register (sync)', () => {
+    it('forwards the default table name to CommandModule', () => {
+      const spy = jest.spyOn(CommandModule, 'register')
+      DirectoryStorageModule.register({ prismaService: MockPrismaService })
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ tableName: 'directory' }),
+      )
+    })
+
+    it('forwards a custom table name to CommandModule', () => {
+      const spy = jest.spyOn(CommandModule, 'register')
+      DirectoryStorageModule.register({
+        prismaService: MockPrismaService,
+        tableName: 'document',
+      })
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ tableName: 'document' }),
+      )
+    })
+
+    it('throws fast when prismaService is missing', () => {
+      expect(() => DirectoryStorageModule.register({} as any)).toThrow(
+        /prismaService/,
+      )
+    })
+  })
+
+  describe('registerAsync', () => {
+    it('compiles and resolves the public service', async () => {
+      const moduleRef = await Test.createTestingModule({
+        imports: [
+          SupportModule,
+          DirectoryStorageModule.registerAsync({
+            inject: [],
+            useFactory: () => ({ prismaService: MockPrismaService }),
+          }),
+        ],
+      }).compile()
+
+      expect(moduleRef.get(DirectoryService)).toBeDefined()
+      await moduleRef.close()
+    })
+  })
+})

--- a/packages/directory/src/directory.module.ts
+++ b/packages/directory/src/directory.module.ts
@@ -38,12 +38,20 @@ export class DirectoryStorageModule extends ConfigurableModuleClass {
       buildPrismaProviderSync(options.prismaService, PRISMA_SERVICE),
     )
 
+    // Data-sync handlers are registered here (not inside CommandModule) so they
+    // can resolve PRISMA_SERVICE from this module's scope.
+    const handlers = options.dataSyncHandlers ?? []
+    providers.push(...handlers)
+
     if (options.enableController) {
       controllers.push(DirectoryController)
     }
 
     imports.push(
-      buildDomainCommandModule(DEFAULT_DIRECTORY_TABLE_NAME, options),
+      buildDomainCommandModule(DEFAULT_DIRECTORY_TABLE_NAME, {
+        tableName: options.tableName,
+        dataSyncHandlers: handlers,
+      }),
     )
 
     return { ...base, providers, controllers, imports }
@@ -78,6 +86,9 @@ export class DirectoryStorageModule extends ConfigurableModuleClass {
       buildPrismaProviderAsync(MODULE_OPTIONS_TOKEN, PRISMA_SERVICE),
     )
 
+    const handlers = options.dataSyncHandlers ?? []
+    providers.push(...handlers)
+
     if (options.enableController) {
       controllers.push(DirectoryController)
     }
@@ -87,7 +98,7 @@ export class DirectoryStorageModule extends ConfigurableModuleClass {
     imports.push(
       buildDomainCommandModule(DEFAULT_DIRECTORY_TABLE_NAME, {
         tableName: options.tableName,
-        dataSyncHandlers: options.dataSyncHandlers,
+        dataSyncHandlers: handlers,
       }),
     )
 

--- a/packages/directory/src/directory.module.ts
+++ b/packages/directory/src/directory.module.ts
@@ -1,5 +1,7 @@
 import {
-  CommandModule,
+  buildDomainCommandModule,
+  buildPrismaProviderAsync,
+  buildPrismaProviderSync,
   DataStoreModule,
   QueueModule,
 } from '@mbc-cqrs-serverless/core'
@@ -8,6 +10,9 @@ import { DynamicModule, Module } from '@nestjs/common'
 import { DirectoryController } from './directory.controller'
 import {
   ConfigurableModuleClass,
+  DEFAULT_DIRECTORY_TABLE_NAME,
+  DirectoryStorageModuleAsyncOptions,
+  MODULE_OPTIONS_TOKEN,
   OPTIONS_TYPE,
   PRISMA_SERVICE,
 } from './directory.module-definition'
@@ -22,41 +27,70 @@ import { DynamoService } from './dynamodb.service'
 })
 export class DirectoryStorageModule extends ConfigurableModuleClass {
   static register(options: typeof OPTIONS_TYPE): DynamicModule {
-    const module = super.register(options)
+    const base = super.register(options)
+    const providers = [...(base.providers ?? [])]
+    const controllers = [...(base.controllers ?? [])]
+    const imports = [...(base.imports ?? [])]
+
+    // The domain services inject PRISMA_SERVICE unconditionally, so it must be
+    // registered regardless of whether controllers are enabled.
+    providers.push(
+      buildPrismaProviderSync(options.prismaService, PRISMA_SERVICE),
+    )
 
     if (options.enableController) {
-      if (!options.prismaService) {
-        throw new Error(
-          'PrismaService must be provided when enableController is true.',
-        )
-      }
-      if (!module.controllers) {
-        module.controllers = []
-      }
-      module.controllers.push(DirectoryController)
-
-      if (!module.providers) {
-        module.providers = []
-      }
-
-      module.providers.push({
-        provide: PRISMA_SERVICE,
-        useExisting: options.prismaService,
-      })
-
-      if (!module.imports) {
-        module.imports = []
-      }
+      controllers.push(DirectoryController)
     }
-    const imports = [...(module.imports ?? [])]
 
     imports.push(
-      CommandModule.register({
-        tableName: 'directory',
-        dataSyncHandlers: options?.dataSyncHandlers,
+      buildDomainCommandModule(DEFAULT_DIRECTORY_TABLE_NAME, options),
+    )
+
+    return { ...base, providers, controllers, imports }
+  }
+
+  static registerAsync(
+    options: DirectoryStorageModuleAsyncOptions,
+  ): DynamicModule {
+    const base = super.registerAsync({
+      imports: options.imports,
+      inject: options.inject ?? [],
+      // Merge the build-time structural fields into the options token so
+      // DirectoryService can read tableName/pkPrefix/prismaModelName. The async
+      // factory only needs to resolve `prismaService`.
+      useFactory: async (...args: any[]) => {
+        const resolved = (await options.useFactory?.(...args)) ?? {}
+        return {
+          ...resolved,
+          enableController: options.enableController,
+          dataSyncHandlers: options.dataSyncHandlers,
+          tableName: options.tableName ?? DEFAULT_DIRECTORY_TABLE_NAME,
+          pkPrefix: options.pkPrefix,
+          prismaModelName: options.prismaModelName,
+        }
+      },
+    })
+    const providers = [...(base.providers ?? [])]
+    const controllers = [...(base.controllers ?? [])]
+    const imports = [...(base.imports ?? [])]
+
+    providers.push(
+      buildPrismaProviderAsync(MODULE_OPTIONS_TOKEN, PRISMA_SERVICE),
+    )
+
+    if (options.enableController) {
+      controllers.push(DirectoryController)
+    }
+
+    // tableName is a build-time constant, so CommandModule.register() (which
+    // eagerly creates the `<tableName>_CommandEventHandler` alias) is correct.
+    imports.push(
+      buildDomainCommandModule(DEFAULT_DIRECTORY_TABLE_NAME, {
+        tableName: options.tableName,
+        dataSyncHandlers: options.dataSyncHandlers,
       }),
     )
 
-    return { ...module, imports }
+    return { ...base, providers, controllers, imports }
   }
 }

--- a/packages/directory/src/directory.module.ts
+++ b/packages/directory/src/directory.module.ts
@@ -52,7 +52,7 @@ export class DirectoryStorageModule extends ConfigurableModuleClass {
 
     imports.push(
       CommandModule.register({
-        tableName: 'directory',
+        tableName: 'document',
         dataSyncHandlers: options?.dataSyncHandlers,
       }),
     )

--- a/packages/directory/src/directory.service.spec.ts
+++ b/packages/directory/src/directory.service.spec.ts
@@ -123,7 +123,7 @@ describe('DirectoryService', () => {
         {
           provide: PRISMA_SERVICE,
           useValue: {
-            directory: {
+            document: {
               groupBy: jest.fn(),
             },
           },

--- a/packages/directory/src/directory.service.spec.ts
+++ b/packages/directory/src/directory.service.spec.ts
@@ -10,12 +10,17 @@ import {
   CommandService,
   DataService,
   DetailDto,
+  DynamoDbService,
   IInvoke,
   S3Service,
+  TableType,
   getUserContext,
 } from '@mbc-cqrs-serverless/core'
 import { DynamoService } from './dynamodb.service'
-import { PRISMA_SERVICE } from './directory.module-definition'
+import {
+  MODULE_OPTIONS_TOKEN,
+  PRISMA_SERVICE,
+} from './directory.module-definition'
 import {
   DirectoryAttributes,
   FilePermission,
@@ -127,6 +132,19 @@ describe('DirectoryService', () => {
               groupBy: jest.fn(),
             },
           },
+        },
+        {
+          provide: MODULE_OPTIONS_TOKEN,
+          useValue: {},
+        },
+        {
+          provide: DynamoDbService,
+          useValue: createMock<DynamoDbService>({
+            getTableName: jest.fn(
+              (name: string, type?: TableType) =>
+                `local-app-${name}${type ? '-' + type : ''}`,
+            ),
+          }),
         },
       ],
     }).compile()
@@ -539,11 +557,10 @@ describe('DirectoryService', () => {
         role: FileRole.WRITE,
       }
 
-      const result = service.checkPermissionObject(
-        permission,
-        'TEST_TENANT',
-        { email: 'anyone@example.com', tenant: 'TEST_TENANT' },
-      )
+      const result = service.checkPermissionObject(permission, 'TEST_TENANT', {
+        email: 'anyone@example.com',
+        tenant: 'TEST_TENANT',
+      })
 
       expect(result).toBe(FileRole.WRITE)
     })
@@ -555,11 +572,10 @@ describe('DirectoryService', () => {
         users: [],
       }
 
-      const result = service.checkPermissionObject(
-        permission,
-        'TEST_TENANT',
-        { email: 'user@example.com', tenant: 'TEST_TENANT' },
-      )
+      const result = service.checkPermissionObject(permission, 'TEST_TENANT', {
+        email: 'user@example.com',
+        tenant: 'TEST_TENANT',
+      })
 
       expect(result).toBeNull()
     })
@@ -652,6 +668,12 @@ describe('DirectoryService', () => {
 
       expect(result.total).toBe(3) // current + 2 history items
       expect(result.items).toHaveLength(3)
+      // Default table name resolves the history table via getTableName.
+      expect(dynamoService.listItemsByPk).toHaveBeenCalledWith(
+        'local-app-directory-history',
+        expect.anything(),
+        expect.anything(),
+      )
     })
 
     it('should throw ForbiddenException when lacking read permission', async () => {
@@ -1353,6 +1375,108 @@ describe('DirectoryService', () => {
           _sum: { fileSize: true },
           _count: { _all: true },
         }),
+      )
+    })
+  })
+
+  // ============================================
+  // CONFIGURABLE TABLE NAME (opt-in overrides)
+  // ============================================
+  describe('configurable table name (custom options)', () => {
+    let customService: DirectoryService
+    let customCommandService: jest.Mocked<CommandService>
+    let customDynamoService: jest.Mocked<DynamoService>
+    let customDynamoDbService: jest.Mocked<DynamoDbService>
+    let customPrisma: any
+
+    beforeEach(async () => {
+      mockGetUserContext.mockReturnValue(mockUserContext as any)
+      customPrisma = { document: { groupBy: jest.fn().mockResolvedValue([]) } }
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          DirectoryService,
+          { provide: CommandService, useValue: createMock<CommandService>() },
+          { provide: DataService, useValue: createMock<DataService>() },
+          {
+            provide: S3Service,
+            useValue: { client: { send: jest.fn() }, privateBucket: 'b' },
+          },
+          { provide: DynamoService, useValue: createMock<DynamoService>() },
+          { provide: PRISMA_SERVICE, useValue: customPrisma },
+          {
+            provide: MODULE_OPTIONS_TOKEN,
+            useValue: {
+              tableName: 'document',
+              pkPrefix: 'DOCUMENT',
+              prismaModelName: 'document',
+            },
+          },
+          {
+            provide: DynamoDbService,
+            useValue: createMock<DynamoDbService>({
+              getTableName: jest.fn(
+                (name: string, type?: TableType) =>
+                  `local-app-${name}${type ? '-' + type : ''}`,
+              ),
+            }),
+          },
+        ],
+      }).compile()
+
+      customService = module.get(DirectoryService)
+      customCommandService = module.get(CommandService)
+      customDynamoService = module.get(DynamoService)
+      customDynamoDbService = module.get(DynamoDbService)
+    })
+
+    it('uses the custom pk prefix when creating a directory', async () => {
+      customCommandService.publishAsync.mockResolvedValue(
+        createMockDirectoryData() as any,
+      )
+
+      await customService.create(
+        {
+          name: 'Doc',
+          type: 'folder',
+          attributes: { parentId: null, ancestors: [] },
+        } as any,
+        { invokeContext: mockInvokeContext },
+      )
+
+      expect(customCommandService.publishAsync).toHaveBeenCalledWith(
+        expect.objectContaining({ pk: 'DOCUMENT#TEST_TENANT' }),
+        expect.any(Object),
+      )
+    })
+
+    it('reads the summary from the custom prisma model', async () => {
+      await customService.getTenantFileSizeSummary()
+      expect(customPrisma.document.groupBy).toHaveBeenCalled()
+    })
+
+    it('resolves the history table from the custom table name', async () => {
+      const mockData = createMockDirectoryData()
+      ;(customService as any).dataService?.getItem
+      customDynamoService.listItemsByPk.mockResolvedValue({ items: [] })
+      const dataService = (customService as any)
+        .dataService as jest.Mocked<DataService>
+      dataService.getItem.mockResolvedValue(mockData)
+
+      await customService.findHistory(
+        { pk: 'DOCUMENT#TEST_TENANT', sk: 'test-ulid' },
+        { invokeContext: mockInvokeContext },
+        { email: 'owner@example.com' },
+      )
+
+      expect(customDynamoDbService.getTableName).toHaveBeenCalledWith(
+        'document',
+        TableType.HISTORY,
+      )
+      expect(customDynamoService.listItemsByPk).toHaveBeenCalledWith(
+        'local-app-document-history',
+        expect.anything(),
+        expect.anything(),
       )
     })
   })

--- a/packages/directory/src/directory.service.spec.ts
+++ b/packages/directory/src/directory.service.spec.ts
@@ -65,9 +65,9 @@ describe('DirectoryService', () => {
     overrides?: Partial<DirectoryDataEntity>,
   ): DirectoryDataEntity => {
     return {
-      pk: 'DIRECTORY#TEST_TENANT',
+      pk: 'DOCUMENT#TEST_TENANT',
       sk: 'test-ulid-123',
-      id: 'DIRECTORY#TEST_TENANT#test-ulid-123',
+      id: 'DOCUMENT#TEST_TENANT#test-ulid-123',
       code: 'test-ulid-123',
       name: 'Test Directory',
       version: 1,
@@ -267,7 +267,7 @@ describe('DirectoryService', () => {
       dataService.getItem.mockResolvedValue(mockData)
 
       const result = await service.hasPermission(
-        { pk: 'DIRECTORY#TEST_TENANT', sk: 'test-ulid' },
+        { pk: 'DOCUMENT#TEST_TENANT', sk: 'test-ulid' },
         [FileRole.WRITE],
         { email: 'user@example.com', tenant: 'TEST_TENANT' },
       )
@@ -289,7 +289,7 @@ describe('DirectoryService', () => {
       dataService.getItem.mockResolvedValue(mockData)
 
       const result = await service.hasPermission(
-        { pk: 'DIRECTORY#TEST_TENANT', sk: 'test-ulid' },
+        { pk: 'DOCUMENT#TEST_TENANT', sk: 'test-ulid' },
         [FileRole.WRITE],
         { email: 'user@example.com', tenant: 'TEST_TENANT' },
       )
@@ -315,7 +315,7 @@ describe('DirectoryService', () => {
       dataService.getItem.mockResolvedValue(mockData)
 
       const result = await service.hasPermission(
-        { pk: 'DIRECTORY#TEST_TENANT', sk: 'test-ulid' },
+        { pk: 'DOCUMENT#TEST_TENANT', sk: 'test-ulid' },
         [FileRole.WRITE],
         { email: 'user@example.com', tenant: 'TEST_TENANT' },
       )
@@ -341,7 +341,7 @@ describe('DirectoryService', () => {
       dataService.getItem.mockResolvedValue(mockData)
 
       const result = await service.hasPermission(
-        { pk: 'DIRECTORY#TEST_TENANT', sk: 'test-ulid' },
+        { pk: 'DOCUMENT#TEST_TENANT', sk: 'test-ulid' },
         [FileRole.WRITE],
         { email: 'user@example.com', tenant: 'TEST_TENANT' },
       )
@@ -374,7 +374,7 @@ describe('DirectoryService', () => {
       dataService.getItem.mockResolvedValue(mockData)
 
       const result = await service.hasPermission(
-        { pk: 'DIRECTORY#TEST_TENANT', sk: 'test-ulid' },
+        { pk: 'DOCUMENT#TEST_TENANT', sk: 'test-ulid' },
         [FileRole.WRITE],
         { email: 'allowed@example.com', tenant: 'TEST_TENANT' },
       )
@@ -407,7 +407,7 @@ describe('DirectoryService', () => {
       dataService.getItem.mockResolvedValue(mockData)
 
       const result = await service.hasPermission(
-        { pk: 'DIRECTORY#TEST_TENANT', sk: 'test-ulid' },
+        { pk: 'DOCUMENT#TEST_TENANT', sk: 'test-ulid' },
         [FileRole.WRITE],
         { email: 'notallowed@example.com', tenant: 'TEST_TENANT' },
       )
@@ -429,7 +429,7 @@ describe('DirectoryService', () => {
       dataService.getItem.mockResolvedValue(mockData)
 
       const result = await service.hasPermission(
-        { pk: 'DIRECTORY#TEST_TENANT', sk: 'test-ulid' },
+        { pk: 'DOCUMENT#TEST_TENANT', sk: 'test-ulid' },
         [FileRole.WRITE],
         { email: 'user@example.com', tenant: 'TEST_TENANT' },
       )
@@ -451,7 +451,7 @@ describe('DirectoryService', () => {
       dataService.getItem.mockResolvedValue(mockData)
 
       const result = await service.hasPermission(
-        { pk: 'DIRECTORY#TEST_TENANT', sk: 'test-ulid' },
+        { pk: 'DOCUMENT#TEST_TENANT', sk: 'test-ulid' },
         [FileRole.WRITE],
         { email: 'user@example.com', tenant: 'OTHER_TENANT' },
       )
@@ -465,7 +465,7 @@ describe('DirectoryService', () => {
       dataService.getItem.mockResolvedValue(null)
 
       const result = await service.getEffectiveRole(
-        { pk: 'DIRECTORY#TEST_TENANT', sk: 'non-existent' },
+        { pk: 'DOCUMENT#TEST_TENANT', sk: 'non-existent' },
         { email: 'user@example.com', tenant: 'TEST_TENANT' },
       )
 
@@ -501,7 +501,7 @@ describe('DirectoryService', () => {
         .mockResolvedValueOnce(parentData)
 
       const result = await service.getEffectiveRole(
-        { pk: 'DIRECTORY#TEST_TENANT', sk: 'child-ulid' },
+        { pk: 'DOCUMENT#TEST_TENANT', sk: 'child-ulid' },
         { email: 'user@example.com', tenant: 'TEST_TENANT' },
       )
 
@@ -524,7 +524,7 @@ describe('DirectoryService', () => {
       dataService.getItem.mockResolvedValue(childData)
 
       const result = await service.getEffectiveRole(
-        { pk: 'DIRECTORY#TEST_TENANT', sk: 'child-ulid' },
+        { pk: 'DOCUMENT#TEST_TENANT', sk: 'child-ulid' },
         { email: 'user@example.com', tenant: 'TEST_TENANT' },
       )
 
@@ -539,11 +539,10 @@ describe('DirectoryService', () => {
         role: FileRole.WRITE,
       }
 
-      const result = service.checkPermissionObject(
-        permission,
-        'TEST_TENANT',
-        { email: 'anyone@example.com', tenant: 'TEST_TENANT' },
-      )
+      const result = service.checkPermissionObject(permission, 'TEST_TENANT', {
+        email: 'anyone@example.com',
+        tenant: 'TEST_TENANT',
+      })
 
       expect(result).toBe(FileRole.WRITE)
     })
@@ -555,11 +554,10 @@ describe('DirectoryService', () => {
         users: [],
       }
 
-      const result = service.checkPermissionObject(
-        permission,
-        'TEST_TENANT',
-        { email: 'user@example.com', tenant: 'TEST_TENANT' },
-      )
+      const result = service.checkPermissionObject(permission, 'TEST_TENANT', {
+        email: 'user@example.com',
+        tenant: 'TEST_TENANT',
+      })
 
       expect(result).toBeNull()
     })
@@ -574,7 +572,7 @@ describe('DirectoryService', () => {
       dataService.getItem.mockResolvedValue(mockData)
 
       const result = await service.findOne(
-        { pk: 'DIRECTORY#TEST_TENANT', sk: 'test-ulid' },
+        { pk: 'DOCUMENT#TEST_TENANT', sk: 'test-ulid' },
         { invokeContext: mockInvokeContext },
         { email: 'user@example.com' },
       )
@@ -609,7 +607,7 @@ describe('DirectoryService', () => {
 
       await expect(
         service.findOne(
-          { pk: 'DIRECTORY#TEST_TENANT', sk: 'test-ulid' },
+          { pk: 'DOCUMENT#TEST_TENANT', sk: 'test-ulid' },
           { invokeContext: mockInvokeContext },
           { email: 'unauthorized@example.com' },
         ),
@@ -625,7 +623,7 @@ describe('DirectoryService', () => {
 
       await expect(
         service.findOne(
-          { pk: 'DIRECTORY#TEST_TENANT', sk: 'non-existent' },
+          { pk: 'DOCUMENT#TEST_TENANT', sk: 'non-existent' },
           { invokeContext: mockInvokeContext },
           { email: 'user@example.com' },
         ),
@@ -645,7 +643,7 @@ describe('DirectoryService', () => {
       dynamoService.listItemsByPk.mockResolvedValue({ items: mockHistoryItems })
 
       const result = await service.findHistory(
-        { pk: 'DIRECTORY#TEST_TENANT', sk: 'test-ulid' },
+        { pk: 'DOCUMENT#TEST_TENANT', sk: 'test-ulid' },
         { invokeContext: mockInvokeContext },
         { email: 'user@example.com' },
       )
@@ -669,7 +667,7 @@ describe('DirectoryService', () => {
 
       await expect(
         service.findHistory(
-          { pk: 'DIRECTORY#TEST_TENANT', sk: 'test-ulid' },
+          { pk: 'DOCUMENT#TEST_TENANT', sk: 'test-ulid' },
           { invokeContext: mockInvokeContext },
           { email: 'user@example.com' },
         ),
@@ -695,7 +693,7 @@ describe('DirectoryService', () => {
       )
 
       const result = await service.update(
-        { pk: 'DIRECTORY#TEST_TENANT', sk: 'test-ulid' },
+        { pk: 'DOCUMENT#TEST_TENANT', sk: 'test-ulid' },
         updateDto,
         { invokeContext: mockInvokeContext },
       )
@@ -716,7 +714,7 @@ describe('DirectoryService', () => {
 
       await expect(
         service.update(
-          { pk: 'DIRECTORY#TEST_TENANT', sk: 'test-ulid' },
+          { pk: 'DOCUMENT#TEST_TENANT', sk: 'test-ulid' },
           updateDto,
           { invokeContext: mockInvokeContext },
         ),
@@ -733,7 +731,7 @@ describe('DirectoryService', () => {
 
       await expect(
         service.update(
-          { pk: 'DIRECTORY#TEST_TENANT', sk: 'non-existent' },
+          { pk: 'DOCUMENT#TEST_TENANT', sk: 'non-existent' },
           updateDto,
           { invokeContext: mockInvokeContext },
         ),
@@ -754,7 +752,7 @@ describe('DirectoryService', () => {
 
       await expect(
         service.update(
-          { pk: 'DIRECTORY#TEST_TENANT', sk: 'test-ulid' },
+          { pk: 'DOCUMENT#TEST_TENANT', sk: 'test-ulid' },
           updateDto,
           { invokeContext: mockInvokeContext },
         ),
@@ -781,7 +779,7 @@ describe('DirectoryService', () => {
 
       await expect(
         service.update(
-          { pk: 'DIRECTORY#TEST_TENANT', sk: 'test-ulid' },
+          { pk: 'DOCUMENT#TEST_TENANT', sk: 'test-ulid' },
           updateDto,
           { invokeContext: mockInvokeContext },
         ),
@@ -810,7 +808,7 @@ describe('DirectoryService', () => {
       )
 
       const result = await service.updatePermission(
-        { pk: 'DIRECTORY#TEST_TENANT', sk: 'test-ulid' },
+        { pk: 'DOCUMENT#TEST_TENANT', sk: 'test-ulid' },
         {
           email: 'user@example.com',
           attributes: {
@@ -841,7 +839,7 @@ describe('DirectoryService', () => {
       }
 
       const result = await service.rename(
-        { pk: 'DIRECTORY#TEST_TENANT', sk: 'test-ulid' },
+        { pk: 'DOCUMENT#TEST_TENANT', sk: 'test-ulid' },
         renameDto,
         { invokeContext: mockInvokeContext },
       )
@@ -854,7 +852,7 @@ describe('DirectoryService', () => {
 
       await expect(
         service.rename(
-          { pk: 'DIRECTORY#TEST_TENANT', sk: 'non-existent' },
+          { pk: 'DOCUMENT#TEST_TENANT', sk: 'non-existent' },
           { name: 'New Name', email: 'user@example.com' },
           { invokeContext: mockInvokeContext },
         ),
@@ -888,7 +886,7 @@ describe('DirectoryService', () => {
       }
 
       const result = await service.copy(
-        { pk: 'DIRECTORY#TEST_TENANT', sk: 'test-ulid' },
+        { pk: 'DOCUMENT#TEST_TENANT', sk: 'test-ulid' },
         copyDto,
         { invokeContext: mockInvokeContext },
       )
@@ -908,7 +906,7 @@ describe('DirectoryService', () => {
 
       await expect(
         service.copy(
-          { pk: 'DIRECTORY#TEST_TENANT', sk: 'non-existent' },
+          { pk: 'DOCUMENT#TEST_TENANT', sk: 'non-existent' },
           copyDto,
           { invokeContext: mockInvokeContext },
         ),
@@ -957,7 +955,7 @@ describe('DirectoryService', () => {
       }
 
       const result = await service.move(
-        { pk: 'DIRECTORY#TEST_TENANT', sk: 'test-ulid' },
+        { pk: 'DOCUMENT#TEST_TENANT', sk: 'test-ulid' },
         moveDto,
         { invokeContext: mockInvokeContext },
       )
@@ -1004,7 +1002,7 @@ describe('DirectoryService', () => {
 
       await expect(
         service.move(
-          { pk: 'DIRECTORY#TEST_TENANT', sk: 'folder-ulid' },
+          { pk: 'DOCUMENT#TEST_TENANT', sk: 'folder-ulid' },
           moveDto,
           { invokeContext: mockInvokeContext },
         ),
@@ -1030,11 +1028,9 @@ describe('DirectoryService', () => {
       }
 
       await expect(
-        service.move(
-          { pk: 'DIRECTORY#TEST_TENANT', sk: 'test-ulid' },
-          moveDto,
-          { invokeContext: mockInvokeContext },
-        ),
+        service.move({ pk: 'DOCUMENT#TEST_TENANT', sk: 'test-ulid' }, moveDto, {
+          invokeContext: mockInvokeContext,
+        }),
       ).rejects.toThrow(ForbiddenException)
     })
   })
@@ -1061,7 +1057,7 @@ describe('DirectoryService', () => {
       )
 
       const result = await service.remove(
-        { pk: 'DIRECTORY#TEST_TENANT', sk: 'test-ulid' },
+        { pk: 'DOCUMENT#TEST_TENANT', sk: 'test-ulid' },
         { invokeContext: mockInvokeContext },
         { email: 'user@example.com' },
       )
@@ -1077,7 +1073,7 @@ describe('DirectoryService', () => {
 
       await expect(
         service.remove(
-          { pk: 'DIRECTORY#TEST_TENANT', sk: 'test-ulid' },
+          { pk: 'DOCUMENT#TEST_TENANT', sk: 'test-ulid' },
           { invokeContext: mockInvokeContext },
           { email: 'user@example.com' },
         ),
@@ -1089,7 +1085,7 @@ describe('DirectoryService', () => {
 
       await expect(
         service.remove(
-          { pk: 'DIRECTORY#TEST_TENANT', sk: 'non-existent' },
+          { pk: 'DOCUMENT#TEST_TENANT', sk: 'non-existent' },
           { invokeContext: mockInvokeContext },
           { email: 'user@example.com' },
         ),
@@ -1122,7 +1118,7 @@ describe('DirectoryService', () => {
       )
 
       const result = await service.removeFile(
-        { pk: 'DIRECTORY#TEST_TENANT', sk: 'test-ulid' },
+        { pk: 'DOCUMENT#TEST_TENANT', sk: 'test-ulid' },
         { invokeContext: mockInvokeContext },
         { email: 'user@example.com' },
       )
@@ -1151,7 +1147,7 @@ describe('DirectoryService', () => {
       } as any)
 
       await service.removeFile(
-        { pk: 'DIRECTORY#TEST_TENANT', sk: 'test-ulid' },
+        { pk: 'DOCUMENT#TEST_TENANT', sk: 'test-ulid' },
         { invokeContext: mockInvokeContext },
         { email: 'user@example.com' },
       )
@@ -1173,7 +1169,7 @@ describe('DirectoryService', () => {
       commandService.publishAsync.mockResolvedValue(historyItem as any)
 
       const result = await service.restoreHistoryItem(
-        { pk: 'DIRECTORY#TEST_TENANT', sk: 'test-ulid' },
+        { pk: 'DOCUMENT#TEST_TENANT', sk: 'test-ulid' },
         '2',
         { email: 'user@example.com' },
         { invokeContext: mockInvokeContext },
@@ -1192,7 +1188,7 @@ describe('DirectoryService', () => {
 
       await expect(
         service.restoreHistoryItem(
-          { pk: 'DIRECTORY#TEST_TENANT', sk: 'test-ulid' },
+          { pk: 'DOCUMENT#TEST_TENANT', sk: 'test-ulid' },
           '999',
           { email: 'user@example.com' },
           { invokeContext: mockInvokeContext },
@@ -1218,7 +1214,7 @@ describe('DirectoryService', () => {
 
       await expect(
         service.restoreHistoryItem(
-          { pk: 'DIRECTORY#TEST_TENANT', sk: 'test-ulid' },
+          { pk: 'DOCUMENT#TEST_TENANT', sk: 'test-ulid' },
           '2',
           { email: 'user@example.com' },
           { invokeContext: mockInvokeContext },
@@ -1240,7 +1236,7 @@ describe('DirectoryService', () => {
       )
 
       const result = await service.restoreTemporary(
-        { pk: 'DIRECTORY#TEST_TENANT', sk: 'test-ulid' },
+        { pk: 'DOCUMENT#TEST_TENANT', sk: 'test-ulid' },
         { email: 'user@example.com' },
         { invokeContext: mockInvokeContext },
       )
@@ -1253,7 +1249,7 @@ describe('DirectoryService', () => {
 
       await expect(
         service.restoreTemporary(
-          { pk: 'DIRECTORY#TEST_TENANT', sk: 'non-existent' },
+          { pk: 'DOCUMENT#TEST_TENANT', sk: 'non-existent' },
           { email: 'user@example.com' },
           { invokeContext: mockInvokeContext },
         ),
@@ -1266,7 +1262,7 @@ describe('DirectoryService', () => {
 
       await expect(
         service.restoreTemporary(
-          { pk: 'DIRECTORY#TEST_TENANT', sk: 'test-ulid' },
+          { pk: 'DOCUMENT#TEST_TENANT', sk: 'test-ulid' },
           { email: 'user@example.com' },
           { invokeContext: mockInvokeContext },
         ),
@@ -1283,7 +1279,7 @@ describe('DirectoryService', () => {
       dataService.getItem.mockResolvedValue(mockData)
 
       const result = await service.getItemAttributes({
-        pk: 'DIRECTORY#TEST_TENANT',
+        pk: 'DOCUMENT#TEST_TENANT',
         sk: 'test-ulid',
       })
 
@@ -1295,7 +1291,7 @@ describe('DirectoryService', () => {
 
       await expect(
         service.getItemAttributes({
-          pk: 'DIRECTORY#TEST_TENANT',
+          pk: 'DOCUMENT#TEST_TENANT',
           sk: 'non-existent',
         }),
       ).rejects.toThrow(NotFoundException)
@@ -1308,7 +1304,7 @@ describe('DirectoryService', () => {
       dataService.getItem.mockResolvedValue(mockData)
 
       const result = await service.getItem({
-        pk: 'DIRECTORY#TEST_TENANT',
+        pk: 'DOCUMENT#TEST_TENANT',
         sk: 'test-ulid',
       })
 
@@ -1320,7 +1316,7 @@ describe('DirectoryService', () => {
 
       await expect(
         service.getItem({
-          pk: 'DIRECTORY#TEST_TENANT',
+          pk: 'DOCUMENT#TEST_TENANT',
           sk: 'non-existent',
         }),
       ).rejects.toThrow(NotFoundException)

--- a/packages/directory/src/directory.service.spec.ts
+++ b/packages/directory/src/directory.service.spec.ts
@@ -1338,12 +1338,12 @@ describe('DirectoryService', () => {
         },
       ]
 
-      prismaService.directory.groupBy.mockResolvedValue(mockSummary)
+      prismaService.document.groupBy.mockResolvedValue(mockSummary)
 
       const result = await service.getTenantFileSizeSummary()
 
       expect(result).toHaveLength(2)
-      expect(prismaService.directory.groupBy).toHaveBeenCalledWith(
+      expect(prismaService.document.groupBy).toHaveBeenCalledWith(
         expect.objectContaining({
           by: ['tenantCode'],
           _sum: { fileSize: true },

--- a/packages/directory/src/directory.service.ts
+++ b/packages/directory/src/directory.service.ts
@@ -63,7 +63,7 @@ export class DirectoryService {
     opts: { invokeContext: IInvoke },
   ) {
     const { tenantCode } = getUserContext(opts.invokeContext)
-    const pk = `DIRECTORY${KEY_SEPARATOR}${tenantCode}`
+    const pk = `DOCUMENT${KEY_SEPARATOR}${tenantCode}`
     const sk = ulid()
 
     const attrs = createDto.attributes as DirectoryAttributes
@@ -155,7 +155,7 @@ export class DirectoryService {
       throw new NotFoundException('Directory not found!')
     }
 
-    const pk = `DIRECTORY${KEY_SEPARATOR}${tenantCode}`
+    const pk = `DOCUMENT${KEY_SEPARATOR}${tenantCode}`
     const sk = ulid()
     const attrs = data.attributes as DirectoryAttributes
     let newAncestors = []
@@ -235,7 +235,7 @@ export class DirectoryService {
       )
     }
 
-    const pk = `DIRECTORY${KEY_SEPARATOR}${tenantCode}`
+    const pk = `DOCUMENT${KEY_SEPARATOR}${tenantCode}`
     const sk = ulid()
     const attrs = data.attributes as DirectoryAttributes
     let newAncestors = []

--- a/packages/directory/src/directory.service.ts
+++ b/packages/directory/src/directory.service.ts
@@ -4,10 +4,12 @@ import {
   CommandService,
   DataService,
   DetailDto,
+  DynamoDbService,
   generateId,
   getUserContext,
   IInvoke,
   S3Service,
+  TableType,
   VER_SEPARATOR,
   VERSION_FIRST,
 } from '@mbc-cqrs-serverless/core'
@@ -22,7 +24,14 @@ import {
 } from '@nestjs/common'
 import { ulid } from 'ulid'
 
-import { PRISMA_SERVICE } from './directory.module-definition'
+import {
+  DEFAULT_DIRECTORY_PK_PREFIX,
+  DEFAULT_DIRECTORY_PRISMA_MODEL,
+  DEFAULT_DIRECTORY_TABLE_NAME,
+  DirectoryStorageModuleOptions,
+  MODULE_OPTIONS_TOKEN,
+  PRISMA_SERVICE,
+} from './directory.module-definition'
 import {
   DirectoryAttributes,
   FilePermission,
@@ -48,22 +57,33 @@ import { parsePk } from './helpers'
 @Injectable()
 export class DirectoryService {
   private readonly logger = new Logger(DirectoryService.name)
+  private readonly tableName: string
+  private readonly pkPrefix: string
+  private readonly prismaModelName: string
 
   constructor(
+    @Inject(MODULE_OPTIONS_TOKEN)
+    private readonly moduleOptions: DirectoryStorageModuleOptions,
     @Inject(PRISMA_SERVICE)
     private readonly prismaService: any,
     private readonly commandService: CommandService,
     private readonly dataService: DataService,
     private readonly s3Service: S3Service,
     private readonly customDynamoService: DynamoService,
-  ) {}
+    private readonly dynamoDbService: DynamoDbService,
+  ) {
+    this.tableName = moduleOptions.tableName ?? DEFAULT_DIRECTORY_TABLE_NAME
+    this.pkPrefix = moduleOptions.pkPrefix ?? DEFAULT_DIRECTORY_PK_PREFIX
+    this.prismaModelName =
+      moduleOptions.prismaModelName ?? DEFAULT_DIRECTORY_PRISMA_MODEL
+  }
 
   async create(
     createDto: DirectoryCreateDto,
     opts: { invokeContext: IInvoke },
   ) {
     const { tenantCode } = getUserContext(opts.invokeContext)
-    const pk = `DIRECTORY${KEY_SEPARATOR}${tenantCode}`
+    const pk = `${this.pkPrefix}${KEY_SEPARATOR}${tenantCode}`
     const sk = ulid()
 
     const attrs = createDto.attributes as DirectoryAttributes
@@ -117,7 +137,9 @@ export class DirectoryService {
   }
 
   async getTenantFileSizeSummary() {
-    const fileSizeSummary = await this.prismaService.directory.groupBy({
+    const fileSizeSummary = await this.prismaService[
+      this.prismaModelName
+    ].groupBy({
       by: ['tenantCode'],
 
       _sum: {
@@ -155,7 +177,7 @@ export class DirectoryService {
       throw new NotFoundException('Directory not found!')
     }
 
-    const pk = `DIRECTORY${KEY_SEPARATOR}${tenantCode}`
+    const pk = `${this.pkPrefix}${KEY_SEPARATOR}${tenantCode}`
     const sk = ulid()
     const attrs = data.attributes as DirectoryAttributes
     let newAncestors = []
@@ -235,7 +257,7 @@ export class DirectoryService {
       )
     }
 
-    const pk = `DIRECTORY${KEY_SEPARATOR}${tenantCode}`
+    const pk = `${this.pkPrefix}${KEY_SEPARATOR}${tenantCode}`
     const sk = ulid()
     const attrs = data.attributes as DirectoryAttributes
     let newAncestors = []
@@ -311,7 +333,7 @@ export class DirectoryService {
     try {
       item = await this.getItem(itemId)
       attributes = item.attributes as DirectoryAttributes
-    } catch (e) {
+    } catch {
       return null
     }
 
@@ -452,7 +474,10 @@ export class DirectoryService {
       skAttributeValues: { ':typeCode': `${item.code}${VER_SEPARATOR}` },
     }
 
-    const table = `${process.env.NODE_ENV}-${process.env.APP_NAME}-directory-history`
+    const table = this.dynamoDbService.getTableName(
+      this.tableName,
+      TableType.HISTORY,
+    )
     const directoryHistories = await this.customDynamoService.listItemsByPk(
       table,
       item.pk,

--- a/packages/directory/src/directory.service.ts
+++ b/packages/directory/src/directory.service.ts
@@ -117,7 +117,7 @@ export class DirectoryService {
   }
 
   async getTenantFileSizeSummary() {
-    const fileSizeSummary = await this.prismaService.directory.groupBy({
+    const fileSizeSummary = await this.prismaService.document.groupBy({
       by: ['tenantCode'],
 
       _sum: {
@@ -452,7 +452,7 @@ export class DirectoryService {
       skAttributeValues: { ':typeCode': `${item.code}${VER_SEPARATOR}` },
     }
 
-    const table = `${process.env.NODE_ENV}-${process.env.APP_NAME}-directory-history`
+    const table = `${process.env.NODE_ENV}-${process.env.APP_NAME}-document-history`
     const directoryHistories = await this.customDynamoService.listItemsByPk(
       table,
       item.pk,

--- a/packages/master/README.md
+++ b/packages/master/README.md
@@ -322,7 +322,10 @@ MasterModule.registerAsync({
 >
 > **Shared table:** If you also use `@mbc-cqrs-serverless/ui-setting`
 > (`SettingModule`), both modules must use the **same** `tableName`, because they
-> share the same physical table.
+> share the same physical table. `MasterModule` should own the data-sync
+> pipeline — register `SettingModule` with `registerEventHandlerAlias: false`.
+> If both modules own the `<tableName>_CommandEventHandler` alias, the framework
+> fails fast at startup.
 
 ## License
 

--- a/packages/master/README.md
+++ b/packages/master/README.md
@@ -309,8 +309,9 @@ MasterModule.register({
 
 MasterModule.registerAsync({
   tableName: 'catalog',
-  inject: [],
-  useFactory: () => ({ prismaService: PrismaService }),
+  imports: [PrismaModule],
+  inject: [PrismaService], // resolve and return the PrismaService INSTANCE
+  useFactory: (prisma) => ({ prismaService: prisma }),
 })
 ```
 
@@ -324,8 +325,8 @@ MasterModule.registerAsync({
 > (`SettingModule`), both modules must use the **same** `tableName`, because they
 > share the same physical table. `MasterModule` should own the data-sync
 > pipeline — register `SettingModule` with `registerEventHandlerAlias: false`.
-> If both modules own the `<tableName>_CommandEventHandler` alias, the framework
-> fails fast at startup.
+> If both modules own the `<tableName>_CommandEventHandler` alias, the app boots
+> but logs a warning and the effective owner becomes import-order dependent.
 
 ## License
 

--- a/packages/master/README.md
+++ b/packages/master/README.md
@@ -294,6 +294,36 @@ Full documentation available at [https://mbc-cqrs-serverless.mbc-net.com/](https
 
 - [Master Service Guide](https://mbc-cqrs-serverless.mbc-net.com/docs/master-service)
 
+## Configurable table name
+
+`MasterModule` uses the `master` DynamoDB table by default. Pass `tableName` to
+override it (backward compatible — omitting it keeps `master`). Both
+`register` and `registerAsync` accept it:
+
+```ts
+MasterModule.register({
+  enableController: true,
+  prismaService: PrismaService,
+  tableName: 'catalog', // default: 'master'
+})
+
+MasterModule.registerAsync({
+  tableName: 'catalog',
+  inject: [],
+  useFactory: () => ({ prismaService: PrismaService }),
+})
+```
+
+> **Provisioning:** Add **only the raw base name** (e.g. `"catalog"`) to
+> `prisma/dynamodbs/cqrs.json`; the CLI creates the `-command` / `-data` /
+> `-history` physical tables, and your IaC must define the same three. Note that
+> `@mbc-cqrs-serverless/master`'s postinstall auto-adds only the default `master`
+> name — a custom name must be added manually.
+>
+> **Shared table:** If you also use `@mbc-cqrs-serverless/ui-setting`
+> (`SettingModule`), both modules must use the **same** `tableName`, because they
+> share the same physical table.
+
 ## License
 
 Copyright © 2024-2025, Murakami Business Consulting, Inc. [https://www.mbc-net.com/](https://www.mbc-net.com/)

--- a/packages/master/README.md
+++ b/packages/master/README.md
@@ -300,11 +300,21 @@ Full documentation available at [https://mbc-cqrs-serverless.mbc-net.com/](https
 override it (backward compatible — omitting it keeps `master`). Both
 `register` and `registerAsync` accept it:
 
+> **⚠️ Renaming the master table is not fully supported.** The `master` table is a
+> framework-wide **central config store** — `TtlService` (TTL config) and the
+> `@mbc-cqrs-serverless/sequence` package (numbering formats) read a fixed
+> `master-data` table name. If you override the master `tableName`, those readers
+> keep looking at `master-data`, so TTLs are not applied and sequence formats
+> silently fall back to defaults. `MasterModule.register`/`registerAsync` logs a
+> warning when a custom `tableName` is set. Prefer keeping the default `master`;
+> only override it if you have separately addressed those readers. (Customizing
+> the directory / survey-template / ui-setting table names has no such caveat.)
+
 ```ts
 MasterModule.register({
   enableController: true,
   prismaService: PrismaService,
-  tableName: 'catalog', // default: 'master'
+  tableName: 'catalog', // default: 'master' — see the caveat above
 })
 
 MasterModule.registerAsync({

--- a/packages/master/README.md
+++ b/packages/master/README.md
@@ -44,7 +44,7 @@ import { AppTaskQueueEventFactory } from './task/app-task-queue-event.factory';
     }),
     MasterModule.register({
       enableController: true, // Optional: enable REST endpoints
-      prismaService: PrismaService, // Required when enableController is true
+      prismaService: PrismaService, // Required (MasterDataService/MasterSettingService inject it)
       dataSyncHandlers: [MasterDataSyncHandler], // Optional: custom sync handlers
     }),
   ],

--- a/packages/master/src/master.module-definition.ts
+++ b/packages/master/src/master.module-definition.ts
@@ -18,16 +18,15 @@ export interface MasterModuleAsyncOptions
   tableName?: string
   inject?: any[]
   /**
-   * Resolves the runtime module options. Must return at least `{ prismaService }`
-   * so the master services (which inject PRISMA_SERVICE) can be constructed.
-   * Optional only to stay assignment-compatible with the inherited
-   * `registerAsync` signature; omitting it makes PRISMA_SERVICE fail fast.
+   * Resolves the runtime module options. Must return the resolved PrismaService
+   * **instance** under `prismaService` (typically by injecting it), so the master
+   * services (which inject PRISMA_SERVICE) can be constructed. Optional only to
+   * stay assignment-compatible with the inherited `registerAsync` signature;
+   * omitting it makes PRISMA_SERVICE fail fast.
    */
   useFactory?: (
     ...args: any[]
-  ) =>
-    | Promise<Pick<MasterModuleOptions, 'prismaService'>>
-    | Pick<MasterModuleOptions, 'prismaService'>
+  ) => Promise<{ prismaService?: any }> | { prismaService?: any }
 }
 
 export const { ConfigurableModuleClass, MODULE_OPTIONS_TOKEN, OPTIONS_TYPE } =

--- a/packages/master/src/master.module-definition.ts
+++ b/packages/master/src/master.module-definition.ts
@@ -1,6 +1,5 @@
 import { IDataSyncHandler } from '@mbc-cqrs-serverless/core'
-import { ConfigurableModuleBuilder } from '@nestjs/common'
-import { Type } from '@nestjs/common'
+import { ConfigurableModuleBuilder, ModuleMetadata, Type } from '@nestjs/common'
 
 export const PRISMA_SERVICE = 'PrismaServiceInjectToken'
 
@@ -8,6 +7,27 @@ export interface MasterModuleOptions {
   enableController?: boolean
   dataSyncHandlers?: Type<IDataSyncHandler>[]
   prismaService?: Type<any>
+  /** DynamoDB base table name. Default: 'master'. */
+  tableName?: string
+}
+
+export interface MasterModuleAsyncOptions
+  extends Pick<ModuleMetadata, 'imports'> {
+  enableController?: boolean
+  dataSyncHandlers?: Type<IDataSyncHandler>[]
+  tableName?: string
+  inject?: any[]
+  /**
+   * Resolves the runtime module options. Must return at least `{ prismaService }`
+   * so the master services (which inject PRISMA_SERVICE) can be constructed.
+   * Optional only to stay assignment-compatible with the inherited
+   * `registerAsync` signature; omitting it makes PRISMA_SERVICE fail fast.
+   */
+  useFactory?: (
+    ...args: any[]
+  ) =>
+    | Promise<Pick<MasterModuleOptions, 'prismaService'>>
+    | Pick<MasterModuleOptions, 'prismaService'>
 }
 
 export const { ConfigurableModuleClass, MODULE_OPTIONS_TOKEN, OPTIONS_TYPE } =

--- a/packages/master/src/master.module.spec.ts
+++ b/packages/master/src/master.module.spec.ts
@@ -1,6 +1,6 @@
 import { CommandModule, StepFunctionService } from '@mbc-cqrs-serverless/core'
 import { TaskService } from '@mbc-cqrs-serverless/task'
-import { Global, Module } from '@nestjs/common'
+import { Global, Logger, Module } from '@nestjs/common'
 import { ConfigModule } from '@nestjs/config'
 import { Test } from '@nestjs/testing'
 
@@ -66,6 +66,25 @@ describe('MasterModule', () => {
 
     it('throws fast when prismaService is missing', () => {
       expect(() => MasterModule.register({} as any)).toThrow(/prismaService/)
+    })
+
+    it('warns that renaming the central master table breaks TTL/sequence config', () => {
+      const warnSpy = jest.spyOn(Logger.prototype, 'warn')
+      MasterModule.register({
+        prismaService: MockPrismaService,
+        tableName: 'catalog',
+      })
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/central config|master-data|not fully supported/),
+      )
+    })
+
+    it('does not warn for the default master table', () => {
+      const warnSpy = jest.spyOn(Logger.prototype, 'warn')
+      MasterModule.register({ prismaService: MockPrismaService })
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringMatching(/not fully supported/),
+      )
     })
   })
 

--- a/packages/master/src/master.module.spec.ts
+++ b/packages/master/src/master.module.spec.ts
@@ -104,5 +104,28 @@ describe('MasterModule', () => {
         expect.objectContaining({ tableName: 'custom-master' }),
       )
     })
+
+    it('rejects a useFactory that returns the PrismaService class instead of an instance', async () => {
+      await expect(
+        Test.createTestingModule({
+          imports: [
+            SupportModule,
+            MasterModule.registerAsync({
+              inject: [],
+              // wrong: returns the class, not an instance
+              useFactory: () => ({ prismaService: MockPrismaService }),
+            }),
+          ],
+        }).compile(),
+      ).rejects.toThrow(/CLASS, not an instance/)
+    })
+  })
+
+  describe('CommandModule.registerAsync guard', () => {
+    it('throws a clear error (not supported)', () => {
+      expect(() => (CommandModule as any).registerAsync({})).toThrow(
+        /not supported/,
+      )
+    })
   })
 })

--- a/packages/master/src/master.module.spec.ts
+++ b/packages/master/src/master.module.spec.ts
@@ -1,0 +1,91 @@
+import { CommandModule, StepFunctionService } from '@mbc-cqrs-serverless/core'
+import { TaskService } from '@mbc-cqrs-serverless/task'
+import { ConfigModule } from '@nestjs/config'
+import { Global, Module } from '@nestjs/common'
+import { Test } from '@nestjs/testing'
+
+import { MasterModule } from './master.module'
+import { MasterDataService } from './services'
+
+class MockPrismaService {}
+
+/**
+ * Provides the globally-scoped dependencies a real app supplies
+ * (ConfigService, StepFunctionService, TaskService, PrismaService) so the
+ * module composed by registerAsync can be compiled in isolation.
+ */
+@Global()
+@Module({
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      ignoreEnvFile: true,
+      load: [() => ({ NODE_ENV: 'local', APP_NAME: 'app' })],
+    }),
+  ],
+  providers: [
+    StepFunctionService,
+    MockPrismaService,
+    { provide: TaskService, useValue: {} },
+  ],
+  exports: [StepFunctionService, MockPrismaService, TaskService],
+})
+class SupportModule {}
+
+describe('MasterModule', () => {
+  afterEach(() => jest.restoreAllMocks())
+
+  describe('register (sync)', () => {
+    it('forwards the default table name to CommandModule', () => {
+      const spy = jest.spyOn(CommandModule, 'register')
+      MasterModule.register({ prismaService: MockPrismaService })
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ tableName: 'master' }),
+      )
+    })
+
+    it('forwards a custom table name to CommandModule', () => {
+      const spy = jest.spyOn(CommandModule, 'register')
+      MasterModule.register({
+        prismaService: MockPrismaService,
+        tableName: 'custom-master',
+      })
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ tableName: 'custom-master' }),
+      )
+    })
+
+    it('throws fast when prismaService is missing', () => {
+      expect(() => MasterModule.register({} as any)).toThrow(/prismaService/)
+    })
+  })
+
+  describe('registerAsync', () => {
+    it('compiles and resolves the public service (default table)', async () => {
+      const moduleRef = await Test.createTestingModule({
+        imports: [
+          SupportModule,
+          MasterModule.registerAsync({
+            inject: [],
+            useFactory: () => ({ prismaService: MockPrismaService }),
+          }),
+        ],
+      }).compile()
+
+      expect(moduleRef.get(MasterDataService)).toBeDefined()
+      await moduleRef.close()
+    })
+
+    it('forwards a custom table name via registerAsync', () => {
+      const spy = jest.spyOn(CommandModule, 'register')
+      MasterModule.registerAsync({
+        inject: [],
+        useFactory: () => ({ prismaService: MockPrismaService }),
+        tableName: 'custom-master',
+      })
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ tableName: 'custom-master' }),
+      )
+    })
+  })
+})

--- a/packages/master/src/master.module.spec.ts
+++ b/packages/master/src/master.module.spec.ts
@@ -1,18 +1,21 @@
 import { CommandModule, StepFunctionService } from '@mbc-cqrs-serverless/core'
 import { TaskService } from '@mbc-cqrs-serverless/task'
-import { ConfigModule } from '@nestjs/config'
 import { Global, Module } from '@nestjs/common'
+import { ConfigModule } from '@nestjs/config'
 import { Test } from '@nestjs/testing'
 
 import { MasterModule } from './master.module'
 import { MasterDataService } from './services'
 
-class MockPrismaService {}
+class MockPrismaService {
+  readonly kind = 'instance'
+}
 
 /**
- * Provides the globally-scoped dependencies a real app supplies
- * (ConfigService, StepFunctionService, TaskService, PrismaService) so the
- * module composed by registerAsync can be compiled in isolation.
+ * Provides the globally-scoped dependencies a real app supplies. PrismaService
+ * is provided via an ASYNC factory (mirroring PrismaModule.forRootAsync) so the
+ * registerAsync path is exercised against the realistic ordering where the
+ * Prisma instance is not available synchronously.
  */
 @Global()
 @Module({
@@ -25,10 +28,16 @@ class MockPrismaService {}
   ],
   providers: [
     StepFunctionService,
-    MockPrismaService,
     { provide: TaskService, useValue: {} },
+    {
+      provide: MockPrismaService,
+      useFactory: async () => {
+        await new Promise((r) => setTimeout(r, 5))
+        return new MockPrismaService()
+      },
+    },
   ],
-  exports: [StepFunctionService, MockPrismaService, TaskService],
+  exports: [StepFunctionService, TaskService, MockPrismaService],
 })
 class SupportModule {}
 
@@ -61,18 +70,26 @@ describe('MasterModule', () => {
   })
 
   describe('registerAsync', () => {
-    it('compiles and resolves the public service (default table)', async () => {
+    it('resolves an async-provided PrismaService instance (not null)', async () => {
       const moduleRef = await Test.createTestingModule({
         imports: [
           SupportModule,
           MasterModule.registerAsync({
-            inject: [],
-            useFactory: () => ({ prismaService: MockPrismaService }),
+            inject: [MockPrismaService],
+            useFactory: (prisma: MockPrismaService) => ({
+              prismaService: prisma,
+            }),
           }),
         ],
       }).compile()
+      await moduleRef.init()
 
-      expect(moduleRef.get(MasterDataService)).toBeDefined()
+      const svc = moduleRef.get(MasterDataService)
+      expect(svc).toBeDefined()
+      // Regression: the injected PRISMA_SERVICE must be the resolved instance,
+      // not null (async Prisma) and not the class reference.
+      expect((svc as any).prismaService).toBeInstanceOf(MockPrismaService)
+      expect((svc as any).prismaService.kind).toBe('instance')
       await moduleRef.close()
     })
 
@@ -80,7 +97,7 @@ describe('MasterModule', () => {
       const spy = jest.spyOn(CommandModule, 'register')
       MasterModule.registerAsync({
         inject: [],
-        useFactory: () => ({ prismaService: MockPrismaService }),
+        useFactory: () => ({ prismaService: new MockPrismaService() }),
         tableName: 'custom-master',
       })
       expect(spy).toHaveBeenCalledWith(

--- a/packages/master/src/master.module.ts
+++ b/packages/master/src/master.module.ts
@@ -1,5 +1,7 @@
 import {
-  CommandModule,
+  buildDomainCommandModule,
+  buildPrismaProviderAsync,
+  buildPrismaProviderSync,
   DataStoreModule,
   QueueModule,
 } from '@mbc-cqrs-serverless/core'
@@ -16,6 +18,8 @@ import { CustomTaskModule } from './custom-task/custom-task.module'
 import { MasterSfnTaskEventHandler } from './handler/master-sfn-task.handler'
 import {
   ConfigurableModuleClass,
+  MasterModuleAsyncOptions,
+  MODULE_OPTIONS_TOKEN,
   OPTIONS_TYPE,
   PRISMA_SERVICE,
 } from './master.module-definition'
@@ -28,49 +32,70 @@ import { MasterDataService, MasterSettingService } from './services'
 })
 export class MasterModule extends ConfigurableModuleClass {
   static register(options: typeof OPTIONS_TYPE): DynamicModule {
-    const module = super.register(options)
+    const base = super.register(options)
+    const providers = [...(base.providers ?? [])]
+    const controllers = [...(base.controllers ?? [])]
+    const imports = [...(base.imports ?? [])]
+
+    // The master services inject PRISMA_SERVICE unconditionally.
+    providers.push(
+      buildPrismaProviderSync(options.prismaService, PRISMA_SERVICE),
+    )
 
     if (options.enableController) {
-      if (!options.prismaService) {
-        throw new Error(
-          'PrismaService must be provided when enableController is true.',
-        )
-      }
-      if (!module.controllers) {
-        module.controllers = []
-      }
-      module.controllers.push(MasterBulkController)
-      module.controllers.push(MasterDataController)
-      module.controllers.push(MasterSettingController)
-
-      if (!module.providers) {
-        module.providers = []
-      }
-
-      module.providers.push({
-        provide: PRISMA_SERVICE,
-        useExisting: options.prismaService,
-      })
-      module.providers.push(MasterSfnTaskEventHandler)
-
-      if (!module.imports) {
-        module.imports = []
-      }
-      module.imports.push(CustomTaskModule)
-      module.imports.push(SequencesModule)
+      controllers.push(
+        MasterBulkController,
+        MasterDataController,
+        MasterSettingController,
+      )
+      providers.push(MasterSfnTaskEventHandler)
+      imports.push(CustomTaskModule, SequencesModule)
     }
-    const imports = [...(module.imports ?? [])]
+
+    imports.push(buildDomainCommandModule(TABLE_NAME, options))
+
+    return { ...base, providers, controllers, imports }
+  }
+
+  static registerAsync(options: MasterModuleAsyncOptions): DynamicModule {
+    const base = super.registerAsync({
+      imports: options.imports,
+      inject: options.inject ?? [],
+      useFactory: async (...args: any[]) => {
+        const resolved = (await options.useFactory?.(...args)) ?? {}
+        return {
+          ...resolved,
+          enableController: options.enableController,
+          dataSyncHandlers: options.dataSyncHandlers,
+          tableName: options.tableName ?? TABLE_NAME,
+        }
+      },
+    })
+    const providers = [...(base.providers ?? [])]
+    const controllers = [...(base.controllers ?? [])]
+    const imports = [...(base.imports ?? [])]
+
+    providers.push(
+      buildPrismaProviderAsync(MODULE_OPTIONS_TOKEN, PRISMA_SERVICE),
+    )
+
+    if (options.enableController) {
+      controllers.push(
+        MasterBulkController,
+        MasterDataController,
+        MasterSettingController,
+      )
+      providers.push(MasterSfnTaskEventHandler)
+      imports.push(CustomTaskModule, SequencesModule)
+    }
 
     imports.push(
-      CommandModule.register({
-        tableName: TABLE_NAME,
-        dataSyncHandlers: options?.dataSyncHandlers,
+      buildDomainCommandModule(TABLE_NAME, {
+        tableName: options.tableName,
+        dataSyncHandlers: options.dataSyncHandlers,
       }),
     )
 
-    return {
-      ...module,
-      imports,
-    }
+    return { ...base, providers, controllers, imports }
   }
 }

--- a/packages/master/src/master.module.ts
+++ b/packages/master/src/master.module.ts
@@ -42,6 +42,11 @@ export class MasterModule extends ConfigurableModuleClass {
       buildPrismaProviderSync(options.prismaService, PRISMA_SERVICE),
     )
 
+    // Data-sync handlers are registered here (not inside CommandModule) so they
+    // can resolve PRISMA_SERVICE from this module's scope.
+    const handlers = options.dataSyncHandlers ?? []
+    providers.push(...handlers)
+
     if (options.enableController) {
       controllers.push(
         MasterBulkController,
@@ -52,7 +57,12 @@ export class MasterModule extends ConfigurableModuleClass {
       imports.push(CustomTaskModule, SequencesModule)
     }
 
-    imports.push(buildDomainCommandModule(TABLE_NAME, options))
+    imports.push(
+      buildDomainCommandModule(TABLE_NAME, {
+        tableName: options.tableName,
+        dataSyncHandlers: handlers,
+      }),
+    )
 
     return { ...base, providers, controllers, imports }
   }
@@ -79,6 +89,9 @@ export class MasterModule extends ConfigurableModuleClass {
       buildPrismaProviderAsync(MODULE_OPTIONS_TOKEN, PRISMA_SERVICE),
     )
 
+    const handlers = options.dataSyncHandlers ?? []
+    providers.push(...handlers)
+
     if (options.enableController) {
       controllers.push(
         MasterBulkController,
@@ -92,7 +105,7 @@ export class MasterModule extends ConfigurableModuleClass {
     imports.push(
       buildDomainCommandModule(TABLE_NAME, {
         tableName: options.tableName,
-        dataSyncHandlers: options.dataSyncHandlers,
+        dataSyncHandlers: handlers,
       }),
     )
 

--- a/packages/master/src/master.module.ts
+++ b/packages/master/src/master.module.ts
@@ -44,8 +44,10 @@ export class MasterModule extends ConfigurableModuleClass {
         `tableName '${tableName}' overrides the 'master' table, which is also read ` +
           `at a fixed 'master-data' name by TtlService (TTL config) and the sequence ` +
           `package (numbering formats). Renaming the master table is not fully ` +
-          `supported — TTL and sequence formats will silently fall back. Keep the ` +
-          `default 'master' unless you have addressed those readers.`,
+          `supported — TTL and sequence formats will silently fall back. Also, if you ` +
+          `use ui-setting's SettingModule, set its tableName to '${tableName}' too ` +
+          `(they share this table). Keep the default 'master' unless you have ` +
+          `addressed those readers.`,
       )
     }
   }

--- a/packages/master/src/master.module.ts
+++ b/packages/master/src/master.module.ts
@@ -6,7 +6,7 @@ import {
   QueueModule,
 } from '@mbc-cqrs-serverless/core'
 import { SequencesModule } from '@mbc-cqrs-serverless/sequence'
-import { DynamicModule, Module } from '@nestjs/common'
+import { DynamicModule, Logger, Module } from '@nestjs/common'
 
 import { TABLE_NAME } from './constants'
 import {
@@ -31,7 +31,27 @@ import { MasterDataService, MasterSettingService } from './services'
   exports: [MasterDataService, MasterSettingService],
 })
 export class MasterModule extends ConfigurableModuleClass {
+  private static readonly logger = new Logger(MasterModule.name)
+
+  /**
+   * The `master` table is a framework-wide central config store: `TtlService`
+   * (TTL config) and the sequence package (numbering formats) read the fixed
+   * `master-data` table. Renaming it silently breaks those readers, so warn.
+   */
+  private static warnIfCustomTable(tableName?: string): void {
+    if (tableName && tableName !== TABLE_NAME) {
+      MasterModule.logger.warn(
+        `tableName '${tableName}' overrides the 'master' table, which is also read ` +
+          `at a fixed 'master-data' name by TtlService (TTL config) and the sequence ` +
+          `package (numbering formats). Renaming the master table is not fully ` +
+          `supported — TTL and sequence formats will silently fall back. Keep the ` +
+          `default 'master' unless you have addressed those readers.`,
+      )
+    }
+  }
+
   static register(options: typeof OPTIONS_TYPE): DynamicModule {
+    MasterModule.warnIfCustomTable(options.tableName)
     const base = super.register(options)
     const providers = [...(base.providers ?? [])]
     const controllers = [...(base.controllers ?? [])]
@@ -68,6 +88,7 @@ export class MasterModule extends ConfigurableModuleClass {
   }
 
   static registerAsync(options: MasterModuleAsyncOptions): DynamicModule {
+    MasterModule.warnIfCustomTable(options.tableName)
     const base = super.registerAsync({
       imports: options.imports,
       inject: options.inject ?? [],

--- a/packages/master/src/templates/master/master.module.ts
+++ b/packages/master/src/templates/master/master.module.ts
@@ -1,4 +1,3 @@
-import { CommandModule } from '@mbc-cqrs-serverless/core'
 import { MasterModule as CoreMasterModule } from '@mbc-cqrs-serverless/master'
 import { Module } from '@nestjs/common'
 import { PrismaService } from 'src/prisma'
@@ -7,10 +6,6 @@ import { MasterDataSyncRdsHandler } from './handler/master-rds.handler'
 
 @Module({
   imports: [
-    CommandModule.register({
-      tableName: 'master',
-      dataSyncHandlers: [MasterDataSyncRdsHandler],
-    }),
     CoreMasterModule.register({
       enableController: true,
       prismaService: PrismaService,

--- a/packages/mcp-server/skills/mbc-migrate/SKILL.md
+++ b/packages/mcp-server/skills/mbc-migrate/SKILL.md
@@ -44,6 +44,7 @@ This skill helps migrate MBC CQRS Serverless projects between versions.
 | v1.2.7 | v1.3.0 | Low | AppSync Events API support (opt-in, no breaking changes) |
 | v1.3.0 | v1.3.1 | Low | Group-based roles (`@GroupRoleResolver`, `custom:groups`); `UserContext.tenantRoles`/`tenantGroupIds` added (opt-in, no breaking changes) |
 | v1.3.2 | v1.3.3 | Low | `ATTRIBUTE_LIMIT_SIZE` default lowered 389120 → 102400 for Step Functions payload limit (transparent unless overridden) |
+| v1.3.5 | v1.4.0 | Low | Configurable DynamoDB table names (opt-in) + `registerAsync` on domain modules; `prismaService` now always required; `MasterModule`+`SettingModule` shared-table alias warns |
 
 ## Migration Guides
 
@@ -688,10 +689,68 @@ Register the class in your module `providers`. `AuthModule` is imported automati
 
 ---
 
+### v1.3.5 → v1.4.0 (opt-in new features; no changes required if you keep defaults)
+
+v1.4.0 makes the DynamoDB table names of the domain modules (`master`, `directory`, `survey-template`, `ui-setting`) configurable and adds `registerAsync` support. **All new options default to the current names, so existing apps upgrade with no code changes.**
+
+**New capabilities (opt-in):**
+- `tableName?` on `MasterModule` / `DirectoryStorageModule` / `SurveyTemplateModule` / `SettingModule` (defaults: `master` / `directory` / `survey` / `master`).
+- `DirectoryStorageModule` also accepts `pkPrefix?` (default `DIRECTORY`) and `prismaModelName?` (default `directory`).
+- `registerAsync(...)` on all four modules.
+
+**Behavior changes to be aware of (not breaking for the common setup):**
+- `prismaService` is now **always required** when registering `MasterModule` / `DirectoryStorageModule` / `SurveyTemplateModule` (previously it was only validated when `enableController: true`). The domain services inject `PRISMA_SERVICE` unconditionally, so a missing `prismaService` now fails fast at startup with a clear message instead of a cryptic `UnknownDependenciesException`. **Action:** if you registered one of these modules with `enableController: false` and omitted `prismaService` (relying on a globally-provided token), pass `prismaService` explicitly.
+- If you use **`MasterModule` + `SettingModule` on the same (default `master`) table**, the framework now logs a **warning** at startup when both own the `master_CommandEventHandler` alias, and which module's data-sync handlers run is import-order dependent. Set `registerEventHandlerAlias: false` on `SettingModule` so `MasterModule` owns the alias (deterministic). This was a silent ambiguity before; nothing breaks, but the warning is new.
+
+#### How to change a table name
+
+Changing a table name is opt-in and backward compatible. Example: run the directory module as `document` (this is how the v1.3.x `directory` → `document` rename is now expressed — as configuration, not a forced default):
+
+```ts
+// Synchronous
+DirectoryStorageModule.register({
+  enableController: true,
+  prismaService: PrismaService,
+  tableName: 'document',        // physical tables: <env>-<app>-document-command/-data/-history
+  pkPrefix: 'DOCUMENT',         // partition key: DOCUMENT#<tenantCode>
+  prismaModelName: 'document',  // RDS reads via prismaService.document
+})
+
+// Async — the factory must resolve and return the PrismaService INSTANCE
+DirectoryStorageModule.registerAsync({
+  tableName: 'document',
+  pkPrefix: 'DOCUMENT',
+  prismaModelName: 'document',
+  imports: [PrismaModule],
+  inject: [PrismaService],
+  useFactory: (prisma) => ({ prismaService: prisma }),
+})
+```
+
+For `MasterModule` / `SurveyTemplateModule` / `SettingModule`, only `tableName` applies:
+
+```ts
+MasterModule.register({ enableController: true, prismaService: PrismaService, tableName: 'catalog' })
+```
+
+**Set all three (`tableName` + `pkPrefix` + `prismaModelName`) together for directory** — changing only `tableName` leaves the PK as `DIRECTORY#` and reads `prismaService.directory`, which is inconsistent.
+
+**Required provisioning and data migration (application responsibility):**
+1. **DynamoDB:** add the **raw base name** (e.g. `"document"`) — not the `-command`/`-data`/`-history` variants — to `prisma/dynamodbs/cqrs.json`, then run `npm run migrate:ddb` (`prisma/ddb.ts`). This creates `<name>-command/-data/-history`. Only `@mbc-cqrs-serverless/master`'s postinstall auto-adds its default `master`; every other module and every custom name must be added to `cqrs.json` by hand. Mirror the three physical tables in your IaC.
+2. **RDS:** add the corresponding Prisma model (e.g. `model Document { ... }` for `prismaModelName: 'document'`) to `schema.prisma`, then run `npm run migrate:rds` (`prisma migrate deploy`).
+3. **Data:** `migrate` only creates the (empty) tables. Copying existing rows from `directory-*` / `DIRECTORY#` / the `directory` model to the new `document-*` / `DOCUMENT#` / `document` targets is your responsibility (DynamoDB scan-and-rewrite + an RDS data migration). See [Data Migration Patterns](/docs/data-migration-patterns).
+
+> **Caveat — do NOT rename the `master` table.** The `master` table is a framework-wide central config store: `TtlService` (TTL config) and `@mbc-cqrs-serverless/sequence` (numbering formats) read a fixed `master-data` name. Overriding `MasterModule`'s `tableName` makes those readers miss their config (TTLs not applied, sequence formats fall back silently); `MasterModule.register`/`registerAsync` logs a warning in that case. Renaming `directory` / `survey-template` / `ui-setting` has no such caveat.
+
+**Action required:** none if you keep the defaults. To adopt a custom name, follow the steps above.
+
+---
+
 ## Version Compatibility Matrix
 
 | Core Version | CLI Version | NestJS | Node.js | TypeScript |
 |--------------|-------------|--------|---------|------------|
+| v1.4.0 | v1.4.0 | 10.x | 18+ | 5.x |
 | v1.3.0 | v1.3.0 | 10.x | 18+ | 5.x |
 | v1.0.23 | v1.0.23 | 10.x | 18+ | 5.x |
 | v1.0.22 | v1.0.22 | 10.x | 18+ | 5.x |

--- a/packages/survey-template/README.md
+++ b/packages/survey-template/README.md
@@ -49,8 +49,9 @@ SurveyTemplateModule.register({
 
 SurveyTemplateModule.registerAsync({
   tableName: 'questionnaire',
-  inject: [],
-  useFactory: () => ({ prismaService: PrismaService }),
+  imports: [PrismaModule],
+  inject: [PrismaService], // resolve and return the PrismaService INSTANCE
+  useFactory: (prisma) => ({ prismaService: prisma }),
 })
 ```
 

--- a/packages/survey-template/README.md
+++ b/packages/survey-template/README.md
@@ -34,6 +34,30 @@ npm install @mbc-cqrs-serverless/survey-template
 - `PUT /api/survey-template/:id` - Update a survey template
 - `DELETE /api/survey-template/:id` - Delete a survey template
 
+## Configurable table name
+
+`SurveyTemplateModule` uses the `survey` DynamoDB table by default. Pass
+`tableName` to override it (backward compatible). Both `register` and
+`registerAsync` accept it:
+
+```ts
+SurveyTemplateModule.register({
+  enableController: true,
+  prismaService: PrismaService,
+  tableName: 'questionnaire', // default: 'survey'
+})
+
+SurveyTemplateModule.registerAsync({
+  tableName: 'questionnaire',
+  inject: [],
+  useFactory: () => ({ prismaService: PrismaService }),
+})
+```
+
+> **Provisioning:** Add **only the raw base name** (e.g. `"questionnaire"`) to
+> `prisma/dynamodbs/cqrs.json`; the CLI creates the `-command` / `-data` /
+> `-history` physical tables, and your IaC must define the same three.
+
 ## Documentation
 
 Visit https://mbc-cqrs-serverless.mbc-net.com/ to view the full documentation.

--- a/packages/survey-template/README.md
+++ b/packages/survey-template/README.md
@@ -58,6 +58,13 @@ SurveyTemplateModule.registerAsync({
 > **Provisioning:** Add **only the raw base name** (e.g. `"questionnaire"`) to
 > `prisma/dynamodbs/cqrs.json`; the CLI creates the `-command` / `-data` /
 > `-history` physical tables, and your IaC must define the same three.
+>
+> **Unique table name:** give `SurveyTemplateModule` its own `tableName`. Sharing
+> one physical table across modules is only wired for `MasterModule` + ui-setting's
+> `SettingModule`. Because survey registers default data-sync handlers, sharing its
+> table with another module registers a duplicate
+> `<tableName>_CommandEventHandler` alias (the app warns and handler ownership
+> becomes import-order dependent).
 
 ## Documentation
 

--- a/packages/survey-template/src/survey-template.module-definition.ts
+++ b/packages/survey-template/src/survey-template.module-definition.ts
@@ -20,16 +20,15 @@ export interface SurveyTemplateModuleAsyncOptions
   tableName?: string
   inject?: any[]
   /**
-   * Resolves the runtime module options. Must return at least `{ prismaService }`
-   * so the survey services (which inject PRISMA_SERVICE) can be constructed.
-   * Optional only to stay assignment-compatible with the inherited
-   * `registerAsync` signature; omitting it makes PRISMA_SERVICE fail fast.
+   * Resolves the runtime module options. Must return the resolved PrismaService
+   * **instance** under `prismaService` (typically by injecting it), so the survey
+   * services (which inject PRISMA_SERVICE) can be constructed. Optional only to
+   * stay assignment-compatible with the inherited `registerAsync` signature;
+   * omitting it makes PRISMA_SERVICE fail fast.
    */
   useFactory?: (
     ...args: any[]
-  ) =>
-    | Promise<Pick<SurveyTemplateModuleOptions, 'prismaService'>>
-    | Pick<SurveyTemplateModuleOptions, 'prismaService'>
+  ) => Promise<{ prismaService?: any }> | { prismaService?: any }
 }
 
 export const { ConfigurableModuleClass, MODULE_OPTIONS_TOKEN, OPTIONS_TYPE } =

--- a/packages/survey-template/src/survey-template.module-definition.ts
+++ b/packages/survey-template/src/survey-template.module-definition.ts
@@ -1,13 +1,35 @@
 import { IDataSyncHandler } from '@mbc-cqrs-serverless/core'
-import { ConfigurableModuleBuilder } from '@nestjs/common'
-import { Type } from '@nestjs/common'
+import { ConfigurableModuleBuilder, ModuleMetadata, Type } from '@nestjs/common'
 
 export const PRISMA_SERVICE = 'PrismaServiceInjectToken'
+
+export const DEFAULT_SURVEY_TABLE_NAME = 'survey'
 
 export interface SurveyTemplateModuleOptions {
   enableController?: boolean
   dataSyncHandlers?: Type<IDataSyncHandler>[]
   prismaService?: Type<any>
+  /** DynamoDB base table name. Default: 'survey'. */
+  tableName?: string
+}
+
+export interface SurveyTemplateModuleAsyncOptions
+  extends Pick<ModuleMetadata, 'imports'> {
+  enableController?: boolean
+  dataSyncHandlers?: Type<IDataSyncHandler>[]
+  tableName?: string
+  inject?: any[]
+  /**
+   * Resolves the runtime module options. Must return at least `{ prismaService }`
+   * so the survey services (which inject PRISMA_SERVICE) can be constructed.
+   * Optional only to stay assignment-compatible with the inherited
+   * `registerAsync` signature; omitting it makes PRISMA_SERVICE fail fast.
+   */
+  useFactory?: (
+    ...args: any[]
+  ) =>
+    | Promise<Pick<SurveyTemplateModuleOptions, 'prismaService'>>
+    | Pick<SurveyTemplateModuleOptions, 'prismaService'>
 }
 
 export const { ConfigurableModuleClass, MODULE_OPTIONS_TOKEN, OPTIONS_TYPE } =

--- a/packages/survey-template/src/survey-template.module.spec.ts
+++ b/packages/survey-template/src/survey-template.module.spec.ts
@@ -1,0 +1,85 @@
+import { CommandModule, StepFunctionService } from '@mbc-cqrs-serverless/core'
+import { Global, Module } from '@nestjs/common'
+import { ConfigModule } from '@nestjs/config'
+import { Test } from '@nestjs/testing'
+
+import { PRISMA_SERVICE } from './survey-template.module-definition'
+import { SurveyTemplateModule } from './survey-template.module'
+import { SurveyTemplateService } from './survey-template.service'
+
+class MockPrismaService {}
+
+/**
+ * Provides globally-scoped dependencies a real app supplies. PRISMA_SERVICE is
+ * exposed globally because the default data-sync handlers are registered inside
+ * the (child) CommandModule and inject the token across the module boundary —
+ * this mirrors how a real app provides PrismaService globally.
+ */
+@Global()
+@Module({
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      ignoreEnvFile: true,
+      load: [() => ({ NODE_ENV: 'local', APP_NAME: 'app' })],
+    }),
+  ],
+  providers: [
+    StepFunctionService,
+    MockPrismaService,
+    { provide: PRISMA_SERVICE, useClass: MockPrismaService },
+  ],
+  exports: [StepFunctionService, MockPrismaService, PRISMA_SERVICE],
+})
+class SupportModule {}
+
+describe('SurveyTemplateModule', () => {
+  afterEach(() => jest.restoreAllMocks())
+
+  describe('register (sync)', () => {
+    it('forwards the default table name to CommandModule', () => {
+      const spy = jest.spyOn(CommandModule, 'register')
+      SurveyTemplateModule.register({ prismaService: MockPrismaService })
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ tableName: 'survey' }),
+      )
+    })
+
+    it('forwards a custom table name to CommandModule', () => {
+      const spy = jest.spyOn(CommandModule, 'register')
+      SurveyTemplateModule.register({
+        prismaService: MockPrismaService,
+        tableName: 'questionnaire',
+      })
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ tableName: 'questionnaire' }),
+      )
+    })
+
+    it('returns a DynamicModule even when enableController is false', () => {
+      const mod = SurveyTemplateModule.register({
+        prismaService: MockPrismaService,
+        enableController: false,
+      })
+      expect(mod).toBeDefined()
+      expect(mod.module).toBe(SurveyTemplateModule)
+    })
+  })
+
+  describe('registerAsync', () => {
+    it('compiles and resolves the public service (default table)', async () => {
+      const moduleRef = await Test.createTestingModule({
+        imports: [
+          SupportModule,
+          SurveyTemplateModule.registerAsync({
+            inject: [],
+            useFactory: () => ({ prismaService: MockPrismaService }),
+          }),
+        ],
+      }).compile()
+
+      expect(moduleRef.get(SurveyTemplateService)).toBeDefined()
+      await moduleRef.close()
+    })
+  })
+})

--- a/packages/survey-template/src/survey-template.module.spec.ts
+++ b/packages/survey-template/src/survey-template.module.spec.ts
@@ -3,17 +3,17 @@ import { Global, Module } from '@nestjs/common'
 import { ConfigModule } from '@nestjs/config'
 import { Test } from '@nestjs/testing'
 
-import { PRISMA_SERVICE } from './survey-template.module-definition'
 import { SurveyTemplateModule } from './survey-template.module'
 import { SurveyTemplateService } from './survey-template.service'
 
 class MockPrismaService {}
 
 /**
- * Provides globally-scoped dependencies a real app supplies. PRISMA_SERVICE is
- * exposed globally because the default data-sync handlers are registered inside
- * the (child) CommandModule and inject the token across the module boundary —
- * this mirrors how a real app provides PrismaService globally.
+ * Provides only globally-scoped app dependencies (ConfigService,
+ * StepFunctionService) and the concrete PrismaService class. PRISMA_SERVICE is
+ * intentionally NOT provided globally: the default data-sync handlers now resolve
+ * it from SurveyTemplateModule's own scope, proving the module boots without the
+ * app having to expose the token globally.
  */
 @Global()
 @Module({
@@ -24,12 +24,8 @@ class MockPrismaService {}
       load: [() => ({ NODE_ENV: 'local', APP_NAME: 'app' })],
     }),
   ],
-  providers: [
-    StepFunctionService,
-    MockPrismaService,
-    { provide: PRISMA_SERVICE, useClass: MockPrismaService },
-  ],
-  exports: [StepFunctionService, MockPrismaService, PRISMA_SERVICE],
+  providers: [StepFunctionService, MockPrismaService],
+  exports: [StepFunctionService, MockPrismaService],
 })
 class SupportModule {}
 

--- a/packages/survey-template/src/survey-template.module.spec.ts
+++ b/packages/survey-template/src/survey-template.module.spec.ts
@@ -68,13 +68,18 @@ describe('SurveyTemplateModule', () => {
         imports: [
           SupportModule,
           SurveyTemplateModule.registerAsync({
-            inject: [],
-            useFactory: () => ({ prismaService: MockPrismaService }),
+            inject: [MockPrismaService],
+            useFactory: (prisma: MockPrismaService) => ({
+              prismaService: prisma,
+            }),
           }),
         ],
       }).compile()
+      await moduleRef.init()
 
-      expect(moduleRef.get(SurveyTemplateService)).toBeDefined()
+      const svc = moduleRef.get(SurveyTemplateService)
+      expect(svc).toBeDefined()
+      expect((svc as any).prismaService).toBeInstanceOf(MockPrismaService)
       await moduleRef.close()
     })
   })

--- a/packages/survey-template/src/survey-template.module.ts
+++ b/packages/survey-template/src/survey-template.module.ts
@@ -1,5 +1,7 @@
 import {
-  CommandModule,
+  buildDomainCommandModule,
+  buildPrismaProviderAsync,
+  buildPrismaProviderSync,
   DataStoreModule,
   QueueModule,
 } from '@mbc-cqrs-serverless/core'
@@ -12,10 +14,18 @@ import { SurveyAnswerService } from './survey-answer.service'
 import { SurveyTemplateController } from './survey-template.controller'
 import {
   ConfigurableModuleClass,
+  DEFAULT_SURVEY_TABLE_NAME,
+  MODULE_OPTIONS_TOKEN,
   OPTIONS_TYPE,
   PRISMA_SERVICE,
+  SurveyTemplateModuleAsyncOptions,
 } from './survey-template.module-definition'
 import { SurveyTemplateService } from './survey-template.service'
+
+const DEFAULT_HANDLERS = [
+  SurveyTemplateDataSyncRdsHandler,
+  SurveyAnswerDataSyncRdsHandler,
+]
 
 @Module({
   imports: [DataStoreModule, QueueModule],
@@ -24,44 +34,66 @@ import { SurveyTemplateService } from './survey-template.service'
 })
 export class SurveyTemplateModule extends ConfigurableModuleClass {
   static register(options: typeof OPTIONS_TYPE): DynamicModule {
-    const module = super.register(options)
+    const base = super.register(options)
+    const providers = [...(base.providers ?? [])]
+    const controllers = [...(base.controllers ?? [])]
+    const imports = [...(base.imports ?? [])]
+
+    // The survey services inject PRISMA_SERVICE unconditionally.
+    providers.push(
+      buildPrismaProviderSync(options.prismaService, PRISMA_SERVICE),
+    )
 
     if (options.enableController) {
-      if (!options.prismaService) {
-        throw new Error(
-          'PrismaService must be provided when enableController is true.',
-        )
-      }
-      if (!module.controllers) {
-        module.controllers = []
-      }
-      module.controllers.push(SurveyTemplateController, SurveyAnswerController)
-
-      if (!module.providers) {
-        module.providers = []
-      }
-      module.providers.push({
-        provide: PRISMA_SERVICE,
-        useExisting: options.prismaService,
-      })
-      if (!module.imports) {
-        module.imports = []
-      }
-
-      const imports = [...(module.imports ?? [])]
-      imports.push(
-        CommandModule.register({
-          tableName: 'survey',
-          dataSyncHandlers: options?.dataSyncHandlers ?? [
-            SurveyTemplateDataSyncRdsHandler,
-            SurveyAnswerDataSyncRdsHandler,
-          ],
-        }),
-      )
-      return {
-        ...module,
-        imports,
-      }
+      controllers.push(SurveyTemplateController, SurveyAnswerController)
     }
+
+    imports.push(
+      buildDomainCommandModule(DEFAULT_SURVEY_TABLE_NAME, {
+        tableName: options.tableName,
+        dataSyncHandlers: options.dataSyncHandlers ?? DEFAULT_HANDLERS,
+      }),
+    )
+
+    // Always return a DynamicModule, even when enableController is false.
+    return { ...base, providers, controllers, imports }
+  }
+
+  static registerAsync(
+    options: SurveyTemplateModuleAsyncOptions,
+  ): DynamicModule {
+    const base = super.registerAsync({
+      imports: options.imports,
+      inject: options.inject ?? [],
+      useFactory: async (...args: any[]) => {
+        const resolved = (await options.useFactory?.(...args)) ?? {}
+        return {
+          ...resolved,
+          enableController: options.enableController,
+          dataSyncHandlers: options.dataSyncHandlers,
+          tableName: options.tableName ?? DEFAULT_SURVEY_TABLE_NAME,
+        }
+      },
+    })
+    const providers = [...(base.providers ?? [])]
+    const controllers = [...(base.controllers ?? [])]
+    const imports = [...(base.imports ?? [])]
+
+    providers.push(
+      buildPrismaProviderAsync(MODULE_OPTIONS_TOKEN, PRISMA_SERVICE),
+    )
+
+    if (options.enableController) {
+      controllers.push(SurveyTemplateController, SurveyAnswerController)
+    }
+
+    imports.push(
+      buildDomainCommandModule(DEFAULT_SURVEY_TABLE_NAME, {
+        tableName: options.tableName,
+        dataSyncHandlers: options.dataSyncHandlers ?? DEFAULT_HANDLERS,
+      }),
+    )
+
+    return { ...base, providers, controllers, imports }
   }
 }

--- a/packages/survey-template/src/survey-template.module.ts
+++ b/packages/survey-template/src/survey-template.module.ts
@@ -44,6 +44,11 @@ export class SurveyTemplateModule extends ConfigurableModuleClass {
       buildPrismaProviderSync(options.prismaService, PRISMA_SERVICE),
     )
 
+    // Data-sync handlers are registered here (not inside CommandModule) so they
+    // can resolve PRISMA_SERVICE from this module's scope.
+    const handlers = options.dataSyncHandlers ?? DEFAULT_HANDLERS
+    providers.push(...handlers)
+
     if (options.enableController) {
       controllers.push(SurveyTemplateController, SurveyAnswerController)
     }
@@ -51,7 +56,7 @@ export class SurveyTemplateModule extends ConfigurableModuleClass {
     imports.push(
       buildDomainCommandModule(DEFAULT_SURVEY_TABLE_NAME, {
         tableName: options.tableName,
-        dataSyncHandlers: options.dataSyncHandlers ?? DEFAULT_HANDLERS,
+        dataSyncHandlers: handlers,
       }),
     )
 
@@ -83,6 +88,9 @@ export class SurveyTemplateModule extends ConfigurableModuleClass {
       buildPrismaProviderAsync(MODULE_OPTIONS_TOKEN, PRISMA_SERVICE),
     )
 
+    const handlers = options.dataSyncHandlers ?? DEFAULT_HANDLERS
+    providers.push(...handlers)
+
     if (options.enableController) {
       controllers.push(SurveyTemplateController, SurveyAnswerController)
     }
@@ -90,7 +98,7 @@ export class SurveyTemplateModule extends ConfigurableModuleClass {
     imports.push(
       buildDomainCommandModule(DEFAULT_SURVEY_TABLE_NAME, {
         tableName: options.tableName,
-        dataSyncHandlers: options.dataSyncHandlers ?? DEFAULT_HANDLERS,
+        dataSyncHandlers: handlers,
       }),
     )
 

--- a/packages/ui-setting/README.md
+++ b/packages/ui-setting/README.md
@@ -314,6 +314,29 @@ await dataSettingService.create(tenantCode, {
 
 Full documentation available at [https://mbc-cqrs-serverless.mbc-net.com/](https://mbc-cqrs-serverless.mbc-net.com/)
 
+## Configurable table name
+
+`SettingModule` stores its data on the `master` DynamoDB table by default
+(shared with `MasterModule`). Pass `tableName` to override it (backward
+compatible). Both `register` and `registerAsync` accept it:
+
+```ts
+SettingModule.register({
+  enableSettingController: true,
+  tableName: 'master', // default: 'master'
+})
+
+SettingModule.registerAsync({ tableName: 'master', inject: [] })
+```
+
+> **Shared table:** `SettingModule` and `MasterModule` share the same physical
+> table. When you use both, they **must** be registered with the **same**
+> `tableName` value, otherwise their data is silently split across two tables.
+>
+> **Provisioning:** A custom `tableName` must exist as physical tables
+> (`-command` / `-data` / `-history`). Add the raw base name to
+> `prisma/dynamodbs/cqrs.json` and define the tables in your IaC.
+
 ## License
 
 Copyright © 2024-2025, Murakami Business Consulting, Inc. [https://www.mbc-net.com/](https://www.mbc-net.com/)

--- a/packages/ui-setting/README.md
+++ b/packages/ui-setting/README.md
@@ -327,11 +327,24 @@ SettingModule.register({
 })
 
 SettingModule.registerAsync({ tableName: 'master', inject: [] })
+
+// When combined with MasterModule on the same table, let MasterModule own the
+// data-sync pipeline and defer the alias:
+SettingModule.register({
+  enableSettingController: true,
+  registerEventHandlerAlias: false,
+})
 ```
 
 > **Shared table:** `SettingModule` and `MasterModule` share the same physical
-> table. When you use both, they **must** be registered with the **same**
-> `tableName` value, otherwise their data is silently split across two tables.
+> table. When you use both:
+> 1. Register them with the **same** `tableName`, otherwise their data is split
+>    across two tables.
+> 2. Set `registerEventHandlerAlias: false` on `SettingModule` so `MasterModule`
+>    owns the `<tableName>_CommandEventHandler` alias. If both modules own the
+>    alias, the framework **fails fast at startup** with a clear error (rather
+>    than silently dropping `MasterModule`'s data-sync handlers depending on
+>    module import order).
 >
 > **Provisioning:** A custom `tableName` must exist as physical tables
 > (`-command` / `-data` / `-history`). Add the raw base name to

--- a/packages/ui-setting/README.md
+++ b/packages/ui-setting/README.md
@@ -342,9 +342,9 @@ SettingModule.register({
 >    across two tables.
 > 2. Set `registerEventHandlerAlias: false` on `SettingModule` so `MasterModule`
 >    owns the `<tableName>_CommandEventHandler` alias. If both modules own the
->    alias, the framework **fails fast at startup** with a clear error (rather
->    than silently dropping `MasterModule`'s data-sync handlers depending on
->    module import order).
+>    alias, the app still boots but logs a **warning** — which module's data-sync
+>    handlers run is then import-order dependent, so setting the flag is required
+>    for deterministic behavior.
 >
 > **Provisioning:** A custom `tableName` must exist as physical tables
 > (`-command` / `-data` / `-history`). Add the raw base name to

--- a/packages/ui-setting/src/setting.module-definition.ts
+++ b/packages/ui-setting/src/setting.module-definition.ts
@@ -14,6 +14,13 @@ export interface SettingModuleOptions {
   /** DynamoDB base table name. Default: 'master' (shared with MasterModule). */
   tableName?: string
   dataSyncHandlers?: Type<IDataSyncHandler>[]
+  /**
+   * Whether SettingModule owns the `<tableName>_CommandEventHandler` alias.
+   * Defaults to `true`. When combined with MasterModule on the same (default
+   * 'master') table, set this to `false` so MasterModule owns the alias and the
+   * duplicate-alias guard does not trip.
+   */
+  registerEventHandlerAlias?: boolean
 }
 
 export interface SettingModuleAsyncOptions
@@ -22,6 +29,7 @@ export interface SettingModuleAsyncOptions
   enableDataController?: boolean
   tableName?: string
   dataSyncHandlers?: Type<IDataSyncHandler>[]
+  registerEventHandlerAlias?: boolean
   inject?: any[]
   /** ui-setting needs no runtime-resolved options; provided for API symmetry. */
   useFactory?: (...args: any[]) => Promise<unknown> | unknown

--- a/packages/ui-setting/src/setting.module-definition.ts
+++ b/packages/ui-setting/src/setting.module-definition.ts
@@ -5,6 +5,11 @@ import { ConfigurableModuleBuilder, ModuleMetadata, Type } from '@nestjs/common'
  * ui-setting stores its data on the master table by default, so `tableName`
  * defaults to 'master'. When combined with MasterModule, both modules MUST use
  * the same `tableName` value.
+ *
+ * NOTE: this value must stay in sync with `TABLE_NAME` in
+ * `@mbc-cqrs-serverless/master` (packages/master/src/constants/index.ts). It is
+ * duplicated here to avoid a package dependency; if the master default table
+ * name ever changes, update this constant too.
  */
 export const DEFAULT_UI_SETTING_TABLE_NAME = 'master'
 

--- a/packages/ui-setting/src/setting.module-definition.ts
+++ b/packages/ui-setting/src/setting.module-definition.ts
@@ -1,7 +1,30 @@
-import { ConfigurableModuleBuilder } from '@nestjs/common'
+import { IDataSyncHandler } from '@mbc-cqrs-serverless/core'
+import { ConfigurableModuleBuilder, ModuleMetadata, Type } from '@nestjs/common'
+
+/**
+ * ui-setting stores its data on the master table by default, so `tableName`
+ * defaults to 'master'. When combined with MasterModule, both modules MUST use
+ * the same `tableName` value.
+ */
+export const DEFAULT_UI_SETTING_TABLE_NAME = 'master'
+
 export interface SettingModuleOptions {
   enableSettingController?: boolean
   enableDataController?: boolean
+  /** DynamoDB base table name. Default: 'master' (shared with MasterModule). */
+  tableName?: string
+  dataSyncHandlers?: Type<IDataSyncHandler>[]
+}
+
+export interface SettingModuleAsyncOptions
+  extends Pick<ModuleMetadata, 'imports'> {
+  enableSettingController?: boolean
+  enableDataController?: boolean
+  tableName?: string
+  dataSyncHandlers?: Type<IDataSyncHandler>[]
+  inject?: any[]
+  /** ui-setting needs no runtime-resolved options; provided for API symmetry. */
+  useFactory?: (...args: any[]) => Promise<unknown> | unknown
 }
 
 export const { ConfigurableModuleClass, MODULE_OPTIONS_TOKEN, OPTIONS_TYPE } =

--- a/packages/ui-setting/src/setting.module.spec.ts
+++ b/packages/ui-setting/src/setting.module.spec.ts
@@ -1,5 +1,6 @@
 import { CommandModule, StepFunctionService } from '@mbc-cqrs-serverless/core'
 import { MasterModule } from '@mbc-cqrs-serverless/master'
+import { TaskService } from '@mbc-cqrs-serverless/task'
 import { Global, Module } from '@nestjs/common'
 import { ConfigModule } from '@nestjs/config'
 import { Test } from '@nestjs/testing'
@@ -8,6 +9,18 @@ import { SettingModule } from './setting.module'
 import { SettingService } from './services/setting.service'
 
 class MockPrismaService {}
+
+// A distinct handler so MasterModule's CommandModule options differ from
+// SettingModule's — otherwise NestJS dedupes the two identical CommandModule
+// registrations into one and there is no alias collision to detect.
+class MasterRdsHandler {
+  async up() {
+    /* noop */
+  }
+  async down() {
+    /* noop */
+  }
+}
 
 @Global()
 @Module({
@@ -18,8 +31,12 @@ class MockPrismaService {}
       load: [() => ({ NODE_ENV: 'local', APP_NAME: 'app' })],
     }),
   ],
-  providers: [StepFunctionService],
-  exports: [StepFunctionService],
+  providers: [
+    StepFunctionService,
+    MockPrismaService,
+    { provide: TaskService, useValue: {} },
+  ],
+  exports: [StepFunctionService, MockPrismaService, TaskService],
 })
 class SupportModule {}
 
@@ -66,6 +83,42 @@ describe('SettingModule', () => {
 
       const tableNames = spy.mock.calls.map((call) => call[0].tableName)
       expect(tableNames.filter((name) => name === 'shared').length).toBe(2)
+    })
+
+    it('fails fast when both modules own the same event-handler alias', async () => {
+      // The duplicate-alias guard runs in CommandService.onModuleInit, which is
+      // triggered by init() (not compile()).
+      const testingModule = await Test.createTestingModule({
+        imports: [
+          SupportModule,
+          MasterModule.register({
+            prismaService: MockPrismaService,
+            dataSyncHandlers: [MasterRdsHandler as any],
+          }),
+          SettingModule.register({}),
+        ],
+      }).compile()
+
+      await expect(testingModule.init()).rejects.toThrow(
+        /CommandModule registrations own/,
+      )
+    })
+
+    it('compiles when SettingModule defers the alias to MasterModule', async () => {
+      const moduleRef = await Test.createTestingModule({
+        imports: [
+          SupportModule,
+          MasterModule.register({
+            prismaService: MockPrismaService,
+            dataSyncHandlers: [MasterRdsHandler as any],
+          }),
+          SettingModule.register({ registerEventHandlerAlias: false }),
+        ],
+      }).compile()
+
+      await moduleRef.init()
+      expect(moduleRef.get(SettingService)).toBeDefined()
+      await moduleRef.close()
     })
   })
 })

--- a/packages/ui-setting/src/setting.module.spec.ts
+++ b/packages/ui-setting/src/setting.module.spec.ts
@@ -120,5 +120,27 @@ describe('SettingModule', () => {
       expect(moduleRef.get(SettingService)).toBeDefined()
       await moduleRef.close()
     })
+
+    it('rejects dataSyncHandlers combined with registerEventHandlerAlias:false', () => {
+      expect(() =>
+        SettingModule.register({
+          registerEventHandlerAlias: false,
+          dataSyncHandlers: [MasterRdsHandler as any],
+        }),
+      ).toThrow(/would not run on the asynchronous/)
+    })
+
+    it('fails fast when the alias is deferred but no module owns it', async () => {
+      const testingModule = await Test.createTestingModule({
+        imports: [
+          SupportModule,
+          SettingModule.register({ registerEventHandlerAlias: false }),
+        ],
+      }).compile()
+
+      await expect(testingModule.init()).rejects.toThrow(
+        /no other CommandModule owns/,
+      )
+    })
   })
 })

--- a/packages/ui-setting/src/setting.module.spec.ts
+++ b/packages/ui-setting/src/setting.module.spec.ts
@@ -1,0 +1,71 @@
+import { CommandModule, StepFunctionService } from '@mbc-cqrs-serverless/core'
+import { MasterModule } from '@mbc-cqrs-serverless/master'
+import { Global, Module } from '@nestjs/common'
+import { ConfigModule } from '@nestjs/config'
+import { Test } from '@nestjs/testing'
+
+import { SettingModule } from './setting.module'
+import { SettingService } from './services/setting.service'
+
+class MockPrismaService {}
+
+@Global()
+@Module({
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      ignoreEnvFile: true,
+      load: [() => ({ NODE_ENV: 'local', APP_NAME: 'app' })],
+    }),
+  ],
+  providers: [StepFunctionService],
+  exports: [StepFunctionService],
+})
+class SupportModule {}
+
+describe('SettingModule', () => {
+  afterEach(() => jest.restoreAllMocks())
+
+  describe('register (sync)', () => {
+    it('forwards the default table name (master) to CommandModule', () => {
+      const spy = jest.spyOn(CommandModule, 'register')
+      SettingModule.register({})
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ tableName: 'master' }),
+      )
+    })
+
+    it('forwards a custom table name to CommandModule', () => {
+      const spy = jest.spyOn(CommandModule, 'register')
+      SettingModule.register({ tableName: 'ui-config' })
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ tableName: 'ui-config' }),
+      )
+    })
+  })
+
+  describe('registerAsync', () => {
+    it('compiles and resolves the public service', async () => {
+      const moduleRef = await Test.createTestingModule({
+        imports: [SupportModule, SettingModule.registerAsync({ inject: [] })],
+      }).compile()
+
+      expect(moduleRef.get(SettingService)).toBeDefined()
+      await moduleRef.close()
+    })
+  })
+
+  describe('shared table with MasterModule', () => {
+    it('registers CommandModule with the same table name for both modules', () => {
+      const spy = jest.spyOn(CommandModule, 'register')
+      MasterModule.register({
+        prismaService: MockPrismaService,
+        tableName: 'shared',
+      })
+      SettingModule.register({ tableName: 'shared' })
+
+      const tableNames = spy.mock.calls.map((call) => call[0].tableName)
+      expect(tableNames.filter((name) => name === 'shared').length).toBe(2)
+    })
+  })
+})

--- a/packages/ui-setting/src/setting.module.spec.ts
+++ b/packages/ui-setting/src/setting.module.spec.ts
@@ -1,7 +1,7 @@
 import { CommandModule, StepFunctionService } from '@mbc-cqrs-serverless/core'
 import { MasterModule } from '@mbc-cqrs-serverless/master'
 import { TaskService } from '@mbc-cqrs-serverless/task'
-import { Global, Module } from '@nestjs/common'
+import { Global, Logger, Module } from '@nestjs/common'
 import { ConfigModule } from '@nestjs/config'
 import { Test } from '@nestjs/testing'
 
@@ -85,9 +85,11 @@ describe('SettingModule', () => {
       expect(tableNames.filter((name) => name === 'shared').length).toBe(2)
     })
 
-    it('fails fast when both modules own the same event-handler alias', async () => {
-      // The duplicate-alias guard runs in CommandService.onModuleInit, which is
-      // triggered by init() (not compile()).
+    it('warns but still boots when both modules own the same alias (backward compatible)', async () => {
+      // The duplicate-alias guard warns (does not throw) so existing
+      // MasterModule + SettingModule deployments keep booting. It runs in
+      // CommandService.onModuleInit, triggered by init() (not compile()).
+      const warnSpy = jest.spyOn(Logger.prototype, 'warn')
       const testingModule = await Test.createTestingModule({
         imports: [
           SupportModule,
@@ -99,9 +101,11 @@ describe('SettingModule', () => {
         ],
       }).compile()
 
-      await expect(testingModule.init()).rejects.toThrow(
-        /CommandModule registrations own/,
+      await expect(testingModule.init()).resolves.toBeDefined()
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/CommandModule registrations own/),
       )
+      await testingModule.close()
     })
 
     it('compiles when SettingModule defers the alias to MasterModule', async () => {

--- a/packages/ui-setting/src/setting.module.ts
+++ b/packages/ui-setting/src/setting.module.ts
@@ -1,5 +1,5 @@
 import {
-  CommandModule,
+  buildDomainCommandModule,
   DataStoreModule,
   QueueModule,
 } from '@mbc-cqrs-serverless/core'
@@ -11,39 +11,70 @@ import { DataSettingService } from './services/data-setting.service'
 import { SettingService } from './services/setting.service'
 import {
   ConfigurableModuleClass,
+  DEFAULT_UI_SETTING_TABLE_NAME,
   OPTIONS_TYPE,
+  SettingModuleAsyncOptions,
 } from './setting.module-definition'
+
 @Module({
-  imports: [
-    CommandModule.register({
-      tableName: 'master',
-    }),
-    DataStoreModule,
-    QueueModule,
-  ],
+  imports: [DataStoreModule, QueueModule],
   providers: [SettingService, DataSettingService],
   exports: [SettingService, DataSettingService],
 })
 export class SettingModule extends ConfigurableModuleClass {
   static register(options: typeof OPTIONS_TYPE): DynamicModule {
-    const module = super.register(options)
+    const base = super.register(options)
+    const controllers = [...(base.controllers ?? [])]
+    const imports = [...(base.imports ?? [])]
 
-    const { enableDataController, enableSettingController } = options
-
-    if (enableDataController || enableSettingController) {
-      if (!module.controllers) {
-        module.controllers = []
-      }
-      if (enableDataController) {
-        module.controllers.push(DataSettingController)
-      }
-      if (enableSettingController) {
-        module.controllers.push(SettingController)
-      }
+    if (options.enableDataController) {
+      controllers.push(DataSettingController)
+    }
+    if (options.enableSettingController) {
+      controllers.push(SettingController)
     }
 
-    return {
-      ...module,
+    imports.push(
+      buildDomainCommandModule(DEFAULT_UI_SETTING_TABLE_NAME, {
+        tableName: options.tableName,
+        dataSyncHandlers: options.dataSyncHandlers,
+      }),
+    )
+
+    return { ...base, controllers, imports }
+  }
+
+  static registerAsync(options: SettingModuleAsyncOptions): DynamicModule {
+    const base = super.registerAsync({
+      imports: options.imports,
+      inject: options.inject ?? [],
+      useFactory: async (...args: any[]) => {
+        await options.useFactory?.(...args)
+        return {
+          enableDataController: options.enableDataController,
+          enableSettingController: options.enableSettingController,
+          tableName: options.tableName ?? DEFAULT_UI_SETTING_TABLE_NAME,
+          dataSyncHandlers: options.dataSyncHandlers,
+        }
+      },
+    })
+    const controllers = [...(base.controllers ?? [])]
+    const imports = [...(base.imports ?? [])]
+
+    if (options.enableDataController) {
+      controllers.push(DataSettingController)
     }
+    if (options.enableSettingController) {
+      controllers.push(SettingController)
+    }
+
+    imports.push(
+      buildDomainCommandModule(DEFAULT_UI_SETTING_TABLE_NAME, {
+        tableName: options.tableName,
+        dataSyncHandlers: options.dataSyncHandlers,
+      }),
+    )
+
+    return { ...base, controllers, imports }
   }
 }

--- a/packages/ui-setting/src/setting.module.ts
+++ b/packages/ui-setting/src/setting.module.ts
@@ -27,6 +27,10 @@ export class SettingModule extends ConfigurableModuleClass {
     const controllers = [...(base.controllers ?? [])]
     const imports = [...(base.imports ?? [])]
 
+    const providers = [...(base.providers ?? [])]
+    const handlers = options.dataSyncHandlers ?? []
+    providers.push(...handlers)
+
     if (options.enableDataController) {
       controllers.push(DataSettingController)
     }
@@ -37,11 +41,12 @@ export class SettingModule extends ConfigurableModuleClass {
     imports.push(
       buildDomainCommandModule(DEFAULT_UI_SETTING_TABLE_NAME, {
         tableName: options.tableName,
-        dataSyncHandlers: options.dataSyncHandlers,
+        dataSyncHandlers: handlers,
+        registerEventHandlerAlias: options.registerEventHandlerAlias,
       }),
     )
 
-    return { ...base, controllers, imports }
+    return { ...base, providers, controllers, imports }
   }
 
   static registerAsync(options: SettingModuleAsyncOptions): DynamicModule {
@@ -60,6 +65,9 @@ export class SettingModule extends ConfigurableModuleClass {
     })
     const controllers = [...(base.controllers ?? [])]
     const imports = [...(base.imports ?? [])]
+    const providers = [...(base.providers ?? [])]
+    const handlers = options.dataSyncHandlers ?? []
+    providers.push(...handlers)
 
     if (options.enableDataController) {
       controllers.push(DataSettingController)
@@ -71,10 +79,11 @@ export class SettingModule extends ConfigurableModuleClass {
     imports.push(
       buildDomainCommandModule(DEFAULT_UI_SETTING_TABLE_NAME, {
         tableName: options.tableName,
-        dataSyncHandlers: options.dataSyncHandlers,
+        dataSyncHandlers: handlers,
+        registerEventHandlerAlias: options.registerEventHandlerAlias,
       }),
     )
 
-    return { ...base, controllers, imports }
+    return { ...base, providers, controllers, imports }
   }
 }


### PR DESCRIPTION
## Overview

v1.4.0 release (`develop` → `main`). Makes the **DynamoDB table names configurable** for the four domain packages (`master` / `directory` / `survey-template` / `ui-setting`) via backward-compatible options, and adds `registerAsync` to all four modules. **Defaults are unchanged** (`master` / `directory` / `survey` / `master`), so existing apps upgrade with no code changes.

## Features

- **core, master, directory, survey-template, ui-setting:** Make the DynamoDB table names of the domain modules configurable via a backward-compatible `tableName?` option, and add `registerAsync` support to all four modules (#493)
  - **directory:** `DirectoryStorageModule` additionally accepts `pkPrefix?` (default `DIRECTORY`) and `prismaModelName?` (default `directory`). The `directory` → `document` rename (#469) is now expressed as opt-in configuration (`tableName: 'document'`, `pkPrefix: 'DOCUMENT'`, `prismaModelName: 'document'`) rather than a forced default
- **mcp-server:** Add the v1.3.5 → v1.4.0 migration guide to the `mbc-migrate` skill (configurable table names, how to change a table name, and the central master-table caveat) (#494)

## Changes (behavior) — upgrade notes

- **master, directory, survey-template:** `prismaService` is now **always required** at registration (previously validated only when `enableController: true`). A missing value now fails fast at startup with a clear message instead of a cryptic dependency-resolution error. Pass `prismaService` explicitly if you registered with `enableController: false` and relied on a globally-provided token (#493)
- **master, ui-setting:** When `MasterModule` and `SettingModule` share the default `master` table, the framework logs a startup warning if both own the `master_CommandEventHandler` alias (data-sync ownership becomes import-order dependent). Set `registerEventHandlerAlias: false` on `SettingModule` so `MasterModule` owns the alias (#493)
- **master:** `MasterModule` logs a warning if its `tableName` is overridden — the `master` table is a framework-wide config store read at a fixed `master-data` name by `TtlService` and the sequence package, so renaming it is not fully supported (#493)
- **core:** `CommandModule.registerAsync()` now throws a clear error (it cannot build the `<tableName>_CommandEventHandler` alias asynchronously); compose CommandModule via `register()` or a domain module (#493)

## How to change a table name

For the full procedure (`register` / `registerAsync` examples, adding the raw base name to `prisma/dynamodbs/cqrs.json` and running `migrate:ddb`, adding the Prisma model and running `migrate:rds`, data migration, and the master-table caveat), see each package README, the `mbc-migrate` skill, and the "Configurable table name" section of `docs/directory.md` on the docs site.

## Included PRs

- #493 Configurable table names + `registerAsync` root fix
- #469 `directory` → `document` rename (made opt-in by #493)
- #494 mbc-migrate migration guide

## Verification

- CI: Unit Test (Node 18/20/22/24), CodeQL, Trivy
- core: all jest suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
