### PR TITLE
feat(infra): swap LocalStack for Floci as the local S3 emulator

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -100,7 +100,7 @@ npm run lint                # ESLint check
 npm run format              # Prettier format
 
 # Local Development
-npm run start:localstack    # Start LocalStack services
+npm run offline:docker      # Start local AWS services
 npm run offline             # Start serverless offline
 
 # Database
@@ -110,7 +110,7 @@ npm run ddb:create          # Create DynamoDB tables
 ## Testing Guidelines
 
 - Unit tests: Use Jest with aws-sdk-client-mock for AWS service mocking
-- E2E tests: Use LocalStack for AWS service emulation
+- E2E tests: Use Floci and other local emulators for AWS service emulation
 - Always write tests for new features
 - Maintain test coverage for critical paths
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,7 @@ module.exports = {
     '.eslintrc.js',
     'prisma',
     '**/*.spec.ts',
+    '**/*.smoke-spec.ts',
     '**/*.test.ts',
     'examples/**',
     // Scaffolding templates are excluded from tsconfig and reference

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,7 +200,7 @@ npm run test                # Run unit tests
 npm run test:e2e            # Run E2E tests
 npm run lint                # ESLint check
 npm run format              # Prettier format
-npm run start:localstack    # Start local AWS services
+npm run offline:docker      # Start local AWS services
 npm run offline             # Start serverless offline
 
 # Database

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Harden npm dependencies — resolve high/moderate vulnerabilities via `overrides` (`lodash`, `tmp`, `multer`, `ajv`, `picomatch`, `fast-xml-parser`) and targeted upgrades (`@nestjs/config` ^4.0.4, `@typescript-eslint` v8); root production audit: 0 critical/high ([#445](https://github.com/mbc-net/mbc-cqrs-serverless/pull/445)–[#453](https://github.com/mbc-net/mbc-cqrs-serverless/pull/453))
 - **cli:** Upgrade `multer` to v2.2.0 in scaffolded templates to fix CVE-2026-5079 (DoS via deeply nested multipart field names) ([#463](https://github.com/mbc-net/mbc-cqrs-serverless/pull/463))
 - Add blocking CI gates: `npm audit --omit=dev --audit-level=high` and ESLint startup check run on every PR, failing the build on any production vulnerability ([#448](https://github.com/mbc-net/mbc-cqrs-serverless/pull/448))
+### Breaking Changes
+
+- **infra:** Replace LocalStack with Floci as the local S3 emulator
+
+  LocalStack Community Edition reached end of life in March 2026 — it now requires an auth
+  token and no longer receives security updates. The template pinned no version, so
+  scaffolded projects silently drifted onto an unmaintained image.
+
+  Floci serves S3 on the same port (4566) with the same path-style addressing, so no
+  application code or `.env` value changes. `S3_ENDPOINT`, `LOCAL_S3_PORT`, `S3_REGION`,
+  and `S3_BUCKET_NAME` are unaffected.
+
+  - **Migration:** In `infra-local/docker-compose.yml`, replace the `localstack` service with:
+
+    ```yaml
+      floci:
+        image: floci/floci:1.6.0
+        ports:
+          - '${LOCAL_S3_PORT:-4566}:4566'
+        environment:
+          - FLOCI_DEFAULT_REGION=ap-northeast-1
+          - FLOCI_STORAGE_MODE=persistent
+          - FLOCI_STORAGE_PERSISTENT_PATH=/data
+        volumes:
+          - ./docker-data/floci:/data
+    ```
+
+    Then remove `serverless-localstack` from `package.json` if present.
+
+  - **Data loss warning:** `FLOCI_STORAGE_MODE` defaults to `memory`. Omitting that line
+    discards all buckets on every `docker compose down`, with no error reported. Existing
+    objects under `docker-data/localstack` are not migrated — recreate buckets with
+    `infra-local/scripts/resources.sh`.
+
+  - Existing projects are not required to migrate immediately; the old stack still runs.
+    It runs on an image that no longer receives security patches.
 
 ## [1.3.1](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.3.1) (2026-06-02)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Please be respectful and constructive in all interactions. We welcome contributo
 - Node.js 18 or higher
 - npm 9 or higher
 - Git
-- Docker (for LocalStack)
+- Docker (for Floci and the other local emulators)
 
 ### Development Setup
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -12,7 +12,7 @@ MBC CQRS Serverless is a TypeScript framework for building serverless applicatio
 - **Event Sourcing**: Complete audit trail of all changes
 - **Multi-tenancy**: Built-in tenant isolation
 - **AWS Integration**: Ready-to-use integrations with AWS services
-- **Local Development**: Full local development support with LocalStack
+- **Local Development**: Full local development support with Floci
 
 ### What AWS services does this framework integrate with?
 
@@ -44,7 +44,7 @@ Node.js 18 or higher is required.
 ### How do I set up local development?
 
 1. Copy environment template: `cp .env.example .env`
-2. Start LocalStack: `npm run start:localstack`
+2. Start the local stack: `npm run offline:docker`
 3. Create tables: `npm run ddb:create`
 4. Start server: `npm run offline`
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -10,7 +10,7 @@ This guide covers common issues and their solutions when working with MBC CQRS S
 
 **Solutions**:
 1. Ensure Docker is running
-2. Check if ports are available (4566, 4571, etc.)
+2. Check if port 4566 is available
 3. Remove old containers: `docker rm -f floci`
 4. Restart Floci: `npm run offline:docker`
 
@@ -19,9 +19,9 @@ This guide covers common issues and their solutions when working with MBC CQRS S
 **Symptom**: "Table not found" errors when running locally.
 
 **Solutions**:
-1. Ensure Floci is running
+1. Ensure DynamoDB Local is running (`npm run offline:docker`)
 2. Run table creation: `npm run ddb:create`
-3. Verify tables exist: `aws --endpoint-url=http://localhost:4566 dynamodb list-tables`
+3. Verify tables exist: `aws --endpoint-url=http://localhost:8000 dynamodb list-tables`
 
 ### Cognito Authentication Fails Locally
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -4,22 +4,22 @@ This guide covers common issues and their solutions when working with MBC CQRS S
 
 ## Local Development
 
-### LocalStack Not Starting
+### Floci Not Starting
 
-**Symptom**: LocalStack container fails to start or services are unavailable.
+**Symptom**: Floci container fails to start or services are unavailable.
 
 **Solutions**:
 1. Ensure Docker is running
 2. Check if ports are available (4566, 4571, etc.)
-3. Remove old containers: `docker rm -f localstack`
-4. Restart LocalStack: `npm run start:localstack`
+3. Remove old containers: `docker rm -f floci`
+4. Restart Floci: `npm run offline:docker`
 
 ### DynamoDB Tables Not Created
 
 **Symptom**: "Table not found" errors when running locally.
 
 **Solutions**:
-1. Ensure LocalStack is running
+1. Ensure Floci is running
 2. Run table creation: `npm run ddb:create`
 3. Verify tables exist: `aws --endpoint-url=http://localhost:4566 dynamodb list-tables`
 
@@ -130,7 +130,7 @@ beforeEach(() => {
 **Symptom**: E2E tests fail with connection errors.
 
 **Solutions**:
-1. Start LocalStack before running tests
+1. Start the local stack before running tests: `npm run offline:docker`
 2. Ensure test database is clean
 3. Check test configuration in `jest.config.js`
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -215,7 +215,7 @@ npm run lint
 npm run format
 
 # Local Development
-npm run start:localstack
+npm run offline:docker
 npm run offline
 
 # Database

--- a/llms.txt
+++ b/llms.txt
@@ -43,7 +43,7 @@ cd PROJECT_NAME
 # Start local development
 npm install
 npm run build
-npm run start:localstack
+npm run offline:docker
 npm run offline
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10552,6 +10552,18 @@
         "node": ">= 8"
       }
     },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "devOptional": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/anynum": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
@@ -14744,12 +14756,6 @@
         "es5-ext": "^0.10.35",
         "es6-symbol": "^3.1.1"
       }
-    },
-    "node_modules/es6-promisify": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.1.1.tgz",
-      "integrity": "sha512-HBL8I3mIki5C1Cc9QjKUenHtnG0A5/xA8Q/AllRcfiwl2CZFXGK7ddBiCoRwAix4i2KxcQfjtIVcrVbB3vbmwg==",
-      "dev": true
     },
     "node_modules/es6-set": {
       "version": "0.1.6",
@@ -25260,6 +25266,18 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/readdirp/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "devOptional": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -26050,17 +26068,6 @@
         "@aws-sdk/client-dynamodb": "^3.474.0",
         "@aws-sdk/lib-dynamodb": "^3.474.0",
         "aws-dynamodb-local": "^0.0.14"
-      }
-    },
-    "node_modules/serverless-localstack": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/serverless-localstack/-/serverless-localstack-1.3.1.tgz",
-      "integrity": "sha512-dBwKCo6mhJuQuIWnYAacfbyZhBnl0N8UgXLkZ3NpOFvEa2PAnwBzoRL5xpZGoPze+aPPOKrMhiSmSGspalJgEQ==",
-      "dev": true,
-      "dependencies": {
-        "adm-zip": "^0.5.10",
-        "aws-sdk": "^2.402.0",
-        "es6-promisify": "^6.0.1"
       }
     },
     "node_modules/serverless-offline": {
@@ -30736,7 +30743,6 @@
         "@types/nodemailer": "^6.4.17",
         "serverless": "^3.40.0",
         "serverless-dynamodb": "^0.2.58",
-        "serverless-localstack": "^1.1.2",
         "serverless-offline": "^13.3.2",
         "serverless-offline-aws-eventbridge": "^2.1.0",
         "serverless-offline-dynamodb-streams": "^7.0.0",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -268,7 +268,7 @@ cp .env.example .env
 ### 3. Start Local Infrastructure
 
 ```bash
-# Start Docker services (DynamoDB Local, LocalStack, etc.)
+# Start Docker services (DynamoDB Local, Floci, etc.)
 npm run offline:docker
 ```
 

--- a/packages/cli/templates/README.md
+++ b/packages/cli/templates/README.md
@@ -17,7 +17,7 @@ TechStack:
   - DynamoDB
 
 - RDS - PostgreSQL
-- Serverless fw && Localstack for local development
+- Serverless fw && Floci for local development
 
 ## Prepare
 
@@ -147,8 +147,7 @@ $ aws stepfunctions --endpoint-url http://localhost:8083 start-execution --state
 - sns: http://localhost:4002
 - sqs: http://localhost:9324
 - sqs admin: http://localhost:9325
-- localstack: http://localhost:4566
-  - S3
+- floci (S3): http://localhost:4566
 - appsync: http://localhost:4001
 - cognito: http://localhost:9229
 - eventbridge: http://localhost:4010

--- a/packages/cli/templates/infra-local/docker-compose.yml
+++ b/packages/cli/templates/infra-local/docker-compose.yml
@@ -56,19 +56,16 @@ services:
       - ./elasticmq.conf:/opt/elasticmq.conf
       - ./docker-data/elasticmq:/data
 
-  localstack:
-    image: localstack/localstack
+  floci:
+    image: floci/floci:1.6.0
     ports:
       - '${LOCAL_S3_PORT:-4566}:4566'
     environment:
-      - SERVICES=s3
-      - AWS_DEFAULT_REGION=ap-northeast-1
-      - SERVICE_ACCESS_KEY=local
-      - SERVICE_SECRET_KEY=local
-      - EXTRA_CORS_ALLOWED_ORIGINS=*
+      - FLOCI_DEFAULT_REGION=ap-northeast-1
+      - FLOCI_STORAGE_MODE=persistent
+      - FLOCI_STORAGE_PERSISTENT_PATH=/data
     volumes:
-      - ./docker-data/localstack:/var/lib/localstack
-      - ./docker-data/run/docker.sock:/var/run/docker.sock
+      - ./docker-data/floci:/data
 
   appsync:
     build:

--- a/packages/cli/templates/infra-local/scripts/resources.ps1
+++ b/packages/cli/templates/infra-local/scripts/resources.ps1
@@ -24,5 +24,36 @@ if (-not $bucketExists) {
     Write-Host "Bucket $env:S3_BUCKET_NAME already exists."
 }
 
+# Presigned upload/view URLs (see DirectoryFileService) are fetched by the
+# browser, so the bucket needs a CORS rule or the preflight fails with 403 and
+# the real request is never sent. The previous LocalStack service granted this
+# implicitly through EXTRA_CORS_ALLOWED_ORIGINS=*; Floci has no such switch.
+# Production configures CORS in the CDK stack - this is the local equivalent.
+# Applied unconditionally so buckets created before this script gained the rule
+# are brought up to date too.
+Write-Host "======= configure S3 bucket CORS ======="
+$corsConfiguration = @'
+{
+  "CORSRules": [
+    {
+      "AllowedOrigins": ["*"],
+      "AllowedMethods": ["GET", "PUT", "POST", "DELETE", "HEAD"],
+      "AllowedHeaders": ["*"],
+      "ExposeHeaders": ["ETag"]
+    }
+  ]
+}
+'@
+
+# Passed as file:// rather than inline: PowerShell mangles embedded quotes on
+# the way to the AWS CLI.
+$corsFile = Join-Path ([System.IO.Path]::GetTempPath()) "mbc-s3-cors.json"
+Set-Content -Path $corsFile -Value $corsConfiguration -Encoding utf8
+try {
+    aws --endpoint-url=http://localhost:$s3Port s3api put-bucket-cors --bucket $env:S3_BUCKET_NAME --cors-configuration "file://$corsFile"
+} finally {
+    Remove-Item $corsFile -ErrorAction SilentlyContinue
+}
+
 Write-Host "======= list S3 buckets ======="
 aws --endpoint-url=http://localhost:$s3Port s3 ls

--- a/packages/cli/templates/infra-local/scripts/resources.sh
+++ b/packages/cli/templates/infra-local/scripts/resources.sh
@@ -19,5 +19,26 @@ else
   echo "Bucket $S3_BUCKET_NAME already exists."
 fi
 
+# Presigned upload/view URLs (see DirectoryFileService) are fetched by the
+# browser, so the bucket needs a CORS rule or the preflight fails with 403 and
+# the real request is never sent. The previous LocalStack service granted this
+# implicitly through EXTRA_CORS_ALLOWED_ORIGINS=*; Floci has no such switch.
+# Production configures CORS in the CDK stack — this is the local equivalent.
+# Applied unconditionally so buckets created before this script gained the rule
+# are brought up to date too.
+echo "======= configure S3 bucket CORS ======="
+aws --endpoint-url=${S3_ENDPOINT_URL} s3api put-bucket-cors \
+  --bucket $S3_BUCKET_NAME \
+  --cors-configuration '{
+    "CORSRules": [
+      {
+        "AllowedOrigins": ["*"],
+        "AllowedMethods": ["GET", "PUT", "POST", "DELETE", "HEAD"],
+        "AllowedHeaders": ["*"],
+        "ExposeHeaders": ["ETag"]
+      }
+    ]
+  }'
+
 echo "======= list S3 buckets ======="
 aws --endpoint-url=${S3_ENDPOINT_URL} s3 ls

--- a/packages/cli/templates/infra-local/serverless.yml
+++ b/packages/cli/templates/infra-local/serverless.yml
@@ -119,8 +119,6 @@ custom:
     retryDelayMs: 500 # retry delay
     throwRetryExhausted: false # default true
     payloadSizeLimit: '10mb' # Controls the maximum payload size being passed to https://www.npmjs.com/package/bytes (Note: this payload size might not be the same size as your AWS Eventbridge receive)
-    # localStackConfig:
-    #   localStackEndpoint: http://localhost:4566
 
 provider:
   name: aws

--- a/packages/cli/templates/package-lock.json
+++ b/packages/cli/templates/package-lock.json
@@ -46,7 +46,6 @@
         "run-script-os": "^1.1.6",
         "serverless": "^3.40.0",
         "serverless-dynamodb": "^0.2.47",
-        "serverless-localstack": "^1.1.2",
         "serverless-offline": "^13.3.2",
         "serverless-offline-aws-eventbridge": "^2.1.0",
         "serverless-offline-dynamodb-streams": "^7.0.0",
@@ -265,6 +264,23 @@
         }
       }
     },
