### PR TITLE
fix(deps): bump security overrides to fixed releases to unblock the audit gate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7697,6 +7697,17 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/@serverless/platform-client/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/@serverless/platform-client/node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -10637,6 +10648,17 @@
         "node": ">= 6"
       }
     },
+    "node_modules/archiver-utils/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/archiver-utils/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -11697,9 +11719,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -13258,6 +13280,17 @@
         "copyup": "copyfiles"
       }
     },
+    "node_modules/copyfiles/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/copyfiles/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -13991,6 +14024,17 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/del/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/del/node_modules/glob": {
@@ -15625,9 +15669,9 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -15637,7 +15681,8 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
       "version": "1.2.0",
@@ -15853,29 +15898,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^5.0.1"
-      }
-    },
-    "node_modules/filelist/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
@@ -17197,6 +17219,17 @@
         "readable-stream": "^3.6.0"
       }
     },
+    "node_modules/help-me/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/help-me/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -17710,9 +17743,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -19362,9 +19395,9 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -19375,6 +19408,7 @@
           "url": "https://github.com/sponsors/nodeca"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -22562,6 +22596,17 @@
       },
       "engines": {
         "node": ">= 0.10.5"
+      }
+    },
+    "node_modules/node-dir/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/node-dir/node_modules/minimatch": {
@@ -26967,6 +27012,17 @@
         "node": ">=4"
       }
     },
+    "node_modules/shelljs/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/shelljs/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -30419,6 +30475,17 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/yamljs/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/yamljs/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -30602,6 +30669,17 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/zip-stream/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/zip-stream/node_modules/glob": {

--- a/package.json
+++ b/package.json
@@ -142,9 +142,9 @@
     "trim-newlines": "^3.0.1",
     "jsonwebtoken": "^9.0.2",
     "lodash": "^4.18.0",
-    "js-yaml": "4.3.0",
-    "fast-uri": "3.1.4",
-    "brace-expansion@2": "5.0.8",
+    "js-yaml": "^4.3.1",
+    "fast-uri": "^3.1.5",
+    "brace-expansion@2": "5.0.9",
     "tmp": "^0.2.6",
     "webpack": "^5.105.0",
     "qs": "^6.14.2",
@@ -156,7 +156,8 @@
     "@angular-devkit/core": {
       "ajv": "^8.18.0",
       "picomatch": "^4.0.4"
-    }
+    },
+    "ip-address": "^10.3.1"
   },
   "dependencies": {
     "jszip": "^3.10.1"


### PR DESCRIPTION
## Summary

The blocking CI gate `npm audit --omit=dev --audit-level=high` (ci-cd.yml:70-71) is failing on `develop` with **7 high advisories**, which is why every PR's Unit Test job is red and `e2e_tests` is skipped.

No commit caused this. The `Sync lockfile` step (`npm install --package-lock-only`) re-resolves the tree on every run, so newly published advisories turn the build red on their own — `develop`'s last green CI was 2026-08-02.

The root cause is that three existing overrides had each drifted to **exactly one patch below** the advisory's fixed release, so they were actively pinning vulnerable versions in place:

| override | before | after | vulnerable range |
|---|---|---|---|
| `js-yaml` | `4.3.0` | `^4.3.1` | `4.0.0 - 4.3.0` |
| `fast-uri` | `3.1.4` | `^3.1.5` | `3.0.0 - 3.1.4` |
| `brace-expansion@2` | `5.0.8` | `5.0.9` | `4.0.0 - 5.0.8` |
| `ip-address` | *(none)* | `^10.3.1` | `<= 10.3.0` |

Only these four are root causes. `@nestjs/swagger`, `ajv` and `minimatch` were flagged solely as downstream effects (`via`) and clear once the roots are fixed. All four bumps stay within the same major.

### Why `brace-expansion@2` keeps its selector

A bare `brace-expansion` key also clears the audit, and it looks tidier — but it is wrong here, and the CI would not tell you.

brace-expansion 5.x no longer exports a callable from its CJS entry (`require()` yields `{ EXPANSION_MAX, EXPANSION_MAX_LENGTH, expand }`). ESLint's nested minimatch 3.1.5 does `var expand = require('brace-expansion')` and then `expand(pattern)`, so a bare override makes **every braced pattern** throw:

```
TypeError: expand is not a function
    at Minimatch.braceExpand (node_modules/eslint/node_modules/minimatch/minimatch.js:271:10)
```

The `ESLint startup check` step (added in #446 to catch exactly this class of breakage) does **not** brace-expand, so it passes — the failure would ship silently. Keeping the `@2` selector from #482 leaves ESLint on its own 1.1.16 copy while still moving the hoisted production copy to 5.0.9.

### Why the lockfile entries are dropped

The stale `node_modules/{brace-expansion,js-yaml,fast-uri,ip-address}` entries are removed so the incremental re-resolve re-evaluates them. Without that, `npm install --package-lock-only` keeps the previously pinned versions and the gate stays red even with the new overrides. Lockfile churn is 150 lines.

Caret ranges replace the two exact pins so future patch releases are picked up by the same re-resolution step that surfaced this, instead of freezing the tree one patch behind the next advisory.

## Verification

Against `origin/develop`, with a clean `npm ci --ignore-scripts`:

| check | before | after |
|---|---|---|
| `npm audit --omit=dev --audit-level=high` (blocking) | **exit 1** — 7 high | **exit 0** — 0 high |
| `ESLint startup check` (blocking) | pass | **pass** |
| ESLint's minimatch 3.1.5 brace expansion (runtime; not covered by CI) | works | **works** — resolves brace-expansion 1.1.16 |
| hoisted production `brace-expansion` | 5.0.8 (vulnerable) | **5.0.9** |
| `npm run lint` | — | **runs normally** — 26 pre-existing rule violations, 0 crashes |
| `npm run test:cov` | — | **167/168 suites, 3658 tests pass** |

The one failing suite (`packages/import/src/event/csv-import.sfn.event.handler.spec.ts`) fails with `TS1261: ... differs from file name ... only in casing` on `@types/JSONStream` vs `@types/jsonstream` — a macOS case-insensitive-filesystem artifact, unrelated to this change, and absent on the Linux CI runners.

## Note

This does not touch the moderate/low advisories (`hono`, `file-type`, `@nestjs/*`, `body-parser`), which the gate tolerates at `--audit-level=high`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)