### PR TITLE
docs(changelog): v1.4.0 entry + release-review fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.4.0](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.4.0) (2026-08-02)
+
+### Features
+
+- **core, master, directory, survey-template, ui-setting:** Make the DynamoDB table names of the domain modules configurable via a backward-compatible `tableName?` option, and add `registerAsync` support to all four modules. Defaults are unchanged (`master` / `directory` / `survey` / `master`), so existing apps upgrade with no code changes ([#493](https://github.com/mbc-net/mbc-cqrs-serverless/pull/493))
+  - **directory:** `DirectoryStorageModule` additionally accepts `pkPrefix?` (default `DIRECTORY`) and `prismaModelName?` (default `directory`). The `directory` → `document` rename ([#469](https://github.com/mbc-net/mbc-cqrs-serverless/pull/469)) is now expressed as opt-in configuration (`tableName: 'document'`, `pkPrefix: 'DOCUMENT'`, `prismaModelName: 'document'`) rather than a forced default
+- **mcp-server:** Add the v1.3.5 → v1.4.0 migration guide to the `mbc-migrate` skill (configurable table names, how to change a table name, and the central master-table caveat) ([#494](https://github.com/mbc-net/mbc-cqrs-serverless/pull/494))
+
+### Changes (behavior)
+
+- **master, directory, survey-template:** `prismaService` is now always required at registration (previously validated only when `enableController: true`). A missing value now fails fast at startup with a clear message instead of a cryptic dependency-resolution error. Pass `prismaService` explicitly if you registered with `enableController: false` and relied on a globally-provided token ([#493](https://github.com/mbc-net/mbc-cqrs-serverless/pull/493))
+- **master, ui-setting:** When `MasterModule` and `SettingModule` share the default `master` table, the framework logs a startup warning if both own the `master_CommandEventHandler` alias (data-sync ownership becomes import-order dependent). Set `registerEventHandlerAlias: false` on `SettingModule` so `MasterModule` owns the alias ([#493](https://github.com/mbc-net/mbc-cqrs-serverless/pull/493))
+- **master:** `MasterModule` logs a warning if its `tableName` is overridden — the `master` table is a framework-wide config store read at a fixed `master-data` name by `TtlService` and the sequence package, so renaming it is not fully supported ([#493](https://github.com/mbc-net/mbc-cqrs-serverless/pull/493))
+- **core:** `CommandModule.registerAsync()` now throws a clear error (it cannot build the `<tableName>_CommandEventHandler` alias asynchronously); compose CommandModule via `register()` or a domain module ([#493](https://github.com/mbc-net/mbc-cqrs-serverless/pull/493))
+
 ## [1.3.5](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.3.5) (2026-08-01)
 
 ### Bug Fixes

--- a/packages/core/src/integration/cross-package-integration.spec.ts
+++ b/packages/core/src/integration/cross-package-integration.spec.ts
@@ -110,18 +110,18 @@ describe('Cross-Package Integration', () => {
     })
 
     describe('Directory package key patterns', () => {
-      const DIRECTORY_PREFIX = 'DOCUMENT'
+      const DIRECTORY_PREFIX = 'DIRECTORY'
 
       it('should generate directory PK with tenant code', () => {
         const pk = generatePk(DIRECTORY_PREFIX, 'COMPANY_X')
-        expect(pk).toBe('DOCUMENT#COMPANY_X')
+        expect(pk).toBe('DIRECTORY#COMPANY_X')
       })
 
       it('should generate complete ID from PK and SK', () => {
         const pk = generatePk(DIRECTORY_PREFIX, 'COMPANY_X')
         const sk = 'folder-ulid-123'
         const id = generateId(pk, sk)
-        expect(id).toBe('DOCUMENT#COMPANY_X#folder-ulid-123')
+        expect(id).toBe('DIRECTORY#COMPANY_X#folder-ulid-123')
       })
     })
   })
@@ -162,7 +162,7 @@ describe('Cross-Package Integration', () => {
      */
     function extractTenantFromPk(pk: string): string | null {
       const match = pk.match(
-        /^(TENANT|SETTING|MASTER|SEQUENCE|TASK|DOCUMENT)#([^#]+)/,
+        /^(TENANT|SETTING|MASTER|SEQUENCE|TASK|DIRECTORY)#([^#]+)/,
       )
       return match ? match[2] : null
     }
@@ -219,8 +219,8 @@ describe('Cross-Package Integration', () => {
         expect(extractTenantFromPk('TASK#CLIENT_1')).toBe('CLIENT_1')
       })
 
-      it('should extract tenant from DOCUMENT PK', () => {
-        expect(extractTenantFromPk('DOCUMENT#CORP_ABC')).toBe('CORP_ABC')
+      it('should extract tenant from DIRECTORY PK', () => {
+        expect(extractTenantFromPk('DIRECTORY#CORP_ABC')).toBe('CORP_ABC')
       })
 
       it('should return null for invalid PK', () => {
@@ -326,9 +326,9 @@ describe('Cross-Package Integration', () => {
       })
 
       it('should support VERSION_FIRST constant', () => {
-        const baseSk = 'DOCUMENT#DOC001'
+        const baseSk = 'DIRECTORY#DOC001'
         const historySk = generateHistorySk(baseSk, VERSION_FIRST)
-        expect(historySk).toBe('DOCUMENT#DOC001@0')
+        expect(historySk).toBe('DIRECTORY#DOC001@0')
       })
     })
 
@@ -545,7 +545,7 @@ describe('Cross-Package Integration', () => {
         data: Partial<DirectoryItem>,
       ): DirectoryItem {
         return {
-          pk: `DOCUMENT${KEY_SEPARATOR}${tenantCode}`,
+          pk: `DIRECTORY${KEY_SEPARATOR}${tenantCode}`,
           sk: itemId,
           tenantCode,
           name: data.name || 'Untitled',
@@ -561,7 +561,7 @@ describe('Cross-Package Integration', () => {
           type: 'folder',
         })
 
-        expect(folder.pk).toBe('DOCUMENT#ORG_123')
+        expect(folder.pk).toBe('DIRECTORY#ORG_123')
         expect(folder.sk).toBe('ulid-folder-001')
         expect(folder.tenantCode).toBe('ORG_123')
       })

--- a/packages/directory/README.md
+++ b/packages/directory/README.md
@@ -59,6 +59,8 @@ DirectoryStorageModule.register({
 // even when Prisma is provided via forRootAsync).
 DirectoryStorageModule.registerAsync({
   tableName: 'document',
+  pkPrefix: 'DOCUMENT',
+  prismaModelName: 'document',
   imports: [PrismaModule],
   inject: [PrismaService],
   useFactory: (prisma) => ({ prismaService: prisma }),


### PR DESCRIPTION
Fixes from the review of the v1.4.0 release PR #495 (develop→main).

- **CHANGELOG.md**: add the `## [1.4.0]` section — the release PR was missing it (only the v1.3.5 date was touched). Covers configurable table names + `registerAsync` (#493), the `directory`→`document` opt-in (#469), `prismaService` now always required, the MasterModule+SettingModule shared-table alias warning, the master rename caveat, and the `CommandModule.registerAsync` throw, plus the mbc-migrate guide (#494).
- **packages/directory/README.md**: the `registerAsync` example now sets `pkPrefix`/`prismaModelName` alongside `tableName` (all three must be set together, per the README's own note).
- **cross-package-integration.spec.ts**: revert the leftover `DIRECTORY_PREFIX = 'DOCUMENT'` (and related DOCUMENT# assertions) back to `DIRECTORY` — directory's default is `DIRECTORY#`; `document` is opt-in. Folder/file data names (`Documents`, `document.pdf`) are unchanged.

Merge into develop before releasing v1.4.0 so PR #495 (develop→main) carries the changelog.

Verification: core jest 93 suites / 2345 tests pass; cross-package-integration.spec 49 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)