+    "node_modules/@angular-devkit/schematics-cli/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@angular-devkit/schematics-cli/node_modules/jsonc-parser": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
@@ -280,6 +296,21 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/@angular-devkit/schematics-cli/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -14535,6 +14566,18 @@
         "node": ">= 8"
       }
     },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/anynum": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
@@ -17969,12 +18012,6 @@
         "es5-ext": "^0.10.35",
         "es6-symbol": "^3.1.1"
       }
-    },
-    "node_modules/es6-promisify": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.1.1.tgz",
-      "integrity": "sha512-HBL8I3mIki5C1Cc9QjKUenHtnG0A5/xA8Q/AllRcfiwl2CZFXGK7ddBiCoRwAix4i2KxcQfjtIVcrVbB3vbmwg==",
-      "dev": true
     },
     "node_modules/es6-set": {
       "version": "0.1.6",
@@ -25129,6 +25166,18 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/readdirp/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -25828,17 +25877,6 @@
         "@aws-sdk/client-dynamodb": "^3.474.0",
         "@aws-sdk/lib-dynamodb": "^3.474.0",
         "aws-dynamodb-local": "^0.0.14"
-      }
-    },
-    "node_modules/serverless-localstack": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/serverless-localstack/-/serverless-localstack-1.2.1.tgz",
-      "integrity": "sha512-obvJHpRo1qRV05OdP7NXXDb6/o1g+oWwAP5GFbnBKpo5+46t15gDJ80LHKnIklT8kR45mNSEbVO6Iw+ctUYhRA==",
-      "dev": true,
-      "dependencies": {
-        "adm-zip": "^0.5.10",
-        "aws-sdk": "^2.402.0",
-        "es6-promisify": "^6.0.1"
       }
     },
     "node_modules/serverless-offline": {

--- a/packages/cli/templates/package.json
+++ b/packages/cli/templates/package.json
@@ -77,7 +77,6 @@
     "run-script-os": "^1.1.6",
     "serverless": "^3.40.0",
     "serverless-dynamodb": "^0.2.47",
-    "serverless-localstack": "^1.1.2",
     "serverless-offline": "^13.3.2",
     "serverless-offline-aws-eventbridge": "^2.1.0",
     "serverless-offline-dynamodb-streams": "^7.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -71,7 +71,6 @@
     "@types/nodemailer": "^6.4.17",
     "serverless": "^3.40.0",
     "serverless-dynamodb": "^0.2.58",
-    "serverless-localstack": "^1.1.2",
     "serverless-offline": "^13.3.2",
     "serverless-offline-aws-eventbridge": "^2.1.0",
     "serverless-offline-dynamodb-streams": "^7.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,6 +28,7 @@
     "build:test": "rm -rf test/dist && tsc -p test/tsconfig.build.json",
     "test": "echo \"Error: no test specified\" && exit 1",
     "test:e2e": "NODE_ENV=local jest --config ./test/jest-e2e.json --runInBand",
+    "test:s3-smoke": "jest --config ./test/jest-s3-smoke.json --runInBand",
     "posttest:e2e": "kill -9 $(lsof -ti :8000)",
     "offline:docker": "cd test/infra-local && mkdir -p docker-data/.cognito && cp -r cognito-local/db docker-data/.cognito && docker compose up --remove-orphans",
     "offline:docker:stop": "cd test/infra-local && docker compose down --remove-orphans",

--- a/packages/core/test/e2e/s3.e2e-spec.ts
+++ b/packages/core/test/e2e/s3.e2e-spec.ts
@@ -4,15 +4,31 @@ import {
   DeleteObjectsCommand,
   GetObjectCommand,
   ListObjectsV2Command,
+  PutBucketCorsCommand,
   PutObjectCommand,
   S3Client,
 } from '@aws-sdk/client-s3'
 import { Upload } from '@aws-sdk/lib-storage'
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import { Readable } from 'stream'
 
 const ENDPOINT = process.env.S3_ENDPOINT || 'http://localhost:4566'
 const REGION = process.env.S3_REGION || 'ap-northeast-1'
 const BUCKET = 'e2e-s3-smoke'
+
+// A browser origin standing in for a local frontend. The value itself does not
+// matter to the assertions; what matters is that an Origin is present at all,
+// because that is what turns a plain request into a CORS request.
+const ORIGIN = 'http://localhost:3000'
+
+// Mirrors the rule applied locally by infra-local/scripts/resources.{sh,ps1}.
+// Keep the two in step: this suite is what proves the emulator honours it.
+const CORS_RULE = {
+  AllowedOrigins: ['*'],
+  AllowedMethods: ['GET', 'PUT', 'POST', 'DELETE', 'HEAD'],
+  AllowedHeaders: ['*'],
+  ExposeHeaders: ['ETag'],
+}
 
 // Mirrors packages/core/src/data-store/s3.service.ts:17-21
 const client = new S3Client({
@@ -123,5 +139,79 @@ describe('S3 emulator smoke test', () => {
         new GetObjectCommand({ Bucket: BUCKET, Key: 'smoke/does-not-exist' }),
       ),
     ).rejects.toMatchObject({ name: 'NoSuchKey' })
+  })
+
+  // --- Browser (presigned URL) access path ---------------------------------
+  // directory-file.service.ts hands presigned PUT/GET URLs to the browser, so
+  // every request on that path is a CORS request. LocalStack covered this with
+  // EXTRA_CORS_ALLOWED_ORIGINS=*; Floci has no such switch, so the bucket
+  // carries its own rule (see infra-local/scripts/resources.{sh,ps1}).
+  describe('presigned URL access from a browser origin', () => {
+    beforeAll(async () => {
+      await client.send(
+        new PutBucketCorsCommand({
+          Bucket: BUCKET,
+          CORSConfiguration: { CORSRules: [CORS_RULE] },
+        }),
+      )
+    })
+
+    // A failed preflight means the browser never sends the real request, so
+    // this is the assertion that catches a CORS regression.
+    it.each(['PUT', 'GET'])(
+      'answers the %s preflight with an allowed origin',
+      async (method) => {
+        const res = await fetch(`${ENDPOINT}/${BUCKET}/smoke/preflight.txt`, {
+          method: 'OPTIONS',
+          headers: {
+            Origin: ORIGIN,
+            'Access-Control-Request-Method': method,
+          },
+        })
+
+        expect(res.status).toBeLessThan(300)
+        expect(res.headers.get('access-control-allow-origin')).toBeTruthy()
+      },
+    )
+
+    // Mirrors genUploadDirectoryUrl then genViewUrl —
+    // directory-file.service.ts:47,22. ACL and ResponseContentDisposition are
+    // carried over deliberately: both are part of the signature the emulator
+    // has to accept.
+    it('round-trips through presigned upload and view URLs', async () => {
+      const key = 'smoke/presigned.txt'
+      const content = 'uploaded straight from the browser'
+
+      const uploadUrl = await getSignedUrl(
+        client,
+        new PutObjectCommand({ Bucket: BUCKET, Key: key, ACL: 'private' }),
+        { expiresIn: 60 * 60 },
+      )
+      const uploaded = await fetch(uploadUrl, {
+        method: 'PUT',
+        body: content,
+        headers: { Origin: ORIGIN },
+      })
+
+      expect(uploaded.status).toBe(200)
+      expect(uploaded.headers.get('access-control-allow-origin')).toBeTruthy()
+
+      const viewUrl = await getSignedUrl(
+        client,
+        new GetObjectCommand({
+          Bucket: BUCKET,
+          Key: key,
+          ResponseContentDisposition: `inline; filename="${encodeURIComponent(
+            'presigned.txt',
+          )}"`,
+        }),
+        { expiresIn: 60 * 60 },
+      )
+      const viewed = await fetch(viewUrl, { headers: { Origin: ORIGIN } })
+
+      expect(viewed.status).toBe(200)
+      expect(viewed.headers.get('access-control-allow-origin')).toBeTruthy()
+      expect(await viewed.text()).toBe(content)
+    })
   })
 })

--- a/packages/core/test/e2e/s3.smoke-spec.ts
+++ b/packages/core/test/e2e/s3.smoke-spec.ts
@@ -1,0 +1,127 @@
+import {
+  CreateBucketCommand,
+  DeleteBucketCommand,
+  DeleteObjectsCommand,
+  GetObjectCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3'
+import { Upload } from '@aws-sdk/lib-storage'
+import { Readable } from 'stream'
+
+const ENDPOINT = process.env.S3_ENDPOINT || 'http://localhost:4566'
+const REGION = process.env.S3_REGION || 'ap-northeast-1'
+const BUCKET = 'e2e-s3-smoke'
+
+// Mirrors packages/core/src/data-store/s3.service.ts:17-21
+const client = new S3Client({
+  endpoint: ENDPOINT,
+  region: REGION,
+  forcePathStyle: true,
+  credentials: {
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID || 'DUMMYIDEXAMPLE',
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || 'DUMMYEXAMPLEKEY',
+  },
+})
+
+const emptyBucket = async () => {
+  const listed = await client.send(new ListObjectsV2Command({ Bucket: BUCKET }))
+  if (!listed.Contents?.length) return
+  await client.send(
+    new DeleteObjectsCommand({
+      Bucket: BUCKET,
+      Delete: { Objects: listed.Contents.map(({ Key }) => ({ Key })) },
+    }),
+  )
+}
+
+describe('S3 emulator smoke test', () => {
+  console.log(`S3 smoke test target: ${ENDPOINT}`)
+
+  beforeAll(async () => {
+    await client.send(new CreateBucketCommand({ Bucket: BUCKET }))
+  })
+
+  afterAll(async () => {
+    await emptyBucket()
+    await client.send(new DeleteBucketCommand({ Bucket: BUCKET }))
+    client.destroy()
+  })
+
+  // Covers S3Service.putItem/getItem — s3.service.ts:29,44
+  it('round-trips a JSON object', async () => {
+    const key = 'smoke/attributes.json'
+    const item = { pk: 'TENANT#abc', sk: 'ORDER#1', nested: { total: 42 } }
+
+    await client.send(
+      new PutObjectCommand({
+        Bucket: BUCKET,
+        Key: key,
+        Body: JSON.stringify(item),
+      }),
+    )
+
+    const result = await client.send(
+      new GetObjectCommand({ Bucket: BUCKET, Key: key }),
+    )
+    const body = await result.Body.transformToString()
+
+    expect(JSON.parse(body)).toEqual(item)
+  })
+
+  // Covers the lib-storage upload — import.service.ts:219
+  // Body must exceed the 5 MB default part size or this silently degrades
+  // to a single-part upload and proves nothing.
+  it('completes a multipart upload via lib-storage', async () => {
+    const key = 'smoke/large.csv'
+    const body = Buffer.alloc(6 * 1024 * 1024, 'a')
+
+    const upload = new Upload({
+      client,
+      params: { Bucket: BUCKET, Key: key, Body: body },
+    })
+    await upload.done()
+
+    const result = await client.send(
+      new GetObjectCommand({ Bucket: BUCKET, Key: key }),
+    )
+    const bytes = await result.Body.transformToByteArray()
+
+    expect(bytes.length).toBe(body.length)
+  })
+
+  // Covers the streamed read — csv-import.sfn.event.handler.ts:220,282,320,340
+  // The `instanceof Readable` assertion is load-bearing: the handler throws
+  // outright if this is false (csv-import.sfn.event.handler.ts:227).
+  it('returns a Readable stream body', async () => {
+    const key = 'smoke/stream.csv'
+    const content = 'code,name\nA001,alpha\nA002,beta\n'
+
+    await client.send(
+      new PutObjectCommand({ Bucket: BUCKET, Key: key, Body: content }),
+    )
+
+    const { Body } = await client.send(
+      new GetObjectCommand({ Bucket: BUCKET, Key: key }),
+    )
+
+    expect(Body).toBeInstanceOf(Readable)
+
+    const chunks: Buffer[] = []
+    for await (const chunk of Body as Readable) {
+      chunks.push(Buffer.from(chunk))
+    }
+
+    expect(Buffer.concat(chunks).toString()).toBe(content)
+  })
+
+  // Callers must be able to tell "absent" from "failed".
+  it('raises NoSuchKey for a missing key', async () => {
+    await expect(
+      client.send(
+        new GetObjectCommand({ Bucket: BUCKET, Key: 'smoke/does-not-exist' }),
+      ),
+    ).rejects.toMatchObject({ name: 'NoSuchKey' })
+  })
+})

--- a/packages/core/test/infra-local/docker-compose.yml
+++ b/packages/core/test/infra-local/docker-compose.yml
@@ -56,20 +56,19 @@ services:
       - ./elasticmq.conf:/opt/elasticmq.conf
       - ./docker-data/elasticmq:/data
 
-  # localstack:
-  #   image: localstack/localstack
-  #   ports:
-  #     - '4566:4566'
-  #     - '4510-4559:4510-4559'
-  #   environment:
-  #     - SERVICES=s3
-  #     - AWS_DEFAULT_REGION=ap-northeast-1
-  #     - SERVICE_ACCESS_KEY=local
-  #     - SERVICE_SECRET_KEY=local
-  #     - EXTRA_CORS_ALLOWED_ORIGINS=*
-  #   volumes:
-  #     - ./docker-data/localstack:/var/lib/localstack
-  #     - ./docker-data/run/docker.sock:/var/run/docker.sock
+  localstack:
+    image: localstack/localstack
+    ports:
+      - '4566:4566'
+      - '4510-4559:4510-4559'
+    environment:
+      - SERVICES=s3
+      - AWS_DEFAULT_REGION=ap-northeast-1
+      - SERVICE_ACCESS_KEY=local
+      - SERVICE_SECRET_KEY=local
+      - EXTRA_CORS_ALLOWED_ORIGINS=*
+    volumes:
+      - ./docker-data/localstack:/var/lib/localstack
 
   appsync:
     build:

--- a/packages/core/test/infra-local/docker-compose.yml
+++ b/packages/core/test/infra-local/docker-compose.yml
@@ -56,19 +56,16 @@ services:
       - ./elasticmq.conf:/opt/elasticmq.conf
       - ./docker-data/elasticmq:/data
 
-  localstack:
-    image: localstack/localstack
+  floci:
+    image: floci/floci:1.6.0
     ports:
       - '4566:4566'
-      - '4510-4559:4510-4559'
     environment:
-      - SERVICES=s3
-      - AWS_DEFAULT_REGION=ap-northeast-1
-      - SERVICE_ACCESS_KEY=local
-      - SERVICE_SECRET_KEY=local
-      - EXTRA_CORS_ALLOWED_ORIGINS=*
+      - FLOCI_DEFAULT_REGION=ap-northeast-1
+      - FLOCI_STORAGE_MODE=persistent
+      - FLOCI_STORAGE_PERSISTENT_PATH=/data
     volumes:
-      - ./docker-data/localstack:/var/lib/localstack
+      - ./docker-data/floci:/data
 
   appsync:
     build:

--- a/packages/core/test/infra-local/serverless.yml
+++ b/packages/core/test/infra-local/serverless.yml
@@ -89,8 +89,6 @@ custom:
     retryDelayMs: 500 # retry delay
     throwRetryExhausted: false # default true
     payloadSizeLimit: '10mb' # Controls the maximum payload size being passed to https://www.npmjs.com/package/bytes (Note: this payload size might not be the same size as your AWS Eventbridge receive)
-    # localStackConfig:
-    #   localStackEndpoint: http://localhost:4566
 
 provider:
   name: aws

--- a/packages/core/test/jest-s3-smoke.json
+++ b/packages/core/test/jest-s3-smoke.json
@@ -1,0 +1,10 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": "./e2e",
+  "testEnvironment": "node",
+  "testRegex": ".smoke-spec.ts$",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "testTimeout": 60000
+}

--- a/packages/core/test/jest-s3-smoke.json
+++ b/packages/core/test/jest-s3-smoke.json
@@ -2,7 +2,7 @@
   "moduleFileExtensions": ["js", "json", "ts"],
   "rootDir": "./e2e",
   "testEnvironment": "node",
-  "testRegex": ".smoke-spec.ts$",
+  "testRegex": "s3.e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   },

--- a/packages/mcp-server/skills/mbc-debug/SKILL.md
+++ b/packages/mcp-server/skills/mbc-debug/SKILL.md
@@ -482,14 +482,13 @@ docker-compose up -d floci
 
 **Verify Services:**
 ```bash
-# Check DynamoDB
-aws --endpoint-url=http://localhost:4566 dynamodb list-tables
-
-# Check S3
+# Check S3 (Floci is S3-only on :4566)
 aws --endpoint-url=http://localhost:4566 s3 ls
+```
 
-# Check SQS
-aws --endpoint-url=http://localhost:4566 sqs list-queues
+DynamoDB Local runs separately on `:8000` (not Floci):
+```bash
+aws --endpoint-url=http://localhost:8000 dynamodb list-tables
 ```
 
 ### Serverless Offline Debug

--- a/packages/mcp-server/skills/mbc-debug/SKILL.md
+++ b/packages/mcp-server/skills/mbc-debug/SKILL.md
@@ -473,11 +473,11 @@ fields @timestamp, @message
 
 ## Local Development Debugging
 
-### LocalStack Issues
+### Floci Issues
 
-**Start LocalStack:**
+**Start Floci:**
 ```bash
-docker-compose up -d localstack
+docker-compose up -d floci
 ```
 
 **Verify Services:**

--- a/packages/mcp-server/src/__tests__/skills.spec.ts
+++ b/packages/mcp-server/src/__tests__/skills.spec.ts
@@ -335,7 +335,7 @@ describe('Claude Code Skills', () => {
     })
 
     it('should contain local development debugging', () => {
-      expect(content).toContain('LocalStack')
+      expect(content).toContain('Floci')
       expect(content).toContain('Serverless Offline')
     })
 
@@ -354,7 +354,7 @@ describe('Claude Code Skills', () => {
     it('should have consistent code block formatting', () => {
       const skills = ['mbc-generate', 'mbc-review', 'mbc-migrate', 'mbc-debug']
 
-      skills.forEach(skillName => {
+      skills.forEach((skillName) => {
         const skillPath = path.join(skillsDir, skillName, 'SKILL.md')
         const content = fs.readFileSync(skillPath, 'utf-8')
 
@@ -370,7 +370,7 @@ describe('Claude Code Skills', () => {
     it('should not contain placeholder text', () => {
       const skills = ['mbc-generate', 'mbc-review', 'mbc-migrate', 'mbc-debug']
 
-      skills.forEach(skillName => {
+      skills.forEach((skillName) => {
         const skillPath = path.join(skillsDir, skillName, 'SKILL.md')
         const content = fs.readFileSync(skillPath, 'utf-8')
 
@@ -384,7 +384,7 @@ describe('Claude Code Skills', () => {
     it('should have all skills with valid YAML frontmatter', () => {
       const skills = ['mbc-generate', 'mbc-review', 'mbc-migrate', 'mbc-debug']
 
-      skills.forEach(skillName => {
+      skills.forEach((skillName) => {
         const skillPath = path.join(skillsDir, skillName, 'SKILL.md')
         const content = fs.readFileSync(skillPath, 'utf-8')
 


### PR DESCRIPTION
## Summary

LocalStack Community Edition reached end of life in March 2026: it now requires an auth token and no longer receives security updates. Our local stack used LocalStack for **exactly one** service — S3 — while every other AWS dependency already has a dedicated emulator (`dynamodb-local`, ElasticMQ, Step Functions Local, Cognito Local, AppSync simulator). The template also pinned no image version (`localstack/localstack`), so every scaffolded project silently drifted onto an unmaintained image.

This PR replaces that S3 emulator with [Floci](https://github.com/floci-io/floci) (`floci/floci:1.6.0`): same port (`4566`), same path-style addressing, so application code and `.env` values stay unchanged. Floci starts in tens of milliseconds and idles at ~13 MiB, versus LocalStack’s multi-second startup and hundreds of MB resident. Equivalence is proven with a real-S3 smoke suite that was green against LocalStack first, then re-run unchanged against Floci.